### PR TITLE
Snipercup/issue762 implement drop items feature

### DIFF
--- a/Scenes/InventoryWindow.tscn
+++ b/Scenes/InventoryWindow.tscn
@@ -13,7 +13,7 @@
 default_font = ExtResource("6_xpf2l")
 default_font_size = 13
 
-[node name="InventoryWindow" type="Control" node_paths=PackedStringArray("proximity_inventory_control", "inventory_control", "containerList", "EquipmentSlotList", "LeftHandEquipmentSlot", "RightHandEquipmentSlot", "tooltip", "tooltip_item_name", "tooltip_item_description", "tool_tip_description_panel", "close_button")]
+[node name="InventoryWindow" type="Control" node_paths=PackedStringArray("proximity_inventory_control", "inventory_control", "containerList", "EquipmentSlotList", "LeftHandEquipmentSlot", "RightHandEquipmentSlot", "tooltip", "tooltip_item_name", "tooltip_item_description", "tool_tip_description_panel", "close_button", "drop_zone_overlay")]
 layout_mode = 3
 anchors_preset = 15
 anchor_right = 1.0
@@ -36,12 +36,23 @@ tooltip_item_name = NodePath("Tooltip/Panel/ItemName")
 tooltip_item_description = NodePath("Tooltip/ToolTipDescriptionPanel/Description")
 tool_tip_description_panel = NodePath("Tooltip/ToolTipDescriptionPanel")
 close_button = NodePath("VBoxContainer/HeaderPanelContainer/HBoxContainer/CloseButton")
+drop_zone_overlay = NodePath("drop_zone_overlay")
 
-[node name="VBoxContainer" type="VBoxContainer" parent="."]
+[node name="drop_zone_overlay" type="Control" parent="."]
 layout_mode = 1
 anchors_preset = 15
 anchor_right = 1.0
 anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 2
+
+[node name="VBoxContainer" type="VBoxContainer" parent="."]
+layout_mode = 1
+anchors_preset = -1
+anchor_left = 0.1
+anchor_top = 0.1
+anchor_right = 0.9
+anchor_bottom = 0.9
 grow_horizontal = 2
 grow_vertical = 2
 theme_override_constants/separation = 0

--- a/Scenes/UI/CtrlInventoryStackedCustom.tscn
+++ b/Scenes/UI/CtrlInventoryStackedCustom.tscn
@@ -76,7 +76,7 @@ size_flags_horizontal = 3
 
 [node name="ContextMenu" type="PopupMenu" parent="."]
 size = Vector2i(123, 116)
-item_count = 5
+item_count = 6
 item_0/text = "Equip (left)"
 item_0/id = 0
 item_1/text = "Equip (right)"
@@ -87,9 +87,10 @@ item_3/text = "Unload"
 item_3/id = 3
 item_4/text = "Use"
 item_4/id = 4
+item_5/text = "Drop"
+item_5/id = 5
 
 [node name="ReloadAudio" type="AudioStreamPlayer3D" parent="."]
 stream = ExtResource("4_rci6u")
-bus = &"Sounds"
 
 [connection signal="id_pressed" from="ContextMenu" to="." method="_on_context_menu_item_selected"]

--- a/Scripts/CtrlInventoryStackedCustom.gd
+++ b/Scripts/CtrlInventoryStackedCustom.gd
@@ -54,6 +54,7 @@ signal equip_left(items: Array[InventoryItem])
 signal equip_right(items: Array[InventoryItem])
 signal reload_item(items: Array[InventoryItem])
 signal unload_item(items: Array[InventoryItem])
+signal drop_items(items: Array[InventoryItem])
 
 # Reload sound for pistol
 @export var reload_audio_player : AudioStreamPlayer3D
@@ -98,6 +99,7 @@ func _on_context_menu_item_selected(id):
 		2: reload_item.emit(selected_inventory_items)
 		3: unload_item.emit(selected_inventory_items)
 		4: Helper.signal_broker.items_were_used.emit(selected_inventory_items)
+		5: drop_items.emit(selected_inventory_items)
 
 
 func _disconnect_inventory_signals():

--- a/Scripts/InventoryWindow.gd
+++ b/Scripts/InventoryWindow.gd
@@ -30,7 +30,7 @@ var is_showing_tooltip = false
 var input_action: String = "toggle_inventory" # What action is used to show/hide this
 
 # Add a transparent drop zone overlay to catch drag-and-drop outside inventory
-@onready var drop_zone_overlay := $DropZoneOverlay if has_node("DropZoneOverlay") else null
+@export var drop_zone_overlay: Control = null
 
 
 # Called when the node enters the scene tree for the first time.

--- a/Scripts/InventoryWindow.gd
+++ b/Scripts/InventoryWindow.gd
@@ -29,6 +29,9 @@ var is_showing_tooltip = false
 @export var close_button: Button = null
 var input_action: String = "toggle_inventory" # What action is used to show/hide this
 
+# Add a transparent drop zone overlay to catch drag-and-drop outside inventory
+@onready var drop_zone_overlay := $DropZoneOverlay if has_node("DropZoneOverlay") else null
+
 
 # Called when the node enters the scene tree for the first time.
 func _ready():
@@ -51,6 +54,10 @@ func _ready():
 		inventory_control.drop_items.connect(_on_drop_items)
 	if proximity_inventory_control.has_signal("drop_items"):
 		proximity_inventory_control.drop_items.connect(_on_drop_items)
+	# Setup drop zone overlay for drag-outside-to-drop
+	if drop_zone_overlay:
+		drop_zone_overlay.drop_data.connect(_on_drop_zone_overlay_drop_data)
+		drop_zone_overlay.can_drop_data.connect(_on_drop_zone_overlay_can_drop_data)
 
 func _on_close_button_pressed():
 	visible = false
@@ -468,3 +475,11 @@ func drop_items_to_ground(items: Array):
 			target_container.insert_item(item)
 
 	Helper.signal_broker.inventory_operation_finished.emit()
+
+# Handler for drop zone overlay drop
+func _on_drop_zone_overlay_drop_data(_pos, data):
+	if data is Array and data.size() > 0 and data[0] is InventoryItem:
+		_on_drop_items(data)
+
+func _on_drop_zone_overlay_can_drop_data(_pos, data):
+	return data is Array and data.size() > 0 and data[0] is InventoryItem

--- a/Scripts/InventoryWindow.gd
+++ b/Scripts/InventoryWindow.gd
@@ -56,8 +56,8 @@ func _ready():
 		proximity_inventory_control.drop_items.connect(_on_drop_items)
 	# Setup drop zone overlay for drag-outside-to-drop
 	if drop_zone_overlay:
-		drop_zone_overlay.drop_data.connect(_on_drop_zone_overlay_drop_data)
-		drop_zone_overlay.can_drop_data.connect(_on_drop_zone_overlay_can_drop_data)
+		# Forward drag-and-drop events to the overlay so it can handle drops outside inventory grids
+		drop_zone_overlay.set_drag_forwarding(Callable(), _on_drop_zone_overlay_can_drop_data, _on_drop_zone_overlay_drop_data)
 
 func _on_close_button_pressed():
 	visible = false

--- a/hud.tscn
+++ b/hud.tscn
@@ -4,7 +4,7 @@
 [ext_resource type="Script" uid="uid://cesohfflurhln" path="res://Scripts/hud.gd" id="1_s3xoj"]
 [ext_resource type="Script" uid="uid://dx6j302ja353t" path="res://Scripts/NonHUDclick.gd" id="2_kpbhl"]
 [ext_resource type="Texture2D" uid="uid://7hppy1l45loq" path="res://Textures/bar_progress.png" id="3_83uwt"]
-[ext_resource type="Resource" uid="uid://bwdmspw266bap" path="res://ItemProtosets.tres" id="3_jmlkb"]
+[ext_resource type="Resource" uid="uid://40imt51cghsv" path="res://ItemProtosets.tres" id="3_jmlkb"]
 [ext_resource type="Texture2D" uid="uid://dcgwgmsmi7mjn" path="res://Textures/bar_border.png" id="3_y43f5"]
 [ext_resource type="PackedScene" uid="uid://b6ooia1084wfx" path="res://Scenes/UI/AttributesWindow.tscn" id="6_6e87o"]
 [ext_resource type="PackedScene" uid="uid://drjw0yaxf8x1p" path="res://Scenes/UI/QuestTrackerUI.tscn" id="7_bbed4"]
@@ -17,7 +17,7 @@
 [ext_resource type="PackedScene" uid="uid://bgswuol251m3u" path="res://Scenes/Overmap/Overmap.tscn" id="19_oomhy"]
 [ext_resource type="PackedScene" uid="uid://b50xhj4218wjd" path="res://Scenes/UI/QuestWindow.tscn" id="19_orjb2"]
 [ext_resource type="PackedScene" uid="uid://e0ebcv1n8jnq" path="res://Scenes/InventoryWindow.tscn" id="20_0l505"]
-[ext_resource type="PackedScene" path="res://Sounds/SFX/UI/UISFX.tscn" id="20_5kc73"]
+[ext_resource type="PackedScene" uid="uid://cvr5g886g53be" path="res://Sounds/SFX/UI/UISFX.tscn" id="20_5kc73"]
 [ext_resource type="PackedScene" uid="uid://ckuh2s0nvwg0x" path="res://Scenes/GameOver.tscn" id="20_jlthm"]
 [ext_resource type="PackedScene" uid="uid://dowehl4nfwxm" path="res://Scenes/LoadingScreen.tscn" id="20_kxcpa"]
 
@@ -169,11 +169,6 @@ anchor_bottom = 0.9
 
 [node name="InventoryWindow" parent="." instance=ExtResource("20_0l505")]
 visible = false
-anchors_preset = -1
-anchor_left = 0.1
-anchor_top = 0.1
-anchor_right = 0.9
-anchor_bottom = 0.9
 
 [node name="CharacterWindow" parent="." instance=ExtResource("17_2f357")]
 visible = false


### PR DESCRIPTION
Fixes #762

Users can now drop an item outside the inventory window or use the context menu to drop an item onto the ground. An item will be dropped into a nearby items container if one is available or a new one will be created if not.