### PR TITLE
Move mob down by .5

### DIFF
--- a/Scripts/Chunk.gd
+++ b/Scripts/Chunk.gd
@@ -167,7 +167,7 @@ func process_level_data() -> Dictionary:
 							if tileJSON.has("mob"):
 								# We spawn it slightly above the block and let it fall. Might want to 
 								# fiddle with the Y coordinate for optimization
-								processed_leveldata.mobs.append({"json": tileJSON.mob, "pos": Vector3(w, y + 1.5, h)+offset})
+								processed_leveldata.mobs.append({"json": tileJSON.mob, "pos": Vector3(w, y + 1.0, h)+offset})
 							if tileJSON.has("mobgroup"):
 								# Fetch the mobgroup ID and use it to get a random mob ID
 								var mobgroup_id: String = tileJSON.mobgroup.id
@@ -175,7 +175,7 @@ func process_level_data() -> Dictionary:
 								if random_mob_id != "":
 									tileJSON.mobgroup.id = random_mob_id
 									# Append the mob with its position and rotation from the mobgroup data
-									processed_leveldata.mobs.append({"json": tileJSON.mobgroup, "pos": Vector3(w, y + 1.5, h)+offset})
+									processed_leveldata.mobs.append({"json": tileJSON.mobgroup, "pos": Vector3(w, y + 1.0, h)+offset})
 							if tileJSON.has("furniture"):
 								# We spawn it slightly above the block. Might want to 
 								# fiddle with the Y coordinate for optimization

--- a/Scripts/OvermapGrid.gd
+++ b/Scripts/OvermapGrid.gd
@@ -619,7 +619,7 @@ func generate_cells() -> void:
 			# If you need to test a specific map, uncomment these two lines and put in your map name.
 			# It will spawn the map at position (0,0), where the player starts
 			#if global_x == 0 and global_y == 0:
-				#cell.map_id = "Generichouse"
+				#cell.map_id = "military_bunker"
 
 			# Add the cell to the grid's cells dictionary
 			cells[cell_key] = cell


### PR DESCRIPTION
Fixes #769 

The mobs already spawned at 1.5 y level. After the .5 position shift, the block at (0,0,0) will have its dimensions set from (0,0,0) to (1,1,1). So when the mob spawns at 1.5 y level, there is room for its collider to touch down on the block. 

After the .5 shift, the mob spawned at 2.0 y level, which is too high. The collider got stuck in the block above it. I lowered the y level of mobs by .5 when the spawn initially.