### PR TITLE
Refactor sfx, split generic and movement players

### DIFF
--- a/Scripts/player.gd
+++ b/Scripts/player.gd
@@ -221,7 +221,7 @@ func _physics_process(delta):
 				current_stamina += delta * stamina_regen_while_standing_still
 			else:
 				if movement_timer.time_left <= 0:
-					Sfx.play_sfx(Sfx.SFX.WALKING_GRASS)
+					Sfx.play_movement_sfx()
 					if not is_running or current_stamina == 0:
 						movement_timer.start(0.5)
 					else: 
@@ -293,7 +293,7 @@ func _check_for_interaction() -> void:
 # 	"mobposition": Vector3(17, 1, 219) # The global position of the mob
 # }
 func get_hit(attack_data: Dictionary):
-	Sfx.play_sfx(Sfx.SFX.HURT_MALE)
+	Sfx.play_generic_sfx()
 	var attack: Dictionary = attack_data.get("attack",{})
 	var rattack: RAttack = Runtimedata.attacks.by_id(attack.get("id", ""))
 	if not rattack:

--- a/Sounds/SFX/sfx.gd
+++ b/Sounds/SFX/sfx.gd
@@ -2,7 +2,9 @@ extends Node
 
 # Preloaded audio streams grouped by sound type
 var tracks := {
-	SFX.WALKING_GRASS: [preload("res://Sounds/SFX/Footsteps/footstep01.wav")],
+	SFX.WALKING_GRASS: [
+		preload("res://Sounds/SFX/Footsteps/footstep01.wav")
+	],
 	SFX.HURT_MALE: [
 		preload("res://Sounds/SFX/Hurt sounds (Male)/aargh0.wav"),
 		preload("res://Sounds/SFX/Hurt sounds (Male)/aargh2.wav"),
@@ -15,7 +17,6 @@ var tracks := {
 @onready var generic_sfx_player := SFXPlayer.new($AudioStreamPlayer, tracks[SFX.HURT_MALE])
 @onready var movement_sfx_player := SFXPlayer.new($MovementSFXPlayer, tracks[SFX.WALKING_GRASS])
 
-
 # UI sound effects mapped by name
 @onready var ui_sounds := {
 	&"UI_Hover": $UI_Hover,
@@ -26,7 +27,6 @@ var tracks := {
 class SFXPlayer:
 	var player: AudioStreamPlayer
 	var tracks: Array = []
-	var current_sfx: int = -1
 
 	func _init(_player: AudioStreamPlayer, _tracks: Array = []) -> void:
 		player = _player
@@ -45,35 +45,31 @@ class SFXPlayer:
 	func is_playing() -> bool:
 		return player and player.playing
 
-
 # Enum to reference sound effects
 enum SFX {
 	WALKING_GRASS,
 	HURT_MALE
 }
 
-# Track current SFX and repeat mode
-var current_sfx: int = SFX.WALKING_GRASS
+# Plays a general SFX sound (e.g., pain grunts, etc.)
+func play_generic_sfx():
+	if not generic_sfx_player.is_playing():
+		generic_sfx_player.play_random()
 
-# Plays the specified sound effect using the appropriate SFXPlayer instance
-func play_sfx(sfx: int):
-	var soundplayer := movement_sfx_player if sfx == SFX.WALKING_GRASS else generic_sfx_player
-
-	if current_sfx != sfx or not soundplayer.is_playing():
-		movement_sfx_player.stop()
-		generic_sfx_player.stop()
-
-		current_sfx = sfx
-		soundplayer.play_random()
-
+# Plays a movement-related SFX (e.g., footsteps)
+func play_movement_sfx():
+	if not movement_sfx_player.is_playing():
+		movement_sfx_player.play_random()
 
 # Plays a UI sound effect by name
 func ui_sfx_play(sound: String):
 	ui_sounds[sound].play()
 
+# Called when generic audio stream finishes
 func _on_audio_stream_player_finished():
 	gameplay_sfx_stop()
 
+# Called when movement audio stream finishes
 func _on_movement_sfx_player_finished():
 	movement_sfx_stop()
 


### PR DESCRIPTION
Contributes to #744 

This splits up the movement and generic sound players and functions. This means that we can have movement and hurt sounds at the same time. I also noticed that the movement sound cut off  when you start walking for .1 meters. This is why I removed the line that stops the movement player when the player stops moving. We can fiddle with it more if needed.

This implementation is not the final solution since we will have more then walking_grass, but we need the ground work in order to expand further.