### PR TITLE
Decople player from game over screen

### DIFF
--- a/Scripts/GameOver.gd
+++ b/Scripts/GameOver.gd
@@ -3,6 +3,13 @@ extends Control
 var is_button_pressed: bool = false
 # This script belongs to the Gameover window that shows in-game when the player is defeated
 
+func _ready() -> void:
+	hide()
+	Helper.signal_broker.player_died.connect(_on_player_died)
+
+func _on_player_died(_player: Player) -> void:
+	show()
+
 # When the player presses the 'return to main menu' button
 func _on_return_button_button_up():
 	if is_button_pressed == false:

--- a/Scripts/Helper/SignalBroker/signal_broker.gd
+++ b/Scripts/Helper/SignalBroker/signal_broker.gd
@@ -132,6 +132,8 @@ signal game_ended() # When the game is completely exited and everything is unloa
 signal game_terminated() # When the user presses 'main menu' button on the escape menu
 @warning_ignore("unused_signal")
 signal player_spawned(player: Player) # When the player has spawned in-game
+@warning_ignore("unused_signal")
+signal player_died(player: Player)
 
 # When a mob was killed
 @warning_ignore("unused_signal")

--- a/Scripts/player.gd
+++ b/Scripts/player.gd
@@ -326,8 +326,8 @@ func die():
 		Sfx.gameplay_sfx_stop()
 		Music.gameplay_music_stop()
 		Music.GameOverMusic.play()
-		$"../../../HUD".get_node("GameOver").show()
-
+		Helper.signal_broker.player_died.emit(self)
+		
 # The player has selected one or more items in the inventory and selected
 # 'use' from the context menu.
 func _on_food_item_used(usedItem: InventoryItem) -> void:


### PR DESCRIPTION

    signal player_died in Player script and emit when the player dies
    notify Helper's SignalBroker with new player_died signal
    show GameOver screen via GameOver.gd when player_died fires
    stop referencing HUD path directly in Player.die()
