### PR TITLE
Update custom mouse cursor

### DIFF
--- a/project.godot
+++ b/project.godot
@@ -38,7 +38,7 @@ AppConfig="*res://addons/maaacks_options_menus/base/scenes/autoloads/app_config.
 
 [display]
 
-mouse_cursor/custom_image="res://Textures/pointer3.png"
+mouse_cursor/custom_image="uid://bomcubohj8q5k"
 mouse_cursor/custom_image_hotspot=Vector2(64, 64)
 
 [editor]


### PR DESCRIPTION
I updated the mouse cursor in the project settings to the same cursor image. it changed it to an uid. Maybe it was a remnant from godot 4.3