### PR TITLE
Implement accuracy stat modding

### DIFF
--- a/Mods/Core/Stats/references.json
+++ b/Mods/Core/Stats/references.json
@@ -1,0 +1,7 @@
+{
+	"dexterity": {
+		"items": [
+			"pistol_9mm"
+		]
+	}
+}

--- a/Mods/Dimensionfall/Items/Items.json
+++ b/Mods/Dimensionfall/Items/Items.json
@@ -84,6 +84,7 @@
 	},
 	{
 		"Ranged": {
+			"accuracy_stat": "dexterity",
 			"firing_speed": 0.4,
 			"range": 1000,
 			"recoil": 10,

--- a/Mods/Test/Stats/references.json
+++ b/Mods/Test/Stats/references.json
@@ -1,0 +1,7 @@
+{
+	"dexterity": {
+		"items": [
+			"pistol_9mm"
+		]
+	}
+}

--- a/Scenes/ContentManager/Custom_Editors/ItemEditor/ItemRangedEditor.tscn
+++ b/Scenes/ContentManager/Custom_Editors/ItemEditor/ItemRangedEditor.tscn
@@ -3,7 +3,7 @@
 [ext_resource type="Script" uid="uid://cibcfcysyj15" path="res://Scripts/ItemRangedEditor.gd" id="1_my1v7"]
 [ext_resource type="PackedScene" uid="uid://dsax7il2yggw8" path="res://Scenes/ContentManager/Custom_Widgets/DropEnabledTextEdit.tscn" id="2_crphu"]
 
-[node name="ItemRangedEditor" type="Control" node_paths=PackedStringArray("UsedAmmoTextEdit", "UsedMagazineContainer", "RangeNumberBox", "SpreadNumberBox", "SwayNumberBox", "RecoilNumberBox", "UsedSkillTextEdit", "skill_xp_spin_box", "ReloadSpeedNumberBox", "FiringSpeedNumberBox")]
+[node name="ItemRangedEditor" type="Control" node_paths=PackedStringArray("UsedAmmoTextEdit", "UsedMagazineContainer", "RangeNumberBox", "SpreadNumberBox", "SwayNumberBox", "RecoilNumberBox", "UsedSkillTextEdit", "skill_xp_spin_box", "ReloadSpeedNumberBox", "FiringSpeedNumberBox", "accuracy_stat_text_edit")]
 layout_mode = 3
 anchors_preset = 15
 anchor_right = 1.0
@@ -21,6 +21,7 @@ UsedSkillTextEdit = NodePath("Ranged/SkillHBoxContainer/UsedSkillTextEdit")
 skill_xp_spin_box = NodePath("Ranged/SkillHBoxContainer/SkillXPSpinBox")
 ReloadSpeedNumberBox = NodePath("Ranged/ReloadSpeedNumber")
 FiringSpeedNumberBox = NodePath("Ranged/FiringSpeedNumber")
+accuracy_stat_text_edit = NodePath("Ranged/AccuracyStatTextEdit")
 
 [node name="Ranged" type="GridContainer" parent="."]
 layout_mode = 1
@@ -148,3 +149,13 @@ tooltip_text = "The delay between shots. A smaller number means firing more quic
 min_value = 0.01
 step = 0.01
 value = 0.25
+
+[node name="AccuracyStatLabel" type="Label" parent="Ranged"]
+layout_mode = 2
+text = "Accuracy Stat"
+
+[node name="AccuracyStatTextEdit" parent="Ranged" instance=ExtResource("2_crphu")]
+layout_mode = 2
+size_flags_vertical = 1
+tooltip_text = "The stat that improves accuracy for this weapon."
+myplaceholdertext = "Drop a stat from the list to the left"

--- a/Scripts/EquippedItem.gd
+++ b/Scripts/EquippedItem.gd
@@ -133,15 +133,16 @@ func calculate_accuracy() -> float:
 	var rangedproperties = equipped_item.get_property("Ranged")
 	var skillid = Helper.json_helper.get_nested_data(rangedproperties, "used_skill.skill_id")
 	var skill_level = player.get_skill_level(skillid)
-	var dex = 0
-	if player.has_method("get_stat"):
-		dex = player.get_stat("dexterity")
+	var stat_value = 0
+	var accuracy_stat: String = rangedproperties.get("accuracy_stat", "")
+	if accuracy_stat != "" and player.has_method("get_stat"):
+		stat_value = player.get_stat(accuracy_stat)
 	# Minimum accuracy is 25%, maximum is 100% at level 30
 	var min_accuracy = 0.25
 	var max_accuracy = 1.0
 	var required_level = 30
 
-	var effective_level = skill_level + dex
+	var effective_level = skill_level + stat_value
 	if effective_level >= required_level:
 		return max_accuracy
 	else:

--- a/Scripts/Gamedata/DItem.gd
+++ b/Scripts/Gamedata/DItem.gd
@@ -543,6 +543,7 @@ func changed(olddata: DItem):
 	for res_id in new_resource_ids:
 		Gamedata.mods.add_reference(DMod.ContentType.ITEMS, res_id, DMod.ContentType.ITEMS, id)
 	update_item_skill_references(olddata)
+	update_item_stat_references(olddata)
 	update_item_attribute_references(olddata)
 	
 	parent.save_items_to_disk()
@@ -613,6 +614,21 @@ func update_item_skill_references(olddata: DItem):
 	# Add new skill references
 	for new_skill_id in new_skill_ids:
 		Gamedata.mods.add_reference(DMod.ContentType.SKILLS, new_skill_id, DMod.ContentType.ITEMS, id)
+
+# Updates references between the ranged item's accuracy stat and the stat entity
+func update_item_stat_references(olddata: DItem):
+	var old_stat_id := ""
+	if olddata.ranged and olddata.ranged.accuracy_stat != "":
+		old_stat_id = olddata.ranged.accuracy_stat
+	var new_stat_id := ""
+	if ranged and ranged.accuracy_stat != "":
+		new_stat_id = ranged.accuracy_stat
+
+	if old_stat_id != new_stat_id:
+		if old_stat_id != "":
+			Gamedata.mods.remove_reference(DMod.ContentType.STATS, old_stat_id, DMod.ContentType.ITEMS, id)
+		if new_stat_id != "":
+			Gamedata.mods.add_reference(DMod.ContentType.STATS, new_stat_id, DMod.ContentType.ITEMS, id)
 
 
 # Collects all attributes defined in an item and updates the references to that attribute
@@ -690,9 +706,12 @@ func delete():
 	if melee and melee.used_skill:
 		skill_ids[melee.used_skill.skill_id] = true
 
-	# Remove the reference of this item from each skill
+# Remove the reference of this item from each skill
 	for skill_id in skill_ids.keys():
 		Gamedata.mods.remove_reference(DMod.ContentType.SKILLS, skill_id, DMod.ContentType.ITEMS, id)
+
+	if ranged and ranged.accuracy_stat != "":
+		Gamedata.mods.remove_reference(DMod.ContentType.STATS, ranged.accuracy_stat, DMod.ContentType.ITEMS, id)
 
 
 # Function to remove all instances of a skill from the item

--- a/Scripts/Gamedata/DItem.gd
+++ b/Scripts/Gamedata/DItem.gd
@@ -191,7 +191,7 @@ class Ranged:
 
 	# Get data function to return a dictionary with all properties
 	func get_data() -> Dictionary:
-		return {
+		var data: Dictionary = {
 			"firing_speed": firing_speed,
 			"range": firing_range,
 			"recoil": recoil,
@@ -200,9 +200,11 @@ class Ranged:
 			"sway": sway,
 			"used_ammo": used_ammo,
 			"used_magazine": used_magazine,
-			"used_skill": used_skill,
-			"accuracy_stat": accuracy_stat
+			"used_skill": used_skill
 		}
+		if accuracy_stat != "":
+			data["accuracy_stat"] = accuracy_stat
+		return data
 		
 	# Function to get used skill ID
 	func get_used_skill_ids() -> Array:

--- a/Scripts/Gamedata/DItem.gd
+++ b/Scripts/Gamedata/DItem.gd
@@ -174,6 +174,7 @@ class Ranged:
 	var used_ammo: String
 	var used_magazine: String
 	var used_skill: Dictionary # example: {"skill_id": "handguns", "xp": 1}
+	var accuracy_stat: String
 
 	# Constructor to initialize ranged properties from a dictionary
 	func _init(data: Dictionary):
@@ -186,6 +187,7 @@ class Ranged:
 		used_ammo = data.get("used_ammo", "")
 		used_magazine = data.get("used_magazine", "")
 		used_skill = data.get("used_skill", {})
+		accuracy_stat = data.get("accuracy_stat", "")
 
 	# Get data function to return a dictionary with all properties
 	func get_data() -> Dictionary:
@@ -198,7 +200,8 @@ class Ranged:
 			"sway": sway,
 			"used_ammo": used_ammo,
 			"used_magazine": used_magazine,
-			"used_skill": used_skill
+			"used_skill": used_skill,
+			"accuracy_stat": accuracy_stat
 		}
 		
 	# Function to get used skill ID

--- a/Scripts/Gamedata/DStats.gd
+++ b/Scripts/Gamedata/DStats.gd
@@ -6,32 +6,44 @@ extends RefCounted
 # This script handles the list of stats. You can access it through Gamedata.mods.by_id("Core").stats
 
 # Paths for stats data and sprites
-var dataPath: String = "./Mods/Core/Stats/Stats.json"
+var dataPath: String = "./Mods/Core/Stats/"
+var file_path: String = "./Mods/Core/Stats/Stats.json"
 var spritePath: String = "./Mods/Core/Stats/"
 var statdict: Dictionary = {}
 var sprites: Dictionary = {}
+var references: Dictionary = {}
 var mod_id: String = "Core"
 
 # Add a mod_id parameter to dynamically initialize paths
 func _init(new_mod_id: String) -> void:
 	mod_id = new_mod_id
 	# Update dataPath and spritePath using the provided mod_id
-	dataPath = "./Mods/" + mod_id + "/Stats/Stats.json"
+	dataPath = "./Mods/" + mod_id + "/Stats/"
+	file_path = "./Mods/" + mod_id + "/Stats/Stats.json"
 	spritePath = "./Mods/" + mod_id + "/Stats/"
 	
 	# Load stats and sprites
 	load_sprites()
 	load_stats_from_disk()
+	load_references()
 
 
 # Load all stats data from disk into memory
 func load_stats_from_disk() -> void:
-	var statslist: Array = Helper.json_helper.load_json_array_file(dataPath)
-	for mystat in statslist:
-		var stat: DStat = DStat.new(mystat, self)
-		if stat.spriteid:
-			stat.sprite = sprites[stat.spriteid]
-		statdict[stat.id] = stat
+		var statslist: Array = Helper.json_helper.load_json_array_file(file_path)
+		for mystat in statslist:
+			var stat: DStat = DStat.new(mystat, self)
+			if stat.spriteid:
+					stat.sprite = sprites[stat.spriteid]
+			statdict[stat.id] = stat
+
+# Load references from references.json
+func load_references() -> void:
+		var path = dataPath.get_base_dir() + "/references.json"
+		if FileAccess.file_exists(path):
+				references = Helper.json_helper.load_json_dictionary_file(path)
+		else:
+				references = {}
 
 # Loads sprites and assigns them to the proper dictionary
 func load_sprites() -> void:
@@ -51,7 +63,7 @@ func save_stats_to_disk() -> void:
 	var save_data: Array = []
 	for stat in statdict.values():
 		save_data.append(stat.get_data())
-	Helper.json_helper.write_json_file(dataPath, JSON.stringify(save_data, "\t"))
+	Helper.json_helper.write_json_file(file_path, JSON.stringify(save_data, "\t"))
 
 # Returns the dictionary containing all stats
 func get_all() -> Dictionary:

--- a/Scripts/ItemRangedEditor.gd
+++ b/Scripts/ItemRangedEditor.gd
@@ -14,6 +14,7 @@ extends Control
 @export var skill_xp_spin_box: SpinBox = null
 @export var ReloadSpeedNumberBox: SpinBox = null
 @export var FiringSpeedNumberBox: SpinBox = null
+@export var accuracy_stat_text_edit: HBoxContainer = null
 
 var ditem: DItem = null:
 	set(value):
@@ -57,6 +58,7 @@ func save_properties() -> void:
 	ditem.ranged.recoil = int(RecoilNumberBox.value)
 	ditem.ranged.reload_speed = ReloadSpeedNumberBox.value
 	ditem.ranged.firing_speed = FiringSpeedNumberBox.value
+	ditem.ranged.accuracy_stat = accuracy_stat_text_edit.get_text()
 	
 	# Only include used_skill if UsedSkillTextEdit has a value
 	if UsedSkillTextEdit.get_text() != "":
@@ -85,6 +87,7 @@ func load_properties() -> void:
 	RecoilNumberBox.value = ditem.ranged.recoil
 	ReloadSpeedNumberBox.value = ditem.ranged.reload_speed
 	FiringSpeedNumberBox.value = ditem.ranged.firing_speed
+	accuracy_stat_text_edit.set_text(ditem.ranged.accuracy_stat)
 	
 	if ditem.ranged.used_skill.has("skill_id"):
 		UsedSkillTextEdit.set_text(ditem.ranged.used_skill["skill_id"])
@@ -118,9 +121,26 @@ func can_skill_drop(dropped_data: Dictionary):
 	# If all checks pass, return true
 	return true
 
+func stat_drop(dropped_data: Dictionary, texteditcontrol: HBoxContainer) -> void:
+	if dropped_data and dropped_data.has("id"):
+		var stat_id = dropped_data["id"]
+		if not Gamedata.mods.by_id(dropped_data["mod_id"]).stats.has_id(stat_id):
+			print_debug("No stat data found for ID: " + stat_id)
+			return
+		texteditcontrol.set_text(stat_id)
+	else:
+		print_debug("Dropped data does not contain an 'id' key.")
+
+func can_stat_drop(dropped_data: Dictionary):
+	if not dropped_data or not dropped_data.has("id"):
+		return false
+	return Gamedata.mods.by_id(dropped_data["mod_id"]).stats.has_id(dropped_data["id"])
+
 
 # Set the drop functions on the required skill and skill progression controls
 # This enables them to receive drop data
 func set_drop_functions():
 	UsedSkillTextEdit.drop_function = skill_drop.bind(UsedSkillTextEdit)
 	UsedSkillTextEdit.can_drop_function = can_skill_drop
+	accuracy_stat_text_edit.drop_function = stat_drop.bind(accuracy_stat_text_edit)
+	accuracy_stat_text_edit.can_drop_function = can_stat_drop

--- a/Scripts/Runtimedata/RItem.gd
+++ b/Scripts/Runtimedata/RItem.gd
@@ -104,6 +104,7 @@ class Ranged:
 	var used_ammo: String
 	var used_magazine: String
 	var used_skill: Dictionary
+	var accuracy_stat: String
 
 	func _init(data: Dictionary):
 		firing_speed = data.get("firing_speed", 0.0)
@@ -115,6 +116,7 @@ class Ranged:
 		used_ammo = data.get("used_ammo", "")
 		used_magazine = data.get("used_magazine", "")
 		used_skill = data.get("used_skill", {})
+		accuracy_stat = data.get("accuracy_stat", "")
 
 	func get_data() -> Dictionary:
 		return {
@@ -126,7 +128,8 @@ class Ranged:
 			"sway": sway,
 			"used_ammo": used_ammo,
 			"used_magazine": used_magazine,
-			"used_skill": used_skill
+			"used_skill": used_skill,
+			"accuracy_stat": accuracy_stat
 		}
 
 class Melee:

--- a/Scripts/Runtimedata/RItem.gd
+++ b/Scripts/Runtimedata/RItem.gd
@@ -119,7 +119,7 @@ class Ranged:
 		accuracy_stat = data.get("accuracy_stat", "")
 
 	func get_data() -> Dictionary:
-		return {
+		var data: Dictionary = {
 			"firing_speed": firing_speed,
 			"range": firing_range,
 			"recoil": recoil,
@@ -128,9 +128,11 @@ class Ranged:
 			"sway": sway,
 			"used_ammo": used_ammo,
 			"used_magazine": used_magazine,
-			"used_skill": used_skill,
-			"accuracy_stat": accuracy_stat
+			"used_skill": used_skill
 		}
+		if accuracy_stat != "":
+			data["accuracy_stat"] = accuracy_stat
+		return data
 
 class Melee:
 	var damage: int


### PR DESCRIPTION
Fixes #808 

A stat can now be configured into a ranged weapon that will improve accuracy for the weapon. For the 9mm pistol it is dexterity. If no stat is configured for the weapon, only the handguns/rifles skill will be used for accuracy.