### PR TITLE
Scroll in content editor lists

### DIFF
--- a/Scenes/ContentManager/Scripts/content_list.gd
+++ b/Scenes/ContentManager/Scripts/content_list.gd
@@ -159,8 +159,14 @@ func set_collapsed():
 	contentItems.visible = not is_collapsed
 	if not is_collapsed:
 		size_flags_vertical = Control.SIZE_EXPAND_FILL
+
+		# Decide minimum height based on item count
+		var item_count := contentItems.item_count
+		var min_height := 180.0 if item_count < 10 else 360.0
+		custom_minimum_size.y = min_height
 	else:
 		size_flags_vertical = Control.SIZE_SHRINK_BEGIN
+		custom_minimum_size.y = 30.0
 
 
 # Function to initiate drag data for selected item

--- a/Scenes/ContentManager/contenteditor.tscn
+++ b/Scenes/ContentManager/contenteditor.tscn
@@ -46,7 +46,7 @@ overmapareaEditor = ExtResource("15_qbq5b")
 mobgroupsEditor = ExtResource("16_lrbdj")
 mobfactionsEditor = ExtResource("17_mcu7c")
 attacksEditor = ExtResource("18_v4s36")
-content = NodePath("HSplitContainer/ContentLists/TabContainer2/Content/ContentList")
+content = NodePath("HSplitContainer/ContentLists/TabContainer2/Content/ScrollContainer/ContentList")
 tabContainer = NodePath("HSplitContainer/TabContainer")
 type_selector_menu_button = NodePath("HSplitContainer/ContentLists/TabContainer2/Content/Toolbar/TypeSelectorMenuButton")
 
@@ -96,9 +96,15 @@ layout_mode = 2
 layout_mode = 2
 text = "☰"
 
-[node name="ContentList" type="VBoxContainer" parent="HSplitContainer/ContentLists/TabContainer2/Content"]
+[node name="ScrollContainer" type="ScrollContainer" parent="HSplitContainer/ContentLists/TabContainer2/Content"]
+layout_mode = 2
+size_flags_vertical = 3
+horizontal_scroll_mode = 0
+
+[node name="ContentList" type="VBoxContainer" parent="HSplitContainer/ContentLists/TabContainer2/Content/ScrollContainer"]
 custom_minimum_size = Vector2(0, 200)
 layout_mode = 2
+size_flags_horizontal = 3
 size_flags_vertical = 3
 
 [node name="Recent" type="ItemList" parent="HSplitContainer/ContentLists/TabContainer2"]


### PR DESCRIPTION
Fixes #760 

As suggested by RoyalFox, the content lists should scroll if there is no space to fit in the window. This change puts the content lists in a scroll container and sets a minimum size based on their collapsed state and number of items in the list.

It's not perfect, but will solve the immediate problem.