### PR TITLE
Test DropEntityTextEdit and itemManager's reloading helpers

### DIFF
--- a/Mods/Test/Items/Items.json
+++ b/Mods/Test/Items/Items.json
@@ -8,8 +8,8 @@
 		"sprite": "test_apple_32.png",
 		"stack_size": 1,
 		"two_handed": false,
-		"volume": 1,
-		"weight": 1
+		"volume": 1.0,
+		"weight": 1.0
 	},
 	{
 		"description": "You could use this item to test if it adds to an inventory",
@@ -20,7 +20,49 @@
 		"sprite": "test_zombie_bone_32.png",
 		"stack_size": 1,
 		"two_handed": false,
-		"volume": 1,
-		"weight": 1
+		"volume": 1.0,
+		"weight": 1.0
+	},
+	{
+		"Magazine": {
+			"current_ammo": 19,
+			"max_ammo": 20,
+			"used_ammo": "bullet_9mm"
+		},
+		"description": "In order for your pistol to fire a bullet, it needs to have a magazine loaded with bullets",
+		"id": "generic_test_pistol_magazine",
+		"image": "./Mods/Test/Items/test_apple_32.png",
+		"max_stack_size": 1,
+		"name": "Pistol magazine",
+		"sprite": "test_apple_32.png",
+		"stack_size": 1,
+		"two_handed": false,
+		"volume": 10.0,
+		"weight": 0.25
+	},
+	{
+		"Ranged": {
+			"firing_speed": 0.4,
+			"range": 1000,
+			"recoil": 10,
+			"reload_speed": 1.5,
+			"spread": 5,
+			"sway": 5,
+			"used_ammo": "9mm",
+			"used_magazine": "generic_test_pistol_magazine",
+			"used_skill": {
+
+			}
+		},
+		"description": "A standard issue pistol that uses 9mm ammunition",
+		"id": "generic_test_pistol",
+		"image": "./Mods/Test/Items/test_zombie_bone_32.png",
+		"max_stack_size": 1,
+		"name": "Pistol 9mm",
+		"sprite": "test_zombie_bone_32.png",
+		"stack_size": 1,
+		"two_handed": false,
+		"volume": 150.0,
+		"weight": 2.0
 	}
 ]

--- a/Scenes/ContentManager/Custom_Widgets/Scripts/DropEntityTextEdit.gd
+++ b/Scenes/ContentManager/Custom_Widgets/Scripts/DropEntityTextEdit.gd
@@ -94,3 +94,17 @@ func enable() -> void:
 	is_disabled = false  # Reset the disabled flag
 	if button:  # Ensure button is valid before enabling
 		button.disabled = false
+
+
+# Setter for `content_types`. Validates and stores the array.
+func set_content_types(types: Array[DMod.ContentType]) -> void:
+	# Ensure we have an Array of the correct enum type
+	if typeof(types) != TYPE_ARRAY:
+		push_error("content_types must be an Array of DMod.ContentType")
+		return
+	for t in types:
+		if typeof(t) != TYPE_INT:
+			push_error("content_types contains a non-ContentType value: %s" % str(t))
+			return
+	# Store it
+	content_types = types.duplicate()

--- a/Tests/Unit/test_drop_entity_text_edit.gd
+++ b/Tests/Unit/test_drop_entity_text_edit.gd
@@ -1,0 +1,74 @@
+class_name TestDropEntityTextEdit
+extends GutTest
+
+var drop_scene: PackedScene = preload("res://Scenes/ContentManager/Custom_Widgets/DropEntityTextEdit.tscn")
+var drop_widget: HBoxContainer
+
+func before_all():
+	var custom_mods: Array[DMod] = [Gamedata.mods.by_id("Core"), Gamedata.mods.by_id("Test")]
+	Runtimedata.reconstruct(custom_mods)
+	await get_tree().process_frame
+
+func before_each():
+	drop_widget = drop_scene.instantiate()
+	add_child(drop_widget)
+	var mycontenttypes: Array[DMod.ContentType] = [DMod.ContentType.WEARABLESLOTS, DMod.ContentType.PLAYERATTRIBUTES]
+	drop_widget.set_content_types(mycontenttypes)
+	await get_tree().process_frame
+
+func after_each():
+	if drop_widget:
+		drop_widget.queue_free()
+
+func after_all():
+	Runtimedata.reset()
+
+func test_can_drop_valid_data() -> void:
+	var data := {
+		"id": "generic_test_wearable_slot",
+		"text": "Test wearable slot",
+		"mod_id": "Test",
+		"contentType": DMod.ContentType.WEARABLESLOTS
+	}
+	assert_true(drop_widget._can_drop_data(Vector2.ZERO, data))
+
+func test_can_drop_invalid_id() -> void:
+	var data := {
+		"id": "non_existing_slot",
+		"text": "Bad slot",
+		"mod_id": "Test",
+		"contentType": DMod.ContentType.WEARABLESLOTS
+	}
+	assert_false(drop_widget._can_drop_data(Vector2.ZERO, data))
+
+func test_can_drop_wrong_type() -> void:
+	var data := {
+		"id": "generic_test_wearable_slot",
+		"text": "Test wearable slot",
+		"mod_id": "Test",
+		"contentType": DMod.ContentType.MAPS
+	}
+	assert_false(drop_widget._can_drop_data(Vector2.ZERO, data))
+
+func test_drop_data_updates_state() -> void:
+	var data := {
+		"id": "generic_test_wearable_slot",
+		"text": "Test wearable slot",
+		"mod_id": "Test",
+		"contentType": DMod.ContentType.WEARABLESLOTS
+	}
+	assert_true(drop_widget.dropped_data.is_empty())
+	drop_widget._drop_data(Vector2.ZERO, data)
+	assert_eq(drop_widget.dropped_data, data)
+	assert_eq(drop_widget.get_text(), "generic_test_wearable_slot")
+
+func test_drop_data_rejects_invalid() -> void:
+	var data := {
+		"id": "non_existing_slot",
+		"text": "Bad slot",
+		"mod_id": "Test",
+		"contentType": DMod.ContentType.WEARABLESLOTS
+	}
+	drop_widget._drop_data(Vector2.ZERO, data)
+	assert_true(drop_widget.dropped_data.is_empty())
+	assert_eq(drop_widget.get_text(), "")

--- a/Tests/Unit/test_drop_entity_text_edit.gd.uid
+++ b/Tests/Unit/test_drop_entity_text_edit.gd.uid
@@ -1,0 +1,1 @@
+uid://ckpblpda0epu

--- a/Tests/Unit/test_item_manager.gd
+++ b/Tests/Unit/test_item_manager.gd
@@ -1,0 +1,52 @@
+extends GutTest
+
+var item_manager: ItemManager
+
+func before_all():
+	var custom_mods: Array[DMod] = [Gamedata.mods.by_id("Core"), Gamedata.mods.by_id("Test")]
+	Runtimedata.reconstruct(custom_mods)
+	await get_tree().process_frame
+
+func before_each():
+	item_manager = preload("res://Scripts/item_manager.gd").new()
+	add_child(item_manager)
+	await get_tree().process_frame
+	item_manager.playerInventory = item_manager.initialize_inventory()
+
+func after_each():
+	if item_manager:
+		item_manager.queue_free()
+
+func after_all():
+	Runtimedata.reset()
+
+func _create_weapon() -> InventoryItem:
+	return item_manager.playerInventory.create_and_add_item("generic_test_pistol")
+
+func _create_magazine(ammo: int) -> InventoryItem:
+	var mag: InventoryItem = item_manager.playerInventory.create_and_add_item("generic_test_pistol_magazine")
+	var props = mag.get_property("Magazine")
+	props["current_ammo"] = ammo
+	mag.set_property("Magazine", props)
+	return mag
+
+func test_find_compatible_magazine() -> void:
+	var gun = _create_weapon()
+	var _low = _create_magazine(5)
+	var high = _create_magazine(15)
+	var compatible_magazine: InventoryItem = item_manager.find_compatible_magazine(gun)
+	assert_not_null(compatible_magazine, "Expected find_compatible_magazine to return a magazine")
+	assert_eq(compatible_magazine, high, "Should pick mag with most ammo")
+
+func test_reload_weapon_no_magazine() -> void:
+	var gun = _create_weapon()
+	assert_false(item_manager.reload_weapon(gun), "Reload should fail without magazine")
+
+func test_start_reload_inserts_magazine() -> void:
+	var gun = _create_weapon()
+	var mag = _create_magazine(10)
+	item_manager.start_reload(gun, 0.01, mag)
+	await wait_frames(5)
+	assert_eq(gun.get_property("current_magazine"), mag, "Magazine should be inserted")
+	assert_false(item_manager.playerInventory.has_item(mag), "Magazine should be removed from inventory")
+	assert_false(gun.get_property("is_reloading"), "Reload flag should reset")

--- a/Tests/Unit/test_item_manager.gd.uid
+++ b/Tests/Unit/test_item_manager.gd.uid
@@ -1,0 +1,1 @@
+uid://pi2ievffbemy


### PR DESCRIPTION

    add a new Gut test for DropEntityTextEdit covering _can_drop_data and _drop_data

    add unit test for ItemManager's reloading helpers
