### PR TITLE
Shift entities by .5 meters

### DIFF
--- a/ItemProtosets.tres
+++ b/ItemProtosets.tres
@@ -1,4 +1,4 @@
-[gd_resource type="Resource" script_class="ItemProtoset" load_steps=2 format=3 uid="uid://6ps34xw3cx7o"]
+[gd_resource type="Resource" script_class="ItemProtoset" load_steps=2 format=3 uid="uid://40imt51cghsv"]
 
 [ext_resource type="Script" uid="uid://blcdlb80ku0ox" path="res://addons/gloot/core/item_protoset.gd" id="1_o35lu"]
 

--- a/ItemProtosets.tres
+++ b/ItemProtosets.tres
@@ -1,4 +1,4 @@
-[gd_resource type="Resource" script_class="ItemProtoset" load_steps=2 format=3 uid="uid://db33eobtt57c0"]
+[gd_resource type="Resource" script_class="ItemProtoset" load_steps=2 format=3 uid="uid://6ps34xw3cx7o"]
 
 [ext_resource type="Script" uid="uid://blcdlb80ku0ox" path="res://addons/gloot/core/item_protoset.gd" id="1_o35lu"]
 

--- a/Scripts/Camera.gd
+++ b/Scripts/Camera.gd
@@ -29,7 +29,7 @@ func _on_inventory_visibility_change(inventoryWindow):
 
 func _process(_delta):
 	# Correct for the camera offset (since the camera is a child of the player)
-	var corrected_position: float = player.global_position.y - 0.101
+	var corrected_position: float = player.global_position.y - 0.601
 	
 	# ✅ Custom snapping function based on Y_THRESHOLD
 	var decimal_part = corrected_position - floor(corrected_position)

--- a/Tests/Unit/test_mob.gd
+++ b/Tests/Unit/test_mob.gd
@@ -82,7 +82,7 @@ func test_mob_spawn():
 	assert_eq(mobs.size(),1,"too many or not enough mobs")
 	var first_mob: Mob = mobs[0]
 	assert_eq(first_mob.rmob.id,"generic_test_mob","A different mob spawned then expected")
-	assert_eq(first_mob.mobPosition,Vector3(47,1.5,79),"Mob spawned somewhere else")
+	assert_eq(first_mob.mobPosition,Vector3(47.5,2.0,79.5),"Mob spawned somewhere else")
 	
 	# Test that the mob is in idle state, since there is no target
 	var current_state: State = first_mob.get_current_state()
@@ -146,10 +146,10 @@ func test_mob_melee_combat():
 	assert_eq(mobs.size(),2,"too many or not enough mobs")
 	var first_mob: Mob = mobs[0]
 	assert_eq(first_mob.rmob.id,"generic_test_mob","A different mob spawned then expected")
-	assert_eq(first_mob.mobPosition,Vector3(46,1.5,79),"Mob spawned somewhere else")
+	assert_eq(first_mob.mobPosition,Vector3(46.5,2.0,79.5),"Mob spawned somewhere else")
 	var second_mob: Mob = mobs[1]
 	assert_eq(second_mob.rmob.id,"generic_enemy_mob","A different mob spawned then expected")
-	assert_eq(second_mob.mobPosition, Vector3(49, 1.5, 79), "Mob spawned somewhere else")
+	assert_eq(second_mob.mobPosition, Vector3(49.5, 2.0, 79.5), "Mob spawned somewhere else")
 
 	# Test that the mobs are moving and getting closer
 	var initial_distance: float = first_mob.global_position.distance_to(second_mob.global_position)
@@ -234,10 +234,10 @@ func test_mob_ranged_vs_melee():
 	assert_eq(mobs.size(),2,"too many or not enough mobs")
 	var first_mob: Mob = mobs[0]
 	assert_eq(first_mob.rmob.id,"generic_ranged_mob","A different mob spawned then expected")
-	assert_eq(first_mob.mobPosition,Vector3(44,1.5,77),"Mob spawned somewhere else")
+	assert_eq(first_mob.mobPosition,Vector3(44.5,2.0,77.5),"Mob spawned somewhere else")
 	var second_mob: Mob = mobs[1]
 	assert_eq(second_mob.rmob.id,"generic_enemy_mob","A different mob spawned then expected")
-	assert_eq(second_mob.mobPosition, Vector3(49, 1.5, 79), "Mob spawned somewhere else")
+	assert_eq(second_mob.mobPosition, Vector3(49.5, 2.0, 79.5), "Mob spawned somewhere else")
 
 	# Test that the mobs are moving and getting closer
 	var initial_distance: float = first_mob.global_position.distance_to(second_mob.global_position)
@@ -316,10 +316,10 @@ func test_mob_ranged_vs_furniture():
 	assert_eq(mobs.size(),2,"too many or not enough mobs")
 	var first_mob: Mob = mobs[0]
 	assert_eq(first_mob.rmob.id,"generic_ranged_mob","A different mob spawned then expected")
-	assert_eq(first_mob.mobPosition,Vector3(44,1.5,77),"Mob spawned somewhere else")
+	assert_eq(first_mob.mobPosition,Vector3(44.5,2.0,77.5),"Mob spawned somewhere else")
 	var second_mob: Mob = mobs[1]
 	assert_eq(second_mob.rmob.id,"generic_enemy_mob","A different mob spawned then expected")
-	assert_eq(second_mob.mobPosition, Vector3(49, 1.5, 79), "Mob spawned somewhere else")
+	assert_eq(second_mob.mobPosition, Vector3(49.5, 2.0, 79.5), "Mob spawned somewhere else")
 
 	# Test that the mobs are moving and getting closer
 	var initial_distance: float = first_mob.global_position.distance_to(second_mob.global_position)

--- a/Tests/Unit/test_player.gd
+++ b/Tests/Unit/test_player.gd
@@ -32,7 +32,7 @@ func before_each():
 	add_child(mock_level_generator)
 	add_child(player)
 	# We expect the player to start here, just like in level_generation.tscn
-	player.global_position = Vector3(0, 1, 15)
+	player.global_position = Vector3(0, 1.5, 15)
 
 	test_chunk.mypos = Vector3(0, 0, 0) # Example position (chunk (1, 2) with 32x32 blocks)
 
@@ -79,7 +79,7 @@ func test_player_basics()->void:
 	
 	assert_true(player.is_alive,"Oops player spawned dead")
 	assert_eq(player.current_stamina, player.max_stamina, "Stamina is loading incorrectly!")
-	assert_eq(player.global_position, Vector3(0, 1, 15), "Player spawned in the wrong location!")
+	assert_eq(player.global_position, Vector3(0, 1.5, 15), "Player spawned in the wrong location!")
 	assert_false(player.knockback_active,"Player spawned with knockback error")
 
 
@@ -188,7 +188,7 @@ func test_player_vs_melee_mob():
 	assert_eq(mobs.size(),1,"too many or not enough mobs")
 	var first_mob: Mob = mobs[0]
 	assert_eq(first_mob.rmob.id,"generic_test_mob","A different mob spawned then expected")
-	assert_eq(first_mob.mobPosition,Vector3(15,1.5,15),"Mob spawned somewhere else")
+	assert_eq(first_mob.mobPosition,Vector3(15.5,2.0,15.5),"Mob spawned somewhere else")
 	
 	# Test that the mob transitions into the mob attack state
 	var first_state: State = first_mob.get_current_state()

--- a/level_generation.tscn
+++ b/level_generation.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=15 format=3 uid="uid://drl78uuphij1l"]
+[gd_scene load_steps=14 format=3 uid="uid://drl78uuphij1l"]
 
 [ext_resource type="PackedScene" uid="uid://cesy3sdpbal3f" path="res://Scenes/input_manager.tscn" id="1_78rss"]
 [ext_resource type="Script" uid="uid://cx5my7n5m1sa5" path="res://LevelGenerator.gd" id="1_i8qa4"]
@@ -9,8 +9,7 @@
 [ext_resource type="Script" uid="uid://hru6h8lopfti" path="res://entity_manager.gd" id="6_vo8ny"]
 [ext_resource type="Script" uid="uid://87k88ikb017y" path="res://Scripts/BuildManager.gd" id="6_y7rk5"]
 [ext_resource type="Script" uid="uid://ked5qb1pnnul" path="res://Scripts/target_manager.gd" id="7_04r2w"]
-[ext_resource type="PackedScene" uid="uid://clhj525tmme3k" path="res://hud.tscn" id="17_qnmns"]
-[ext_resource type="AudioStream" uid="uid://b1q36r8e5wmen" path="res://Sounds/Music/Just in Reach of Sirens.mp3" id="18_ddslh"]
+[ext_resource type="PackedScene" uid="uid://b4o76k6afwt1g" path="res://hud.tscn" id="17_qnmns"]
 
 [sub_resource type="Environment" id="Environment_aklx6"]
 background_mode = 1
@@ -87,12 +86,11 @@ transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 3.4043, 0, -8.78679)
 [node name="Projectiles" type="Node3D" parent="TacticalMap/Entities"]
 
 [node name="Player" parent="TacticalMap/Entities" instance=ExtResource("6_icwa4")]
-transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 1, 15)
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 1.5, 15)
 
 [node name="HUD" parent="." instance=ExtResource("17_qnmns")]
 
 [node name="Music" type="AudioStreamPlayer" parent="."]
-stream = ExtResource("18_ddslh")
 volume_db = -20.15
 bus = &"Music"
 


### PR DESCRIPTION
Fixes #753 

I followed the solution that was suggested to me, and it seems to work fine. The entities are visible and at the right place. Moving up and down is no issue, even for mobs. Saving and loading still works too.

This will possibly mess up construction of blocks and furniture. We can make separate issue for that.