### PR TITLE
Double the amount of mobs, cache camera in player script

### DIFF
--- a/Mods/Dimensionfall/Maps/Generichouse.json
+++ b/Mods/Dimensionfall/Maps/Generichouse.json
@@ -3,7 +3,7 @@
 		{
 			"entities": [
 				{
-					"count": 24.0,
+					"count": 48.0,
 					"id": "basic_zombies",
 					"type": "mobgroup"
 				}

--- a/Mods/Dimensionfall/Maps/Generichouse_00.json
+++ b/Mods/Dimensionfall/Maps/Generichouse_00.json
@@ -3,7 +3,7 @@
 		{
 			"entities": [
 				{
-					"count": 24.0,
+					"count": 48.0,
 					"id": "basic_zombies",
 					"type": "mobgroup"
 				}

--- a/Mods/Dimensionfall/Maps/abandoned_building.json
+++ b/Mods/Dimensionfall/Maps/abandoned_building.json
@@ -3,7 +3,7 @@
 		{
 			"entities": [
 				{
-					"count": 24.0,
+					"count": 48.0,
 					"id": "basic_zombies",
 					"type": "mobgroup"
 				}

--- a/Mods/Dimensionfall/Maps/factory_hall.json
+++ b/Mods/Dimensionfall/Maps/factory_hall.json
@@ -138,7 +138,7 @@
 		{
 			"entities": [
 				{
-					"count": 1,
+					"count": 2,
 					"id": "security_robots",
 					"type": "mobgroup"
 				}

--- a/Mods/Dimensionfall/Maps/generichouse_corner.json
+++ b/Mods/Dimensionfall/Maps/generichouse_corner.json
@@ -3,7 +3,7 @@
 		{
 			"entities": [
 				{
-					"count": 24.0,
+					"count": 48.0,
 					"id": "basic_zombies",
 					"type": "mobgroup"
 				}

--- a/Mods/Dimensionfall/Maps/generichouse_cross.json
+++ b/Mods/Dimensionfall/Maps/generichouse_cross.json
@@ -3,7 +3,7 @@
 		{
 			"entities": [
 				{
-					"count": 24.0,
+					"count": 48.0,
 					"id": "basic_zombies",
 					"type": "mobgroup"
 				}

--- a/Mods/Dimensionfall/Maps/generichouse_end.json
+++ b/Mods/Dimensionfall/Maps/generichouse_end.json
@@ -3,7 +3,7 @@
 		{
 			"entities": [
 				{
-					"count": 24.0,
+					"count": 48.0,
 					"id": "basic_zombies",
 					"type": "mobgroup"
 				}

--- a/Mods/Dimensionfall/Maps/generichouse_t.json
+++ b/Mods/Dimensionfall/Maps/generichouse_t.json
@@ -3,7 +3,7 @@
 		{
 			"entities": [
 				{
-					"count": 24.0,
+					"count": 48.0,
 					"id": "basic_zombies",
 					"type": "mobgroup"
 				}

--- a/Mods/Dimensionfall/Maps/industrial_control_center.json
+++ b/Mods/Dimensionfall/Maps/industrial_control_center.json
@@ -69,7 +69,7 @@
 		{
 			"entities": [
 				{
-					"count": 1,
+					"count": 2,
 					"id": "security_robots",
 					"type": "mobgroup"
 				}

--- a/Mods/Dimensionfall/Maps/neighborhood_school.json
+++ b/Mods/Dimensionfall/Maps/neighborhood_school.json
@@ -3,7 +3,7 @@
 		{
 			"entities": [
 				{
-					"count": 24.0,
+					"count": 48.0,
 					"id": "basic_zombies",
 					"type": "mobgroup"
 				}

--- a/Mods/Dimensionfall/Maps/office_building_00.json
+++ b/Mods/Dimensionfall/Maps/office_building_00.json
@@ -85,7 +85,7 @@
 		{
 			"entities": [
 				{
-					"count": 24.0,
+					"count": 48.0,
 					"id": "basic_zombies",
 					"type": "mobgroup"
 				}

--- a/Mods/Dimensionfall/Maps/parking_garage.json
+++ b/Mods/Dimensionfall/Maps/parking_garage.json
@@ -71,7 +71,7 @@
 		{
 			"entities": [
 				{
-					"count": 24.0,
+					"count": 48.0,
 					"id": "basic_zombies",
 					"type": "mobgroup"
 				}

--- a/Mods/Dimensionfall/Maps/radio_tower.json
+++ b/Mods/Dimensionfall/Maps/radio_tower.json
@@ -154,27 +154,27 @@
 		{
 			"entities": [
 				{
-					"count": 10,
+					"count": 20,
 					"id": "disruptor_drone",
 					"type": "mob"
 				},
 				{
-					"count": 2,
+					"count": 4,
 					"id": "scavenger_skitter",
 					"type": "mob"
 				},
 				{
-					"count": 1,
+					"count": 2,
 					"id": "iron_stalker",
 					"type": "mob"
 				},
 				{
-					"count": 4,
+					"count": 8,
 					"id": "scrapwalker",
 					"type": "mob"
 				},
 				{
-					"count": 3,
+					"count": 6,
 					"id": "rust_sentinel",
 					"type": "mob"
 				}

--- a/Mods/Dimensionfall/Maps/scrap_yard.json
+++ b/Mods/Dimensionfall/Maps/scrap_yard.json
@@ -121,7 +121,7 @@
 		{
 			"entities": [
 				{
-					"count": 1,
+					"count": 2,
 					"id": "security_robots",
 					"type": "mobgroup"
 				}

--- a/Mods/Dimensionfall/Maps/store_electronic_clothing.json
+++ b/Mods/Dimensionfall/Maps/store_electronic_clothing.json
@@ -3,7 +3,7 @@
 		{
 			"entities": [
 				{
-					"count": 24.0,
+					"count": 48.0,
 					"id": "basic_zombies",
 					"type": "mobgroup"
 				}

--- a/Mods/Dimensionfall/Maps/subway_station.json
+++ b/Mods/Dimensionfall/Maps/subway_station.json
@@ -104,7 +104,7 @@
 		{
 			"entities": [
 				{
-					"count": 24.0,
+					"count": 48.0,
 					"id": "basic_zombies",
 					"type": "mobgroup"
 				}

--- a/Mods/Dimensionfall/Maps/two_story_house.json
+++ b/Mods/Dimensionfall/Maps/two_story_house.json
@@ -3,7 +3,7 @@
 		{
 			"entities": [
 				{
-					"count": 24.0,
+					"count": 48.0,
 					"id": "basic_zombies",
 					"type": "mobgroup"
 				}

--- a/Mods/Dimensionfall/Maps/warehouse_storage.json
+++ b/Mods/Dimensionfall/Maps/warehouse_storage.json
@@ -128,7 +128,7 @@
 		{
 			"entities": [
 				{
-					"count": 1,
+					"count": 2,
 					"id": "security_robots",
 					"type": "mobgroup"
 				}

--- a/Scripts/player.gd
+++ b/Scripts/player.gd
@@ -48,6 +48,7 @@ var move_input: Vector2 = Vector2.ZERO
 @export var testing: bool = false  # Used to test in the test_environment
 @export var interact_range: float = 10
 @export var camera_3d: Camera3D = null
+var my_viewport: Viewport
 
 #@export var progress_bar : NodePath
 #@export var progress_bar_filling : NodePath
@@ -70,6 +71,7 @@ func _init():
 
 
 func _ready():
+	my_viewport = get_viewport()
 	connect_held_item_slots()
 	initialize_condition()
 	initialize_attributes()
@@ -146,11 +148,10 @@ func initialize_stats_and_skills():
 
 func _process(_delta):
 	# Get the 2D screen position of the player
-	var camera = get_tree().get_first_node_in_group("Camera")
-	var player_screen_pos = camera.unproject_position(global_position)
+	var player_screen_pos = camera_3d.unproject_position(global_position)
 
 	# Get the mouse position in 2D screen space
-	var mouse_pos_2d = get_viewport().get_mouse_position()
+	var mouse_pos_2d = my_viewport.get_mouse_position()
 
 	# Calculate the direction vector from the player to the mouse position
 	var dir = (mouse_pos_2d - player_screen_pos).normalized()


### PR DESCRIPTION
This doubles the amount of mobs in the game on most maps. It still runs well.

I noticed a spike in frame time in the player `_process` function, so I cached the camera and viewport. Seems to make a difference.