### PR TITLE
Comment out the farm field in overmapgrid

### DIFF
--- a/Scripts/OvermapGrid.gd
+++ b/Scripts/OvermapGrid.gd
@@ -638,8 +638,8 @@ func generate_cells() -> void:
 				cell.map_id = "default_map"  # Fallback if no maps found
 			# If you need to test a specific map, uncomment these two lines and put in your map name.
 			# It will spawn the map at position (0,0), where the player starts
-			if global_x == 0 and global_y == 0:
-				cell.map_id = "field_farmland"
+			#if global_x == 0 and global_y == 0:
+				#cell.map_id = "field_farmland"
 
 			# Add the cell to the grid's cells dictionary
 			cells[cell_key] = cell


### PR DESCRIPTION
Wasn't supposed to stay uncommented. We should replace it with a mechanic that doesn't involve messing with scripts