### PR TITLE
Delay mobs and double amount of zombies

### DIFF
--- a/Mods/Dimensionfall/Maps/Generichouse.json
+++ b/Mods/Dimensionfall/Maps/Generichouse.json
@@ -3,7 +3,7 @@
 		{
 			"entities": [
 				{
-					"count": 12.0,
+					"count": 24.0,
 					"id": "basic_zombies",
 					"type": "mobgroup"
 				}

--- a/Mods/Dimensionfall/Maps/Generichouse_00.json
+++ b/Mods/Dimensionfall/Maps/Generichouse_00.json
@@ -3,7 +3,7 @@
 		{
 			"entities": [
 				{
-					"count": 12.0,
+					"count": 24.0,
 					"id": "basic_zombies",
 					"type": "mobgroup"
 				}

--- a/Mods/Dimensionfall/Maps/abandoned_building.json
+++ b/Mods/Dimensionfall/Maps/abandoned_building.json
@@ -3,7 +3,7 @@
 		{
 			"entities": [
 				{
-					"count": 12.0,
+					"count": 24.0,
 					"id": "basic_zombies",
 					"type": "mobgroup"
 				}

--- a/Mods/Dimensionfall/Maps/city_square.json
+++ b/Mods/Dimensionfall/Maps/city_square.json
@@ -123,7 +123,7 @@
 		{
 			"entities": [
 				{
-					"count": 5.0,
+					"count": 10.0,
 					"id": "basic_zombies",
 					"type": "mobgroup"
 				}

--- a/Mods/Dimensionfall/Maps/generichouse_corner.json
+++ b/Mods/Dimensionfall/Maps/generichouse_corner.json
@@ -3,7 +3,7 @@
 		{
 			"entities": [
 				{
-					"count": 12.0,
+					"count": 24.0,
 					"id": "basic_zombies",
 					"type": "mobgroup"
 				}

--- a/Mods/Dimensionfall/Maps/generichouse_cross.json
+++ b/Mods/Dimensionfall/Maps/generichouse_cross.json
@@ -3,7 +3,7 @@
 		{
 			"entities": [
 				{
-					"count": 12.0,
+					"count": 24.0,
 					"id": "basic_zombies",
 					"type": "mobgroup"
 				}

--- a/Mods/Dimensionfall/Maps/generichouse_end.json
+++ b/Mods/Dimensionfall/Maps/generichouse_end.json
@@ -3,7 +3,7 @@
 		{
 			"entities": [
 				{
-					"count": 12.0,
+					"count": 24.0,
 					"id": "basic_zombies",
 					"type": "mobgroup"
 				}

--- a/Mods/Dimensionfall/Maps/generichouse_t.json
+++ b/Mods/Dimensionfall/Maps/generichouse_t.json
@@ -3,7 +3,7 @@
 		{
 			"entities": [
 				{
-					"count": 12.0,
+					"count": 24.0,
 					"id": "basic_zombies",
 					"type": "mobgroup"
 				}

--- a/Mods/Dimensionfall/Maps/military_bunker.json
+++ b/Mods/Dimensionfall/Maps/military_bunker.json
@@ -188,7 +188,7 @@
 		{
 			"entities": [
 				{
-					"count": 1,
+					"count": 2,
 					"id": "basic_zombies",
 					"type": "mobgroup"
 				}
@@ -207,7 +207,7 @@
 		{
 			"entities": [
 				{
-					"count": 1,
+					"count": 2,
 					"id": "basic_zombies",
 					"type": "mobgroup"
 				}

--- a/Mods/Dimensionfall/Maps/neighborhood_school.json
+++ b/Mods/Dimensionfall/Maps/neighborhood_school.json
@@ -3,7 +3,7 @@
 		{
 			"entities": [
 				{
-					"count": 12.0,
+					"count": 24.0,
 					"id": "basic_zombies",
 					"type": "mobgroup"
 				}

--- a/Mods/Dimensionfall/Maps/office_building_00.json
+++ b/Mods/Dimensionfall/Maps/office_building_00.json
@@ -85,7 +85,7 @@
 		{
 			"entities": [
 				{
-					"count": 12.0,
+					"count": 24.0,
 					"id": "basic_zombies",
 					"type": "mobgroup"
 				}

--- a/Mods/Dimensionfall/Maps/parking_garage.json
+++ b/Mods/Dimensionfall/Maps/parking_garage.json
@@ -71,7 +71,7 @@
 		{
 			"entities": [
 				{
-					"count": 12.0,
+					"count": 24.0,
 					"id": "basic_zombies",
 					"type": "mobgroup"
 				}

--- a/Mods/Dimensionfall/Maps/police_station.json
+++ b/Mods/Dimensionfall/Maps/police_station.json
@@ -85,7 +85,7 @@
 		{
 			"entities": [
 				{
-					"count": 22.0,
+					"count": 44.0,
 					"id": "basic_zombies",
 					"type": "mobgroup"
 				}

--- a/Mods/Dimensionfall/Maps/store_electronic_clothing.json
+++ b/Mods/Dimensionfall/Maps/store_electronic_clothing.json
@@ -3,7 +3,7 @@
 		{
 			"entities": [
 				{
-					"count": 12.0,
+					"count": 24.0,
 					"id": "basic_zombies",
 					"type": "mobgroup"
 				}

--- a/Mods/Dimensionfall/Maps/store_groceries.json
+++ b/Mods/Dimensionfall/Maps/store_groceries.json
@@ -250,7 +250,7 @@
 		{
 			"entities": [
 				{
-					"count": 12.0,
+					"count": 24.0,
 					"id": "basic_zombies",
 					"type": "mobgroup"
 				}

--- a/Mods/Dimensionfall/Maps/subway_station.json
+++ b/Mods/Dimensionfall/Maps/subway_station.json
@@ -104,7 +104,7 @@
 		{
 			"entities": [
 				{
-					"count": 12.0,
+					"count": 24.0,
 					"id": "basic_zombies",
 					"type": "mobgroup"
 				}

--- a/Mods/Dimensionfall/Maps/survivor_gas_station.json
+++ b/Mods/Dimensionfall/Maps/survivor_gas_station.json
@@ -85,7 +85,7 @@
 		{
 			"entities": [
 				{
-					"count": 1,
+					"count": 2,
 					"id": "basic_zombies",
 					"type": "mobgroup"
 				}

--- a/Mods/Dimensionfall/Maps/two_story_house.json
+++ b/Mods/Dimensionfall/Maps/two_story_house.json
@@ -3,7 +3,7 @@
 		{
 			"entities": [
 				{
-					"count": 12.0,
+					"count": 24.0,
 					"id": "basic_zombies",
 					"type": "mobgroup"
 				}

--- a/Mods/Dimensionfall/Maps/urbanroad.json
+++ b/Mods/Dimensionfall/Maps/urbanroad.json
@@ -85,7 +85,7 @@
 		{
 			"entities": [
 				{
-					"count": 1,
+					"count": 2,
 					"id": "basic_zombies",
 					"type": "mobgroup"
 				}

--- a/Scripts/Chunk.gd
+++ b/Scripts/Chunk.gd
@@ -234,10 +234,16 @@ func add_block_mobs():
 	mutex.lock()
 	var mobdatalist = processed_level_data.mobs.duplicate()
 	mutex.unlock()
+	var batch_size := 1  # Number of mob to spawn per batch
+	var count := 0
 	for mobdata: Dictionary in mobdatalist:
 		# Pass the position and the mob json to the newmob and have it construct itself
 		var newMob: CharacterBody3D = Mob.new(mypos+mobdata.pos, mobdata.json)
 		level_manager.add_child.call_deferred(newMob)
+		count += 1
+		if count >= batch_size:
+			count = 0
+			OS.delay_msec(200)  # Stagger by 200 ms (adjust as needed)
 	# If you want to test a mob, you can use this to spawn it at the Vector3 location
 	# Comment it out again when you're done testing
 	#if mypos == Vector3(0,0,0):
@@ -309,11 +315,17 @@ func add_mobs_to_map() -> void:
 	mutex.lock()
 	var mobdata: Array = chunk_data.mobs.duplicate()
 	mutex.unlock()
+	var batch_size := 1  # Number of mob to spawn per batch
+	var count := 0
 	for mob: Dictionary in mobdata:
 		# Put the mob back where it was when the map was unloaded
 		var mobpos: Vector3 = Vector3(mob.global_position_x,mob.global_position_y,mob.global_position_z)
 		var newMob: CharacterBody3D = Mob.new(mobpos, mob)
 		level_manager.add_child.call_deferred(newMob)
+		count += 1
+		if count >= batch_size:
+			count = 0
+			OS.delay_msec(200)  # Stagger by 200 ms (adjust as needed)
 
 
 # Called by generate_items function when a save is loaded

--- a/Scripts/Mob/Mob.gd
+++ b/Scripts/Mob/Mob.gd
@@ -106,10 +106,8 @@ func create_detection():
 
 # Create and configure CollisionShape3D
 func create_collision_shape():
-	var new_shape = BoxShape3D.new()
-	new_shape.size = Vector3(0.35, 0.35, 0.35)
 	collision_shape_3d = CollisionShape3D.new()
-	collision_shape_3d.shape = new_shape
+	collision_shape_3d.shape = General.shared_shape
 	add_child.call_deferred(collision_shape_3d)
 
 

--- a/Scripts/general.gd
+++ b/Scripts/general.gd
@@ -4,11 +4,14 @@ extends Node
 var is_mouse_outside_HUD = false
 var is_allowed_to_shoot = true
 
-# New variables
+# For controlling the player actions
 var is_action_in_progress = false
 var action_timer: Timer
 var action_complete_callback: Callable  # Use Callable to store the function reference
 signal start_timer_progressbar(time_left: float)
+
+# Shared shape for mobs
+var shared_shape = BoxShape3D.new()
 
 func _ready():
 	# Initialize the timer
@@ -16,6 +19,7 @@ func _ready():
 	action_timer.timeout.connect(_on_action_timer_timeout)
 	add_child(action_timer)
 	start_timer_progressbar.connect(Helper.signal_broker.on_start_timer_progressbar)
+	shared_shape.size = Vector3(0.35, 0.35, 0.35)
 
 
 # Function to start an action

--- a/Tests/Unit/test_mob.gd
+++ b/Tests/Unit/test_mob.gd
@@ -163,9 +163,10 @@ func test_mob_melee_combat():
 	assert_true(second_mob.has_state("mobattack"),"Mob should have the mobattack state")
 	
 	# Test that the mob transitions into the mob attack state
+	await wait_frames(30)
 	var first_state: State = first_mob.get_current_state()
 	assert_not_null(first_state, "Mob has no state")
-	assert_is(first_state,MobFollow,"Mob should have MobFollow state")
+	assert_is(first_state, MobFollow, "Mob should have MobFollow state")
 	assert_true(await wait_for_signal(first_state.Transistioned, 5), "Mob doesn't transition")
 	first_state = first_mob.get_current_state()
 	assert_is(first_state,MobAttack,"A different state then expected")
@@ -249,6 +250,7 @@ func test_mob_ranged_vs_melee():
 	)
 	
 	# Test that the mob transitions into the mob ranged attack state
+	await wait_frames(30)
 	var first_state: State = first_mob.get_current_state()
 	assert_not_null(first_state, "Mob has no state")
 	assert_is(first_state,MobRangedAttack,"A different state then expected")
@@ -331,6 +333,7 @@ func test_mob_ranged_vs_furniture():
 	)
 	
 	# Test that the mob transitions into the mob ranged attack state
+	await wait_frames(30)
 	var first_state: State = first_mob.get_current_state()
 	assert_not_null(first_state, "Mob has no state")
 	assert_is(first_state,MobRangedAttack,"A different state then expected")

--- a/Tests/Unit/test_player.gd
+++ b/Tests/Unit/test_player.gd
@@ -206,7 +206,7 @@ func test_player_vs_melee_mob():
 	assert_true(await wait_for_signal(first_state.Transistioned, 5), "Mob doesn't transition")
 	first_state = first_mob.get_current_state()
 	var mob_has_transitioned = func():
-		return first_state is MobAttack
+		return first_mob.get_current_state() is MobAttack
 	# Replace the existing assert_true line with this one:
 	assert_true(await wait_until(mob_has_transitioned, 10, 1), 
 		"Mob should have transitioned, but current state is: %s" % [first_mob.get_current_state().get_class()])


### PR DESCRIPTION
Fixes #718 
Alternative to #794

This pr doubles the amount of zombies.
Instead of pooling zombies in #794, this pr only delays the spawn of zombies, staggering them over multiple frames. At the current rate, 5 zombies will spawn in 1 second. Previously, there was no time delay between each spawn.

This does not fully remove the integrate_forces time from the profiler, but the frame time is acceptable now.