### PR TITLE
Fix typos and improve documentation

### DIFF
--- a/Documentation/Game_development/Getting_started.md
+++ b/Documentation/Game_development/Getting_started.md
@@ -93,3 +93,7 @@ UI is another area that is somewhat accessible to contributors starting out. Thi
 Keep in mind that the UI communicates with the game world through autoloads. For example, the Inventory menu works together with the `ItemManager` (`/Scripts/item_manager.gd`). Some game elements like the player and some windows communicate through `Helper.signal_broker`. To find out what connects to what, press `ctrl+shift+f` in Godot and search for `Helper.signal_broker` and a list will come up.
 
 Icons used in the UI can be found in `/Textures` and `/Images/Icons`. Sometimes you don't need to use an icon and a button with an `x` or arrow `->` will suffice. In the case of the character menu, the icons are loaded from the mod data in `/Mods/Core/Stats` and `/Mods/Core/Stats`
+## Running tests
+The project uses the [GUT](https://github.com/bitwes/Gut) addon for unit testing. Tests are managed inside the Godot editor.
+
+Open the project in Godot and look at the bottom panel of the window. Next to `Output` and `Debugger` you will find the `GUT` tab. Click it to open the control panel where you can run all tests or filter them by directory or file.

--- a/Documentation/Modding/Documentation/Creating_documentation.md
+++ b/Documentation/Modding/Documentation/Creating_documentation.md
@@ -1,9 +1,9 @@
 ### Help creation
 This page includes information about creating documentation files
 
-The format of documentation files should be .md. The contents of the file should contain **Github Flavored Markdown** formatted text. Since the documentation will also be viewable in-game, only the formatting supported by [this addon](https://github.com/daenvil/MarkdownLabel) will work.
+Documentation files should use the `.md` format. The contents of the file should contain **GitHub Flavored Markdown** formatted text. Since the documentation will also be viewable in-game, only the formatting supported by [this addon](https://github.com/daenvil/MarkdownLabel) will work.
 
-Put new documentation files inside one of the folders in the `Documentation` folder. If needed, create a new subfolder. The documentation files either be edited locally, or in your browser using the editor on Github. When editing in Github, keep the formatting limitations described above in mind.
+Put new documentation files inside one of the folders in the `Documentation` folder. If needed, create a new subfolder. The documentation files can be edited locally or in your browser using the editor on GitHub. When editing in GitHub, keep the formatting limitations described above in mind.
 
 ### File names
-File names should start with a capital letter. Instead of a space " ", use an unders core _. Keep in mind that in the in-game menu, the file name will be the display name in the documentation list and underscores will be replaced with a space.
+File names should start with a capital letter. Instead of a space " ", use an underscore _. Keep in mind that in the in-game menu, the file name will be the display name in the documentation list, and underscores will be replaced with spaces.

--- a/FeatureList.md
+++ b/FeatureList.md
@@ -103,70 +103,70 @@ Allows you to create new mobs and configure them. You can then use the map edito
 ![Catax_mob_editor](Media/Catax_mob_editor.png)
 
 
-# Furniture editor
+### Furniture editor
 Create new furniture or edit existing ones with this editor. After creating them, you can place them on the map with the Map Editor. Hover over the controls to get information about each of them.
 
 ![Catax_furniture_editor](Media/Catax_furniture_editor.png)
 
 
 
-# Itemgroup editor
-Specify itemgroups, used to spawn items in various locations including containers and corpses. By specifying a spawn chance and amount, it offers a wide veriety of possibilities. To add items to the itemgroup, drag them from the left side of the screen onto the itemgroup!
+### Itemgroup editor
+Specify itemgroups, used to spawn items in various locations including containers and corpses. By specifying a spawn chance and amount, it offers a wide variety of possibilities. To add items to the itemgroup, drag them from the left side of the screen onto the itemgroup!
 
 ![Catax_furniture_editor](Media/Catax_itemgroup_editor.png)
 
 
 
-# Player attribute editor
+### Player attribute editor
 In line with complete moddability, you can set the player's attributes using the editor. This allows for more immersion and customization. Once the attribute is created, you can then drag them from the menu onto items and have them alter the attribute. For example, you can have an "apple" item increase the "food" attribute when used.
 
 ![Catax_furniture_editor](Media/Catax_playerattribute_editor.png)
 
 
 
-# Wearable slots editor
+### Wearable slots editor
 Ever wanted to create that unique piece of armor, but didn't have that slot to fit it in? Now you can add your own slots. These show up in the player's inventory and enables the player to equip armor into it.
 
 ![Catax_furniture_editor](Media/Catax_wearableslots_editor.png)
 
 
 
-# Stats editor
+### Stats editor
 Add your own stats to the game. Stats are not implemented yet, but you can define them.
 
 ![Catax_furniture_editor](Media/Catax_stats_editor.png)
 
 
-# Skills editor
+### Skills editor
 Make any and every skill you need! Some are included in the core mod, but you can easily add your own in the Skills Editor. After they are created, use them in weapon or recipe configuration for other entities.
 
 ![Catax_furniture_editor](Media/Catax_skills_editor.png)
 
 
-# Quests editor
+### Quests editor
 Create a story for the player using the quest editor. These will show up in the quest journal in-game. It allows you to guide the player to their next destination and reward them for their efforts. There are multiple step types available. You can set many details and add a tip for the player.
 
 ![Catax_furniture_editor](Media/Catax_quest_editor.png)
 
 
-# Overmap area editor
-This editor allows you to define an area that will be generated on the overmap. An area can be created from an unlimted number of regions. In this image, a city is defined by the urban, suburban and field regions:
+### Overmap area editor
+This editor allows you to define an area that will be generated on the overmap. An area can be created from an unlimited number of regions. In this image, a city is defined by the urban, suburban and field regions:
 
 ![Catax_furniture_editor](Media/Dimensionfall_overmaparea_editor.png)
 
-Each region in the area will cover a differen circle around the center, depending on the radius. Using the generator, you can quickly see the result of your settings:
+Each region in the area will cover a different circle around the center, depending on the radius. Using the generator, you can quickly see the result of your settings:
 
 ![Catax_furniture_editor](Media/Dimensionfall_overmaparea_generator.png)
 
 
 Using this tool you can add new maps to cities, or create a whole new area with maps you made! This allows for the creation of biomes, for example.
 
-# Mob group editor
-With this editor, you can create your own group of mobs by adding a sprite, name, description, monsters (which can be dragged straight from the mob editor section within the content manager). You can even configure the monsters' spawn chance invidually by altering their weight, all within the editor:
+### Mob group editor
+With this editor, you can create your own group of mobs by adding a sprite, name, description, monsters (which can be dragged straight from the mob editor section within the content manager). You can even configure the monsters' spawn chance individually by altering their weight, all within the editor:
 
 ![Catax_mobgroup_editor](Media/Dimensionfall_mobgroup_editor.png)
 
-# Mob faction editor
+### Mob faction editor
 (Work in progress), you can create a new custom faction and assign it to any mobs or mobgroups you want. You can set what this faction is friendly, neutral and hostile towards other mobs, mobgroups and factions.
 
 ![Catax_mobfaction_editor](Media/Dimensionfall_mobfaction_editor.png)

--- a/README.md
+++ b/README.md
@@ -1,9 +1,16 @@
-# Dimensionfall:
-
+# Dimensionfall
 Dimensionfall is a top-down real-time survival game set in a post-apocalyptic world. Survive in a strange place where multiple dimensions have merged. Will you fight demons? Aliens? Zombies? Who knows what you will come across. The [lore](https://github.com/Khaligufzel/Dimensionfall/blob/main/Documentation/Game_design/Lore.md) has many interesting angles.
 
-![Catax_basic](Media/Catax_basic.png)
+## Table of Contents
+- [How to play](#how-to-play)
+- [Features](#features)
+- [Roadmap](#roadmap)
+- [Contribute](#contribute)
+- [Community](#community)
+- [Credits](#credits)
 
+Find a way to defend yourself in the city
+![Catax_basic](Media/Catax_basic.png)
 
 The world is infinite in every direction. Explore and survive as long as you can!
 ![Catax_basic](Media/Catax_basic_zoomed_out.png)
@@ -12,7 +19,7 @@ Check out the gameplay video:
 
 [![Dimensionfall_gameplay_demo](https://img.youtube.com/vi/Dnn8xvyTN74/maxresdefault.jpg)](https://www.youtube.com/watch?v=Dnn8xvyTN74)
 
-## How to play:
+## How to play
 You can find some demo releases [here](https://github.com/Khaligufzel/Dimensionfall/releases).
 Alternatively, you can play the game in the following way:
 - Download [Godot](https://godotengine.org/download/) from their website or from [steam](https://store.steampowered.com/app/404790/Godot_Engine/)
@@ -21,7 +28,7 @@ Alternatively, you can play the game in the following way:
 - Open Godot and click open project and navigate to the folder where you extracted the zip file
 - Open the project in Godot and click 'play' in the top-right
 
-## Features:
+## Features
 The game has the following features:
 - Melee and ranged combat + dual wielding
 - Inventory management
@@ -36,8 +43,7 @@ See also the extended [list of features](FeatureList.md)
 
 ## Roadmap
 
-### Stage 1 (first release):
-
+### Stage 1 (first release)
 - Building ~~/crafting/reloading~~ should take resources from the inventory
 - Basic ~~crafting/~~ building menu
 - ~~"Progress bar" to show the player when the current action will be finished (reloading, building, crafting etc.)~~
@@ -49,7 +55,6 @@ See also the extended [list of features](FeatureList.md)
 - Polishing
 
 Additional features before our first release:
-
 - ~~furniture/containers~~
 - personal goals
 - more enemies/better AI
@@ -58,8 +63,7 @@ Additional features before our first release:
 - equipment
 - ~~proper player inventory, bags~~
 
-### Stage 2:
-
+### Stage 2
 - Vehicles
 - Proper base building
 - Base raids?
@@ -69,10 +73,8 @@ Additional features before our first release:
 - ~~Melee weapons~~
 - ~~Recoil/sway/spread/aiming~~
 
-
 ## Contribute
-
-If you like Godot and want to contribute, feel free to submit a pull request or issue on your ideas, or join us on discord. To make edits, start by reading the [getting started guide](https://github.com/Khaligufzel/Dimensionfall/blob/main/Documentation/Game_development/Getting_started.md). 
+If you like Godot and want to contribute, feel free to submit a pull request or issue on your ideas, or join us on discord. To make edits, start by reading the [getting started guide](https://github.com/Khaligufzel/Dimensionfall/blob/main/Documentation/Game_development/Getting_started.md).
 
 This is and always will be a hobby project and will not be for sale. However, if you want to, you can to donate to the developers:
 
@@ -80,14 +82,12 @@ Khaligufzel: https://ko-fi.com/khaligufzel
 
 snipercup: https://ko-fi.com/snipercup
 
-
 ## Community
 
 Official Discord:
 [https://discord.gg/yzrxG9zZqA](https://discord.gg/yzrxG9zZqA)
 
-
-## Credits:
+## Credits
 - Sprites: Some sprites were created with https://github.com/int-ua/blender-pixelart
 - Sprites: Some sprites were created with https://github.com/RodZill4/material-maker
 - Inventory: This game uses https://github.com/peter-kish/gloot to implement the inventory

--- a/Scenes/ContentManager/Scripts/modmaintenance.gd
+++ b/Scenes/ContentManager/Scripts/modmaintenance.gd
@@ -1,7 +1,7 @@
 extends Control
 
-# This script is meant to be used with the mod maintenance inteface
-# This script allows the user to select one of the scripts to perform a veriety of functions
+# This script is meant to be used with the mod maintenance interface
+# This script allows the user to select one of the scripts to perform a variety of functions
 # When more functions need to be added, create a new scene and instantiate as a child instance
 # under the vbox container and add it to the code below to update it's visibility.
 

--- a/Scenes/UI/options_menu/ATTRIBUTION.md
+++ b/Scenes/UI/options_menu/ATTRIBUTION.md
@@ -9,24 +9,24 @@ Person 2
 
 ## Sourced / Unaffiliated
 ### Asset Type
-#### Use Case
+### Use Case
 Author: [Name]()  
 Source: [Domain : webpage.html]()  
 License: [License]()
 
 
 ## Tools
-#### Godot
+### Godot
 Author: [Juan Linietsky, Ariel Manzur, and contributors](https://godotengine.org/contact)  
 Source: [godotengine.org](https://godotengine.org/)  
 License: [MIT License](https://github.com/godotengine/godot/blob/master/LICENSE.txt) 
 
-#### Git
+### Git
 Author: [Linus Torvalds](https://github.com/torvalds)  
 Source: [git-scm.com](https://git-scm.com/downloads)  
 License: [GNU General Public License version 2](https://opensource.org/licenses/GPL-2.0)
 
-#### Godot Options Menus
+### Godot Options Menus
 Author: [Marek Belski](https://github.com/Maaack/Godot-Options-Menus/graphs/contributors)  
 Source: [github: Godot-Options-Menus](https://github.com/Maaack/Godot-Options-Menus)  
 License: [MIT License](LICENSE.txt)  


### PR DESCRIPTION
## Summary
- update README
  - add table of contents
  - rewrap paragraphs so sentences are not split
  - fix instructions about documentation filenames and GitHub references

other documentation:
standardize heading depth in the main documentation
fix typos in the mod maintenance script
restore addon documentation to its prior form

clarify testing instructions for Godot's GUT addon
