### PR TITLE
 Add sound properties to tile classes

### DIFF
--- a/Scripts/Gamedata/DTile.gd
+++ b/Scripts/Gamedata/DTile.gd
@@ -50,13 +50,17 @@ func get_data() -> Dictionary:
 		"name": name,
 		"description": description,
 		"sprite": spriteid,
-		"categories": categories,
-		"sound_category": sound_category,
-		"sound_volume": sound_volume
+		"categories": categories
 	}
 	
 	if shape and not shape == "":
 		data["shape"] = shape
+	
+	if sound_category and not sound_category == "":
+		data["sound_category"] = sound_category
+	
+	if sound_volume and not sound_volume == 100:
+		data["sound_volume"] = sound_volume
 
 	return data
 

--- a/Scripts/Gamedata/DTile.gd
+++ b/Scripts/Gamedata/DTile.gd
@@ -33,27 +33,27 @@ var parent: DTiles
 
 # Constructor to initialize tile properties from a dictionary
 func _init(data: Dictionary, myparent: DTiles):
-        parent = myparent
-        id = data.get("id", "")
-        name = data.get("name", "")
-        description = data.get("description", "")
-        shape = data.get("shape", "")
-        spriteid = data.get("sprite", "")
-        categories = data.get("categories", [])
-        sound_category = data.get("sound_category", "")
-        sound_volume = data.get("sound_volume", 100)
+		parent = myparent
+		id = data.get("id", "")
+		name = data.get("name", "")
+		description = data.get("description", "")
+		shape = data.get("shape", "")
+		spriteid = data.get("sprite", "")
+		categories = data.get("categories", [])
+		sound_category = data.get("sound_category", "")
+		sound_volume = data.get("sound_volume", 100)
 
 # Get data function to return a dictionary with all properties
 func get_data() -> Dictionary:
-        var data: Dictionary = {
-                "id": id,
-                "name": name,
-                "description": description,
-                "sprite": spriteid,
-                "categories": categories,
-                "sound_category": sound_category,
-                "sound_volume": sound_volume
-        }
+	var data: Dictionary = {
+		"id": id,
+		"name": name,
+		"description": description,
+		"sprite": spriteid,
+		"categories": categories,
+		"sound_category": sound_category,
+		"sound_volume": sound_volume
+	}
 	
 	if shape and not shape == "":
 		data["shape"] = shape

--- a/Scripts/Gamedata/DTile.gd
+++ b/Scripts/Gamedata/DTile.gd
@@ -33,15 +33,15 @@ var parent: DTiles
 
 # Constructor to initialize tile properties from a dictionary
 func _init(data: Dictionary, myparent: DTiles):
-		parent = myparent
-		id = data.get("id", "")
-		name = data.get("name", "")
-		description = data.get("description", "")
-		shape = data.get("shape", "")
-		spriteid = data.get("sprite", "")
-		categories = data.get("categories", [])
-		sound_category = data.get("sound_category", "")
-		sound_volume = data.get("sound_volume", 100)
+	parent = myparent
+	id = data.get("id", "")
+	name = data.get("name", "")
+	description = data.get("description", "")
+	shape = data.get("shape", "")
+	spriteid = data.get("sprite", "")
+	categories = data.get("categories", [])
+	sound_category = data.get("sound_category", "")
+	sound_volume = data.get("sound_volume", 100)
 
 # Get data function to return a dictionary with all properties
 func get_data() -> Dictionary:

--- a/Scripts/Runtimedata/RTile.gd
+++ b/Scripts/Runtimedata/RTile.gd
@@ -39,10 +39,10 @@ var parent: RTiles
 # data: the data as loaded from json
 # myparent: The list containing all tiles for this mod
 func _init(myparent: RTiles, newid: String):
-        parent = myparent
-        id = newid
-        sound_category = ""
-        sound_volume = 100
+		parent = myparent
+		id = newid
+		sound_category = ""
+		sound_volume = 100
 
 # Overwrite this tile's properties using a DTile
 func overwrite_from_dtile(dtile: DTile) -> void:
@@ -52,22 +52,22 @@ func overwrite_from_dtile(dtile: DTile) -> void:
 	description = dtile.description
 	shape = dtile.shape
 	spriteid = dtile.spriteid
-        sprite = dtile.sprite
-        categories = dtile.categories.duplicate(true)
-        sound_category = dtile.sound_category
-        sound_volume = dtile.sound_volume
+	sprite = dtile.sprite
+	categories = dtile.categories.duplicate(true)
+	sound_category = dtile.sound_category
+	sound_volume = dtile.sound_volume
 
 # Get data function to return a dictionary with all properties
 func get_data() -> Dictionary:
-        var data: Dictionary = {
-                "id": id,
-                "name": name,
-                "description": description,
-                "sprite": spriteid,
-                "categories": categories,
-                "sound_category": sound_category,
-                "sound_volume": sound_volume
-        }
+	var data: Dictionary = {
+		"id": id,
+		"name": name,
+		"description": description,
+		"sprite": spriteid,
+		"categories": categories,
+		"sound_category": sound_category,
+		"sound_volume": sound_volume
+	}
 	if shape and not shape == "":
 		data["shape"] = shape
 	return data

--- a/Scripts/Runtimedata/RTile.gd
+++ b/Scripts/Runtimedata/RTile.gd
@@ -39,10 +39,8 @@ var parent: RTiles
 # data: the data as loaded from json
 # myparent: The list containing all tiles for this mod
 func _init(myparent: RTiles, newid: String):
-		parent = myparent
-		id = newid
-		sound_category = ""
-		sound_volume = 100
+	parent = myparent
+	id = newid
 
 # Overwrite this tile's properties using a DTile
 func overwrite_from_dtile(dtile: DTile) -> void:


### PR DESCRIPTION
## Summary
- store sound settings in `DTile` data
- persist sound settings when reading/writing JSON
- keep runtime `RTile` objects aware of sound settings

Contributes to #744 
