### PR TITLE
Fix container sprites on furniture

### DIFF
--- a/Scripts/FurnitureBlueprintSrv.gd
+++ b/Scripts/FurnitureBlueprintSrv.gd
@@ -115,7 +115,7 @@ class FurnitureContainer:
 	var itemgroup: String # The ID of an itemgroup that it creates loot from
 	var sprite_mesh: PlaneMesh
 	var sprite_instance: RID # RID to the quadmesh that displays the containersprite
-	var material: ShaderMaterial
+	var material: StandardMaterial3D
 	var furniture_transform: FurnitureTransform
 	var world3d: World3D
 

--- a/Scripts/FurnitureBlueprintSrv.gd
+++ b/Scripts/FurnitureBlueprintSrv.gd
@@ -106,7 +106,7 @@ class FurnitureTransform:
 	func correct_new_position():
 		# We have to compensate for the fact that the physicsserver and
 		# renderingserver place the furniture lower then the intended height
-		posy += 0.5+(0.5*height)
+		posy += 0.5*height
 
 
 # Inner Container Class

--- a/Scripts/FurnitureStaticSrv.gd
+++ b/Scripts/FurnitureStaticSrv.gd
@@ -184,7 +184,7 @@ class FurnitureContainer:
 		var items: Array[InventoryItem] = inventory.get_items()
 		if items.size() == 0:
 			# Use standard material for empty container
-			sprite_mesh.material = Runtimedata.furnitures.get_container_empty_material()
+			sprite_mesh.material = Gamedata.materials.container # set empty container
 			return
 		
 		# Pick a random item from the inventory
@@ -398,9 +398,9 @@ class FurnitureContainer:
 				if sprite_mesh:
 					# Check if the container is empty before setting material
 					if inventory.get_item_count() <= 0:
-						sprite_mesh.material = Runtimedata.furnitures.get_container_empty_material()  # Empty container material
+						sprite_mesh.material = Gamedata.materials.container  # Empty container material
 					else:
-						sprite_mesh.material = Runtimedata.furnitures.get_container_filled_material()  # Filled container material
+						sprite_mesh.material = Gamedata.materials.container_filled  # Filled container material
 
 
 # Class representing a queued item for the CraftingContainer

--- a/Scripts/FurnitureStaticSrv.gd
+++ b/Scripts/FurnitureStaticSrv.gd
@@ -183,7 +183,8 @@ class FurnitureContainer:
 			return # We don't want a sprite visible when it's set to hide
 		var items: Array[InventoryItem] = inventory.get_items()
 		if items.size() == 0:
-			sprite_mesh.material = Gamedata.materials.container # set empty container
+			# Use standard material for empty container
+			sprite_mesh.material = Runtimedata.furnitures.get_container_empty_material()
 			return
 		
 		# Pick a random item from the inventory
@@ -397,9 +398,9 @@ class FurnitureContainer:
 				if sprite_mesh:
 					# Check if the container is empty before setting material
 					if inventory.get_item_count() <= 0:
-						sprite_mesh.material = Gamedata.materials.container  # Empty container material
+						sprite_mesh.material = Runtimedata.furnitures.get_container_empty_material()  # Empty container material
 					else:
-						sprite_mesh.material = Gamedata.materials.container_filled  # Filled container material
+						sprite_mesh.material = Runtimedata.furnitures.get_container_filled_material()  # Filled container material
 
 
 # Class representing a queued item for the CraftingContainer

--- a/Scripts/Runtimedata/RFurnitures.gd
+++ b/Scripts/Runtimedata/RFurnitures.gd
@@ -12,6 +12,9 @@ var shape_materials: Dictionary = {}  # Cache for shape materials by furniture I
 var standard_materials: Dictionary = {}  # Cache for standard materials by furniture ID
 var under_construction_material: StandardMaterial3D
 
+var container_empty_material: StandardMaterial3D = null
+var container_filled_material: StandardMaterial3D = null
+
 # Constructor
 func _init(mod_list: Array[DMod]) -> void:
 	# Loop through each mod
@@ -160,3 +163,20 @@ func create_standard_material(furniture_id: String) -> StandardMaterial3D:
 	material.flags_transparent = true
 
 	return material
+
+func get_container_empty_material() -> StandardMaterial3D:
+	if container_empty_material == null:
+		container_empty_material = _create_container_material("res://Textures/container_32.png")
+	return container_empty_material
+
+func get_container_filled_material() -> StandardMaterial3D:
+	if container_filled_material == null:
+		container_filled_material = _create_container_material("res://Textures/container_filled_32.png")
+	return container_filled_material
+
+func _create_container_material(texture_path: String) -> StandardMaterial3D:
+	var tex = load(texture_path)
+	var mat = StandardMaterial3D.new()
+	mat.albedo_texture = tex
+	mat.flags_transparent = true
+	return mat

--- a/Scripts/Runtimedata/RFurnitures.gd
+++ b/Scripts/Runtimedata/RFurnitures.gd
@@ -12,9 +12,6 @@ var shape_materials: Dictionary = {}  # Cache for shape materials by furniture I
 var standard_materials: Dictionary = {}  # Cache for standard materials by furniture ID
 var under_construction_material: StandardMaterial3D
 
-var container_empty_material: StandardMaterial3D = null
-var container_filled_material: StandardMaterial3D = null
-
 # Constructor
 func _init(mod_list: Array[DMod]) -> void:
 	# Loop through each mod
@@ -163,20 +160,3 @@ func create_standard_material(furniture_id: String) -> StandardMaterial3D:
 	material.flags_transparent = true
 
 	return material
-
-func get_container_empty_material() -> StandardMaterial3D:
-	if container_empty_material == null:
-		container_empty_material = _create_container_material("res://Textures/container_32.png")
-	return container_empty_material
-
-func get_container_filled_material() -> StandardMaterial3D:
-	if container_filled_material == null:
-		container_filled_material = _create_container_material("res://Textures/container_filled_32.png")
-	return container_filled_material
-
-func _create_container_material(texture_path: String) -> StandardMaterial3D:
-	var tex = load(texture_path)
-	var mat = StandardMaterial3D.new()
-	mat.albedo_texture = tex
-	mat.flags_transparent = true
-	return mat

--- a/Scripts/gamedata.gd
+++ b/Scripts/gamedata.gd
@@ -10,12 +10,12 @@ static var hide_above_player_shader := preload("res://Shaders/HideAbovePlayer.gd
 static var hide_above_player_shadow := preload("res://Shaders/HideAbovePlayerShadow.gdshader")
 
 # Dictionary to store loaded textures
-var textures: Dictionary = {
+var textures: Dictionary[String,Texture] = {
 	"container": load("res://Textures/container_32.png"),
 	"container_filled": load("res://Textures/container_filled_32.png"),
 	"under_construction": load("res://Textures/under_construction_32.png")
 }
-var materials: Dictionary = {}
+var materials: Dictionary[String,StandardMaterial3D] = {}
 
 # Rotation mappings for how directions change based on tile rotation
 const ROTATION_MAP: Dictionary = {
@@ -41,18 +41,14 @@ func _ready():
 	# Instantiate the content type instances
 	mods = DMods.new()
 
-	materials["container"] = create_item_shader_material(textures.container)
-	materials["container_filled"] = create_item_shader_material(textures.container_filled)
-	materials["under_construction"] = create_item_shader_material(textures.under_construction)
+	materials["container"] = _create_container_material(textures.container)
+	materials["container_filled"] = _create_container_material(textures.container_filled)
+	materials["under_construction"] = _create_container_material(textures.under_construction)
 
 
-# Helper function to create a ShaderMaterial for the item
-func create_item_shader_material(albedo_texture: Texture) -> ShaderMaterial:
-	# Create a new ShaderMaterial
-	var shader_material = ShaderMaterial.new()
-	shader_material.shader = hide_above_player_shader  # Use the shared shader
-
-	# Assign the texture to the material
-	shader_material.set_shader_parameter("texture_albedo", albedo_texture)
-
-	return shader_material
+# Helper function to create a StandardMaterial3D for the coontainer sprite
+func _create_container_material(tex: Texture) -> StandardMaterial3D:
+	var mat = StandardMaterial3D.new()
+	mat.albedo_texture = tex
+	mat.flags_transparent = true
+	return mat


### PR DESCRIPTION
Fixes #768 

The container sprites were still using shader materials instead of standardmaterials. I changed it so now everything uses standardmaterials. I also corrected the position of blueprint furniture.