### PR TITLE
Replace texture id string with a texture sprite instance

### DIFF
--- a/Scripts/FurniturePhysicsSrv.gd
+++ b/Scripts/FurniturePhysicsSrv.gd
@@ -370,7 +370,7 @@ func add_corpse(pos: Vector3) -> void:
 	
 	var fursprite = rfurniture.destruction.sprite
 	if fursprite:
-		itemdata["texture_id"] = fursprite
+		itemdata["containertexture"] = fursprite
 
 	var myitemgroup = rfurniture.destruction.group
 	if myitemgroup:

--- a/Scripts/Runtimedata/RFurniture.gd
+++ b/Scripts/Runtimedata/RFurniture.gd
@@ -113,40 +113,34 @@ class SupportShape:
 # Inner class to handle the Destruction property
 class Destruction:
 	var group: String
-	var sprite: String
+	var sprite: Texture
 
 	# Constructor to initialize destruction properties from a dictionary
 	func _init(data: Dictionary):
 		group = data.get("group", "")
-		sprite = data.get("sprite", "")
 
 	# Get data function to return a dictionary with all properties
 	func get_data() -> Dictionary:
 		var destructiondata: Dictionary = {}
 		if not group == "":
 			destructiondata["group"] = group
-		if not sprite == "":
-			destructiondata["sprite"] = sprite
 		return destructiondata
 
 
 # Inner class to handle the Disassembly property
 class Disassembly:
 	var group: String
-	var sprite: String
+	var sprite: Texture
 
 	# Constructor to initialize disassembly properties from a dictionary
 	func _init(data: Dictionary):
 		group = data.get("group", "")
-		sprite = data.get("sprite", "")
 
 	# Get data function to return a dictionary with all properties
 	func get_data() -> Dictionary:
 		var disassemblydata: Dictionary = {}
 		if not group == "":
 			disassemblydata["group"] = group
-		if not sprite == "":
-			disassemblydata["sprite"] = sprite
 		return disassemblydata
 
 # Crafting Property
@@ -221,7 +215,9 @@ func overwrite_from_dfurniture(dfurniture: DFurniture) -> void:
 	function = Function.new(dfurniture.function.get_data())
 	support_shape = SupportShape.new(dfurniture.support_shape.get_data())
 	destruction = Destruction.new(dfurniture.destruction.get_data())
+	destruction.sprite = dfurniture.parent.sprite_by_file(dfurniture.destruction.sprite)
 	disassembly = Disassembly.new(dfurniture.disassembly.get_data())
+	disassembly.sprite = dfurniture.parent.sprite_by_file(dfurniture.disassembly.sprite)
 	crafting = Crafting.new(dfurniture.crafting.get_data())
 	construction = Construction.new(dfurniture.construction.get_data())
 

--- a/Scripts/Runtimedata/RItemgroup.gd
+++ b/Scripts/Runtimedata/RItemgroup.gd
@@ -51,6 +51,7 @@ var name: String
 var description: String
 var mode: String # "Collection" or "Distribution"
 var items: Array[Item] = []
+var sprite: Texture
 var use_sprite: bool = false
 var spriteid: String
 var parent: RItemgroups  # Reference to the list containing all runtime itemgroups for this mod
@@ -70,6 +71,7 @@ func overwrite_from_ditemgroup(ditemgroup: DItemgroup) -> void:
 	description = ditemgroup.description
 	mode = ditemgroup.mode
 	use_sprite = ditemgroup.use_sprite
+	sprite = ditemgroup.sprite
 	spriteid = ditemgroup.spriteid
 	
 	# Convert DItemgroup items to RItemgroup items


### PR DESCRIPTION
Fixes #607 

The previous implementation assumed that Rfurnitures would know what sprite matches with a certain texture_id, but Rfurnitures doesn't know that. This is because all the mods are merged into RFurnitures at runtime.

Instead, I save the texture itself to the RItemgroup and RFurniture.destruction and disassembly. Now the texture shows up again in-game. The downside is that when a game is saved and loaded, the container on the ground will assume a different sprite, namely one of the item sprites in the container.