### PR TITLE
Add new items to itemgroups

### DIFF
--- a/Mods/Dimensionfall/Itemgroups/Itemgroups.json
+++ b/Mods/Dimensionfall/Itemgroups/Itemgroups.json
@@ -62,6 +62,18 @@
 				"max": 1,
 				"min": 1,
 				"probability": 1
+			},
+			{
+				"id": "dried_fruit_mix",
+				"max": 1,
+				"min": 1,
+				"probability": 20
+			},
+			{
+				"id": "jar_honey",
+				"max": 1,
+				"min": 1,
+				"probability": 20
 			}
 		],
 		"mode": "Collection",
@@ -196,6 +208,18 @@
 				"max": 1,
 				"min": 1,
 				"probability": 1
+			},
+			{
+				"id": "adjustable_wrench",
+				"max": 1,
+				"min": 1,
+				"probability": 1
+			},
+			{
+				"id": "multi_tool",
+				"max": 1,
+				"min": 1,
+				"probability": 10
 			}
 		],
 		"mode": "Collection",
@@ -1727,6 +1751,18 @@
 			},
 			{
 				"id": "rope_coil",
+				"max": 1,
+				"min": 1,
+				"probability": 1
+			},
+			{
+				"id": "steel_rebar",
+				"max": 1,
+				"min": 1,
+				"probability": 1
+			},
+			{
+				"id": "cement_bag",
 				"max": 1,
 				"min": 1,
 				"probability": 1

--- a/Mods/Dimensionfall/Items/references.json
+++ b/Mods/Dimensionfall/Items/references.json
@@ -4,6 +4,11 @@
 			"generic_forest_finds"
 		]
 	},
+	"adjustable_wrench": {
+		"itemgroups": [
+			"cabinet_general"
+		]
+	},
 	"apple": {
 		"itemgroups": [
 			"refrigerator",
@@ -204,6 +209,11 @@
 			"refrigerator"
 		]
 	},
+	"cement_bag": {
+		"itemgroups": [
+			"loot_gas_station"
+		]
+	},
 	"ceramic_fragments": {
 		"itemgroups": [
 			"debris_urban"
@@ -273,6 +283,11 @@
 		],
 		"quests": [
 			"quest_radio_signal_01"
+		]
+	},
+	"dried_fruit_mix": {
+		"itemgroups": [
+			"kitchen_cupboard"
 		]
 	},
 	"eggs": {
@@ -370,6 +385,11 @@
 			"zombie_loot"
 		]
 	},
+	"jar_honey": {
+		"itemgroups": [
+			"kitchen_cupboard"
+		]
+	},
 	"jeans": {
 		"itemgroups": [
 			"clothing_general",
@@ -457,6 +477,11 @@
 		"itemgroups": [
 			"electronics_store_medium",
 			"electronics_store_mixed"
+		]
+	},
+	"multi_tool": {
+		"itemgroups": [
+			"cabinet_general"
 		]
 	},
 	"mushrooms_forest": {
@@ -671,6 +696,11 @@
 	"stale_bread": {
 		"itemgroups": [
 			"urban_litter"
+		]
+	},
+	"steel_rebar": {
+		"itemgroups": [
+			"loot_gas_station"
 		]
 	},
 	"steel_scrap": {


### PR DESCRIPTION
Fixes #881 

Adds the new items to itemgroups, so they spawn into the world. It's not perfect but its a start.