### PR TITLE
 feat: add general tile placement primitives to map recipe generator 

### DIFF
--- a/Documentation/Game_design/Map_generation_plan.md
+++ b/Documentation/Game_design/Map_generation_plan.md
@@ -1,4 +1,4 @@
-You have now completed the **foundation and first generator milestone**. The project can generate a structurally valid 32×32 Dimensionfall map from a compact recipe, but it cannot yet describe or place enough content to build a useful playable map.
+You have now completed the **foundation, minimal generator, and general placement-primitives milestones**. The project can generate a structurally valid, visually recognizable 32×32 outdoor Dimensionfall map from a compact recipe, but it cannot yet place gameplay features or buildings.
 
 ## Overall goal
 
@@ -123,6 +123,9 @@ The generator currently supports:
 * one populated level at level-array index 10;
 * a base tile covering the entire map;
 * ordered rectangular regions;
+* ordered `set`, `rectangle`, `rectangle_outline`, `line`, and `scatter` operations;
+* inclusive Bresenham line rasterization;
+* deterministic scatter by count or density;
 * fixed tile rotations;
 * deterministic random rotations;
 * `null` region tiles that produce `{}`;
@@ -146,7 +149,7 @@ unused levels: []
 
 ## 5. Generator and validator tests: complete for version 1
 
-The current Python test suite contains 16 tests and passes.
+The current Python test suite contains 24 tests and passes.
 
 Coverage includes:
 
@@ -154,6 +157,12 @@ Coverage includes:
 * exactly 1024 entries;
 * deterministic generation;
 * rectangular overlays;
+* single-cell placement;
+* filled and outlined rectangles, including thin outlines;
+* horizontal, vertical, and diagonal lines;
+* deterministic scatter by count and density;
+* operation ordering and overwrite behavior;
+* operation field, type, coordinate, bounds, and scatter-argument validation;
 * empty-tile representation;
 * unknown fields;
 * invalid IDs;
@@ -198,10 +207,7 @@ The current recipe language is intentionally minimal. It cannot yet express most
 
 It does not currently support:
 
-* lines or paths;
-* rectangle outlines;
 * circles or irregular regions;
-* scattered terrain;
 * weighted tile variation;
 * terrain blending;
 * multiple populated vertical levels;
@@ -221,7 +227,19 @@ It does not currently support:
 * importing an existing map into a recipe;
 * regeneration while preserving hand-authored changes.
 
-At present, it can create a technically valid field with rectangular patches. It cannot yet create a credible playable location.
+At present, it can create a recognizable outdoor terrain layout with paths, bounded clearings, and scattered variation. It cannot yet create a credible playable location because it has no furniture, semantic areas, buildings, or gameplay content.
+
+---
+
+# Progress tracking
+
+This document is the roadmap source of truth. Keep it current at milestone boundaries rather than recording a chronological activity log:
+
+* use `planned`, `next`, `in progress`, or `complete` for each phase;
+* mark a phase complete only after its success criterion and listed validation pass;
+* when a phase changes, update its delivered list, current capabilities and limitations, test count, recommended next task, and the one-view summary together;
+* keep temporary implementation notes and command output out of this document;
+* preserve detailed operation contracts in `Documentation/Modding/map_recipe_generator.md` and tests rather than duplicating them here.
 
 ---
 
@@ -268,69 +286,19 @@ Delivered:
 
 ## Phase 3 — General placement primitives
 
-**Status: next**
+**Status: complete**
 
-This should be the next branch.
+Delivered:
 
-Suggested name:
-
-```text
-feature/map-generator-primitives
-```
-
-or:
-
-```text
-hermes/map-generator-primitives
-```
-
-Recommended additions:
-
-* single-cell placement;
-* filled rectangle;
-* rectangle outline;
-* horizontal and vertical lines;
-* general line placement;
-* circles or ellipses;
-* deterministic scattered placement;
-* deterministic clusters;
-* checker or repeating patterns;
-* strict versus clipped boundary behavior.
-
-These primitives are the basic vocabulary needed before attempting authored maps.
-
-A recipe might begin to support:
-
-```json
-{
-  "operations": [
-    {
-      "type": "line",
-      "from": [0, 16],
-      "to": [31, 16],
-      "tile": {
-        "id": "dirt-light"
-      },
-      "width": 2
-    },
-    {
-      "type": "scatter",
-      "region": {
-        "x": 0,
-        "y": 0,
-        "width": 32,
-        "height": 32
-      },
-      "tile": {
-        "id": "grass-tall"
-      },
-      "density": 0.12
-    }
-  ]
-}
-```
-
-The exact schema should be designed after inspecting the available tile and map formats.
+* ordered `operations` applied after legacy `regions`;
+* `set`, filled `rectangle`, and `rectangle_outline` placement;
+* inclusive one-cell-wide lines using the integer Bresenham algorithm;
+* deterministic scatter using exactly one of `count` or `density`;
+* strict bounds with no silent clipping;
+* unknown-field and unknown-operation rejection;
+* shared placement logic for legacy regions and rectangle operations;
+* an outdoor example with a path, bounded clearing, and scattered flowers;
+* focused tests and recipe documentation.
 
 ### Success criterion
 
@@ -341,11 +309,11 @@ A recipe can generate a visually recognizable outdoor layout containing:
 * one bounded clearing;
 * some deterministic scattered variation.
 
-No furniture or buildings yet.
+No furniture or buildings yet. This criterion is met by `Tools/examples/map_recipe.json`.
 
 ## Phase 4 — Tile palettes and reusable patterns
 
-**Status: planned**
+**Status: next**
 
 Raw tile IDs are cumbersome and encourage agents to invent invalid identifiers. Introduce semantic recipe-level palettes.
 
@@ -640,93 +608,15 @@ An agent can create a new playable map from a concise design request, run all re
 
 # Recommended immediate next task
 
-The next contribution should stay narrow: **placement primitives only**.
+The next contribution should stay narrow: **tile palettes and deterministic variation**.
 
-Do not combine primitives, buildings, features, roads, and semantic map generation into one branch. That would make the recipe format unstable and difficult to review.
+Keep the completed placement-operation schema stable. Add named, recipe-level tile palettes that can be referenced anywhere an operation currently accepts a tile. Palette entries should use validated tile IDs and positive integer weights, select deterministically from the recipe seed, preserve explicit tile objects and `null`, and reject unknown palette names or malformed entries.
 
-A suitable Hermes task is:
+The branch should not add furniture, areas, buildings, semantic roads, towns, or additional levels. Its success criterion is visibly varied terrain without one recipe entry per cell.
 
-```text
-Extend the recipe-driven Dimensionfall map generator with a small set of
-general-purpose tile placement primitives.
+Before implementation, inspect the current generator, tests, tile database, recipe documentation, and example. Define how palette selection interacts with `"random"` rotation and RNG ordering, add focused compatibility and validation tests, update the example and documentation, generate and validate the example map, inspect dimensions and tile count, and run `git diff --check`.
 
-Read the repository guidance, current generator, validator, tests,
-documentation, example recipe, tile database, and representative valid maps
-before editing.
-
-Keep the existing fixed 32x32 map format and one populated ground level.
-
-Add an ordered `operations` recipe array. Preserve support for the existing
-`regions` field during this branch unless there is a strong, documented reason
-to migrate it.
-
-Implement these operations:
-
-1. `set`
-   - places one tile at x, y
-
-2. `rectangle`
-   - places a filled rectangle
-   - equivalent to the current region behavior
-
-3. `rectangle_outline`
-   - places only a rectangle's border
-   - define behavior for width or height equal to 1
-
-4. `line`
-   - places a deterministic one-tile-wide line between two integer points
-   - document the rasterization algorithm
-   - support horizontal, vertical, and diagonal lines
-
-5. `scatter`
-   - places tiles within a rectangular region using the recipe seed
-   - use either an explicit count or density, but not both
-   - deterministic for the same recipe and seed
-   - document whether existing cells are replaced
-
-Requirements:
-
-- operations execute in array order;
-- later operations may overwrite earlier terrain;
-- every coordinate must be checked against the fixed 32x32 grid;
-- preserve `{}` as the empty-tile representation;
-- reject unknown operation fields;
-- reject invalid operation types;
-- reject invalid coordinates and dimensions;
-- do not silently clip out-of-bounds shapes unless clipping is explicitly part
-  of the documented operation contract;
-- preserve deterministic output;
-- keep the generator independent of Godot;
-- do not add furniture, areas, buildings, roads, towns, or additional levels
-  in this branch.
-
-Decide whether `regions` should internally translate into a rectangle
-operation to avoid maintaining duplicate placement logic.
-
-Add tests covering:
-
-- each operation;
-- operation ordering and overwrite behavior;
-- horizontal, vertical, and diagonal lines;
-- thin rectangle outlines;
-- deterministic scatter;
-- invalid scatter arguments;
-- out-of-bounds operations;
-- unknown operation fields and types;
-- unchanged fixed dimensions and 1024-tile invariant;
-- backwards compatibility with the current example recipe, if retained.
-
-Update the recipe documentation and add or revise an example that produces a
-recognizable outdoor test layout with a path, clearing, and scattered terrain.
-
-Run the Python test suite, generate the example map, run the map validator,
-inspect generated dimensions and tile count, and run git diff --check.
-
-Do not commit or push.
-
-Report the chosen recipe schema, placement semantics, tests, validation
-results, limitations, and git diff summary.
-```
+Do not commit or push unless explicitly requested.
 
 ---
 
@@ -739,12 +629,12 @@ results, limitations, and git diff summary.
 [Complete] Minimal JSON recipe format
 [Complete] Deterministic 32×32 generator
 [Complete] Base tile and rectangle overlays
+[Complete] General tile-placement primitives
 [Complete] Generator and validator test suite
-[Complete] Documentation and example recipe
+[Complete] Documentation and recognizable outdoor example
 [Complete] Development moved to snipercup/CataX
 
-[Next]     General tile-placement primitives
-[Planned]  Palettes and deterministic variation
+[Next]     Palettes and deterministic variation
 [Planned]  Features and furniture
 [Planned]  Areas and buildings
 [Planned]  Roads and map connections

--- a/Documentation/Game_design/Map_generation_plan.md
+++ b/Documentation/Game_design/Map_generation_plan.md
@@ -1,0 +1,758 @@
+You have now completed the **foundation and first generator milestone**. The project can generate a structurally valid 32×32 Dimensionfall map from a compact recipe, but it cannot yet describe or place enough content to build a useful playable map.
+
+## Overall goal
+
+The long-term objective is a map-authoring pipeline where an agent describes a map at a meaningful design level rather than manually writing thousands of JSON entries.
+
+```text
+Map concept
+    ↓
+Compact recipe
+    ↓
+Deterministic generator
+    ↓
+Complete Dimensionfall map JSON
+    ↓
+Automated validation and tests
+    ↓
+Godot/editor smoke test
+    ↓
+Playable map
+```
+
+For example, the eventual recipe should express concepts such as:
+
+```text
+Create a forest settlement with:
+- a road entering from the west
+- three small buildings around a square
+- a pond to the southeast
+- trees around the perimeter
+- indoor and outdoor areas
+```
+
+The generator should handle the mechanical work:
+
+* converting coordinates to array indices;
+* producing all 1024 entries per populated level;
+* inserting valid tile and furniture IDs;
+* generating metadata;
+* creating areas and connections;
+* enforcing bounds;
+* producing deterministic output;
+* rejecting invalid designs before they reach Godot.
+
+The agent remains responsible for map intent and composition. The generator remains responsible for correctness.
+
+---
+
+# Current state
+
+## 1. Agent guidance: complete
+
+`AGENTS.md` was revised to work well with Hermes rather than relying on Codex-specific or TaskMaster-specific behavior.
+
+The repository guidance is now intended to be:
+
+* tool-independent;
+* repository-specific;
+* suitable for multiple Hermes profiles;
+* focused on project structure, coding standards, validation, and safe editing;
+* free of personal Docker, worktree, Kanban, and model configuration details.
+
+This gives the map-making agents a stable set of repository instructions.
+
+## 2. Existing-map sanitation: complete
+
+The project now sanitizes malformed tile data when maps are serialized.
+
+Corrupt or incomplete tile dictionaries—particularly entries missing a valid tile ID—are converted to the established empty-tile representation:
+
+```json
+{}
+```
+
+A GUT test was added around this behavior.
+
+This protects existing and generated maps from lingering malformed tile entries.
+
+## 3. Map validator improvements: complete
+
+`Tools/map_validator.py` now understands the fixed Dimensionfall map dimensions.
+
+It rejects:
+
+* `mapwidth` values other than `32`;
+* `mapheight` values other than `32`;
+* populated levels with fewer than 1024 entries;
+* populated levels with more than 1024 entries.
+
+It continues accepting unused levels represented as:
+
+```json
+[]
+```
+
+The validator successfully caught the original invalid generated prototype:
+
+```text
+width: 12
+height: 8
+level 10 entries: 96
+```
+
+That is an important milestone because the validator now independently enforces the structural assumptions used by the generator.
+
+## 4. Recipe-driven generator prototype: complete
+
+The merged work added:
+
+```text
+Tools/map_generator.py
+Tools/examples/map_recipe.json
+Tools/tests/test_map_generator.py
+Documentation/Modding/map_recipe_generator.md
+```
+
+The generator currently supports:
+
+* map ID;
+* display name;
+* description;
+* deterministic integer seed;
+* one populated level at level-array index 10;
+* a base tile covering the entire map;
+* ordered rectangular regions;
+* fixed tile rotations;
+* deterministic random rotations;
+* `null` region tiles that produce `{}`;
+* tile-ID validation against the tile database;
+* strict rejection of unknown recipe fields;
+* region bounds validation;
+* output filename validation;
+* overwrite protection;
+* generation to a temporary file;
+* validation before publication;
+* atomic replacement of the target file.
+
+It always produces:
+
+```text
+mapwidth: 32
+mapheight: 32
+populated level size: 1024
+unused levels: []
+```
+
+## 5. Generator and validator tests: complete for version 1
+
+The current Python test suite contains 16 tests and passes.
+
+Coverage includes:
+
+* fixed 32×32 dimensions;
+* exactly 1024 entries;
+* deterministic generation;
+* rectangular overlays;
+* empty-tile representation;
+* unknown fields;
+* invalid IDs;
+* unknown tile IDs;
+* invalid metadata;
+* malformed tile databases;
+* out-of-bounds placement;
+* output filename mismatch;
+* overwrite protection;
+* validator rejection of bad dimensions;
+* validator rejection of short and long levels;
+* acceptance of unused empty levels;
+* acceptance of correctly generated maps.
+
+This is sufficient coverage for the prototype’s present capabilities.
+
+## 6. Repository ownership and remotes: complete
+
+Your working repository is now your fork:
+
+```text
+origin:
+https://github.com/snipercup/CataX.git
+
+upstream:
+https://github.com/Dimensionfall/Dimensionfall.git
+```
+
+That gives you control over the generator roadmap without depending on every experimental stage being accepted upstream immediately.
+
+Your working directory remains:
+
+```bash
+~/hermes/dimensionfall/workspace/Dimensionfall-test-runner
+```
+
+---
+
+# What the generator cannot do yet
+
+The current recipe language is intentionally minimal. It cannot yet express most meaningful maps.
+
+It does not currently support:
+
+* lines or paths;
+* rectangle outlines;
+* circles or irregular regions;
+* scattered terrain;
+* weighted tile variation;
+* terrain blending;
+* multiple populated vertical levels;
+* features or furniture;
+* areas or rooms;
+* doors;
+* buildings;
+* roads as semantic objects;
+* map-edge connection placement;
+* reusable templates;
+* towns or settlements;
+* biome rules;
+* walkability checks;
+* accessibility or connectivity checks;
+* encounters, creatures, items, or spawn points;
+* visual previews;
+* importing an existing map into a recipe;
+* regeneration while preserving hand-authored changes.
+
+At present, it can create a technically valid field with rectangular patches. It cannot yet create a credible playable location.
+
+---
+
+# Roadmap
+
+## Phase 1 — Structural safety
+
+**Status: complete**
+
+Goals:
+
+* sanitize malformed map data;
+* understand the real map structure;
+* improve validator coverage;
+* establish agent guidance.
+
+Delivered:
+
+* sanitation in `DMap`;
+* GUT sanitation test;
+* improved validator;
+* Hermes-oriented `AGENTS.md`.
+
+## Phase 2 — Minimal deterministic generator
+
+**Status: complete**
+
+Goals:
+
+* define a compact recipe;
+* generate one valid ground level;
+* validate before writing;
+* test determinism and failure cases.
+
+Delivered:
+
+* recipe format version 1;
+* generator CLI;
+* fixed 32×32 output;
+* base tile plus rectangular overlays;
+* tile validation;
+* 16 Python tests;
+* documentation and example.
+
+## Phase 3 — General placement primitives
+
+**Status: next**
+
+This should be the next branch.
+
+Suggested name:
+
+```text
+feature/map-generator-primitives
+```
+
+or:
+
+```text
+hermes/map-generator-primitives
+```
+
+Recommended additions:
+
+* single-cell placement;
+* filled rectangle;
+* rectangle outline;
+* horizontal and vertical lines;
+* general line placement;
+* circles or ellipses;
+* deterministic scattered placement;
+* deterministic clusters;
+* checker or repeating patterns;
+* strict versus clipped boundary behavior.
+
+These primitives are the basic vocabulary needed before attempting authored maps.
+
+A recipe might begin to support:
+
+```json
+{
+  "operations": [
+    {
+      "type": "line",
+      "from": [0, 16],
+      "to": [31, 16],
+      "tile": {
+        "id": "dirt-light"
+      },
+      "width": 2
+    },
+    {
+      "type": "scatter",
+      "region": {
+        "x": 0,
+        "y": 0,
+        "width": 32,
+        "height": 32
+      },
+      "tile": {
+        "id": "grass-tall"
+      },
+      "density": 0.12
+    }
+  ]
+}
+```
+
+The exact schema should be designed after inspecting the available tile and map formats.
+
+### Success criterion
+
+A recipe can generate a visually recognizable outdoor layout containing:
+
+* a base terrain;
+* one path;
+* one bounded clearing;
+* some deterministic scattered variation.
+
+No furniture or buildings yet.
+
+## Phase 4 — Tile palettes and reusable patterns
+
+**Status: planned**
+
+Raw tile IDs are cumbersome and encourage agents to invent invalid identifiers. Introduce semantic recipe-level palettes.
+
+Example:
+
+```json
+{
+  "palette": {
+    "ground": [
+      {
+        "tile": "grass",
+        "weight": 8
+      },
+      {
+        "tile": "grass_variant",
+        "weight": 2
+      }
+    ],
+    "path": [
+      {
+        "tile": "dirt-light",
+        "weight": 3
+      },
+      {
+        "tile": "dirt-dark",
+        "weight": 1
+      }
+    ]
+  }
+}
+```
+
+Goals:
+
+* weighted deterministic selection;
+* named tile sets;
+* automatic rotation rules;
+* reusable pattern definitions;
+* fewer raw IDs throughout recipes;
+* centralized checking of allowed tiles.
+
+### Success criterion
+
+The generator can create terrain that looks varied without requiring a recipe entry for every cell.
+
+## Phase 5 — Features and furniture
+
+**Status: planned; requires schema investigation**
+
+This is where generated maps start becoming playable rather than merely visual.
+
+The agent should first determine:
+
+* how features are represented;
+* how furniture or objects are stored;
+* whether objects belong directly to tiles or separate arrays;
+* how rotation and state are encoded;
+* how IDs are validated;
+* whether occupied tiles require supporting terrain;
+* how multi-tile objects work.
+
+Likely recipe concepts:
+
+```json
+{
+  "features": [
+    {
+      "template": "tree",
+      "at": [5, 8]
+    },
+    {
+      "template": "bench",
+      "at": [15, 13],
+      "rotation": 90
+    }
+  ]
+}
+```
+
+Necessary validation:
+
+* known feature IDs;
+* bounds;
+* occupied-cell conflicts;
+* support rules;
+* prohibited overlap;
+* deterministic scatter;
+* placement failure reporting.
+
+### Success criterion
+
+Generate an outdoor map with trees, rocks, vegetation, and simple interactable or decorative objects.
+
+## Phase 6 — Areas, rooms, and buildings
+
+**Status: planned**
+
+The generator needs semantic areas before it can create convincing buildings.
+
+Capabilities:
+
+* named rectangular or polygonal areas;
+* room boundaries;
+* floors and walls;
+* doors and openings;
+* indoor/outdoor designation;
+* area metadata;
+* reusable building footprints;
+* furniture anchors;
+* optional additional levels.
+
+Example concept:
+
+```json
+{
+  "buildings": [
+    {
+      "template": "small_cabin",
+      "origin": [10, 9],
+      "entrance": "south",
+      "area_id": "cabin_1"
+    }
+  ]
+}
+```
+
+Important checks:
+
+* every room has an entrance;
+* doors connect compatible cells;
+* walls do not block all access;
+* area definitions match physical boundaries;
+* upper levels have valid support and transitions;
+* furniture remains inside intended rooms.
+
+### Success criterion
+
+Generate one small, enterable building that loads correctly and has a reachable interior.
+
+## Phase 7 — Roads and map connections
+
+**Status: planned**
+
+The prototype currently puts placeholder connection values in the output. These need to become meaningful.
+
+Capabilities:
+
+* entrances on map edges;
+* road endpoints;
+* path routing between anchors;
+* north/east/south/west connection metadata;
+* guaranteed connection between entry points and important locations;
+* bridge or obstacle handling where supported.
+
+Validation should determine:
+
+* whether every declared connection has a corresponding traversable edge;
+* whether important map areas are reachable;
+* whether roads terminate correctly;
+* whether edge tiles match adjacent-map expectations.
+
+### Success criterion
+
+Generate a map with one or more working edge connections and a traversable road to its main feature.
+
+## Phase 8 — Templates and compositional generation
+
+**Status: planned**
+
+Once primitives and object placement work, add reusable templates.
+
+Possible templates:
+
+```text
+small cabin
+large house
+shop
+warehouse
+crossroads
+road bend
+pond
+farm plot
+forest clearing
+camp
+ruin
+village square
+```
+
+Templates should be:
+
+* parameterized;
+* deterministic;
+* validated independently;
+* composable;
+* able to expose anchors such as entrances and road connections.
+
+Example:
+
+```json
+{
+  "placements": [
+    {
+      "template": "village_square",
+      "origin": [16, 16],
+      "rotation": 0
+    },
+    {
+      "template": "small_house",
+      "anchor": "square.north",
+      "entrance_facing": "south"
+    }
+  ]
+}
+```
+
+### Success criterion
+
+Create a small settlement by composing templates rather than manually specifying every wall, road, and object.
+
+## Phase 9 — Semantic map recipes
+
+**Status: long-term target**
+
+At this point the agent should be able to write recipes in terms of design intent:
+
+```json
+{
+  "biome": "temperate_forest",
+  "layout": {
+    "type": "small_settlement",
+    "entry": "west",
+    "center": "village_square"
+  },
+  "requirements": [
+    "three houses",
+    "one workshop",
+    "a pond southeast of the square",
+    "a road connecting west and east",
+    "dense trees around the outer border"
+  ]
+}
+```
+
+The generator or a planning layer would translate those requirements into:
+
+* anchors;
+* templates;
+* primitives;
+* placement constraints;
+* routing;
+* validation.
+
+This may eventually involve two distinct stages:
+
+```text
+High-level design
+       ↓
+Expanded concrete recipe
+       ↓
+Map generator
+       ↓
+Map JSON
+```
+
+Keeping planning separate from final generation would make failures easier to inspect.
+
+## Phase 10 — Quality and gameplay validation
+
+**Status: long-term requirement**
+
+Structural validity is not enough. Generated maps eventually need higher-level checks:
+
+* all required locations are reachable;
+* edge connections are usable;
+* doors are not blocked;
+* buildings have interiors;
+* paths do not end unexpectedly;
+* important objects are accessible;
+* no impossible overlaps occur;
+* minimum walkable-space requirements are met;
+* map density remains within useful ranges;
+* visual variety is adequate;
+* deterministic regeneration works.
+
+Some checks can be implemented in Python. Others may need Godot or project runtime logic.
+
+### Final success criterion
+
+An agent can create a new playable map from a concise design request, run all relevant checks, and produce a map that needs refinement rather than structural repair.
+
+---
+
+# Recommended immediate next task
+
+The next contribution should stay narrow: **placement primitives only**.
+
+Do not combine primitives, buildings, features, roads, and semantic map generation into one branch. That would make the recipe format unstable and difficult to review.
+
+A suitable Hermes task is:
+
+```text
+Extend the recipe-driven Dimensionfall map generator with a small set of
+general-purpose tile placement primitives.
+
+Read the repository guidance, current generator, validator, tests,
+documentation, example recipe, tile database, and representative valid maps
+before editing.
+
+Keep the existing fixed 32x32 map format and one populated ground level.
+
+Add an ordered `operations` recipe array. Preserve support for the existing
+`regions` field during this branch unless there is a strong, documented reason
+to migrate it.
+
+Implement these operations:
+
+1. `set`
+   - places one tile at x, y
+
+2. `rectangle`
+   - places a filled rectangle
+   - equivalent to the current region behavior
+
+3. `rectangle_outline`
+   - places only a rectangle's border
+   - define behavior for width or height equal to 1
+
+4. `line`
+   - places a deterministic one-tile-wide line between two integer points
+   - document the rasterization algorithm
+   - support horizontal, vertical, and diagonal lines
+
+5. `scatter`
+   - places tiles within a rectangular region using the recipe seed
+   - use either an explicit count or density, but not both
+   - deterministic for the same recipe and seed
+   - document whether existing cells are replaced
+
+Requirements:
+
+- operations execute in array order;
+- later operations may overwrite earlier terrain;
+- every coordinate must be checked against the fixed 32x32 grid;
+- preserve `{}` as the empty-tile representation;
+- reject unknown operation fields;
+- reject invalid operation types;
+- reject invalid coordinates and dimensions;
+- do not silently clip out-of-bounds shapes unless clipping is explicitly part
+  of the documented operation contract;
+- preserve deterministic output;
+- keep the generator independent of Godot;
+- do not add furniture, areas, buildings, roads, towns, or additional levels
+  in this branch.
+
+Decide whether `regions` should internally translate into a rectangle
+operation to avoid maintaining duplicate placement logic.
+
+Add tests covering:
+
+- each operation;
+- operation ordering and overwrite behavior;
+- horizontal, vertical, and diagonal lines;
+- thin rectangle outlines;
+- deterministic scatter;
+- invalid scatter arguments;
+- out-of-bounds operations;
+- unknown operation fields and types;
+- unchanged fixed dimensions and 1024-tile invariant;
+- backwards compatibility with the current example recipe, if retained.
+
+Update the recipe documentation and add or revise an example that produces a
+recognizable outdoor test layout with a path, clearing, and scattered terrain.
+
+Run the Python test suite, generate the example map, run the map validator,
+inspect generated dimensions and tile count, and run git diff --check.
+
+Do not commit or push.
+
+Report the chosen recipe schema, placement semantics, tests, validation
+results, limitations, and git diff summary.
+```
+
+---
+
+# Current position in one view
+
+```text
+[Complete] Hermes-compatible repository guidance
+[Complete] Existing map sanitation
+[Complete] Fixed-size map validation
+[Complete] Minimal JSON recipe format
+[Complete] Deterministic 32×32 generator
+[Complete] Base tile and rectangle overlays
+[Complete] Generator and validator test suite
+[Complete] Documentation and example recipe
+[Complete] Development moved to snipercup/CataX
+
+[Next]     General tile-placement primitives
+[Planned]  Palettes and deterministic variation
+[Planned]  Features and furniture
+[Planned]  Areas and buildings
+[Planned]  Roads and map connections
+[Planned]  Reusable templates
+[Planned]  Semantic map planning
+[Planned]  Connectivity and gameplay validation
+[Target]   Agent-generated playable maps
+```
+
+You are no longer experimenting with whether maps can be generated safely. That part is established. The project is now at the point of expanding the generator’s vocabulary until it can express an actual location.
+

--- a/Documentation/Modding/map_recipe_generator.md
+++ b/Documentation/Modding/map_recipe_generator.md
@@ -1,6 +1,6 @@
 # Recipe-driven map generator
 
-`Tools/map_generator.py` converts a compact JSON recipe into a complete Dimensionfall map JSON file. Dimensionfall maps have fixed dimensions of 32 x 32 tiles. The prototype creates one populated ground level (level array index `10`) with exactly 1024 entries and leaves the other 20 levels empty.
+`Tools/map_generator.py` converts a compact JSON recipe into a complete Dimensionfall map JSON file. Dimensionfall maps have fixed dimensions of 32 x 32 tiles. The generator creates one populated ground level (level array index `10`) with exactly 1024 entries and leaves the other 20 levels empty.
 
 ## Usage
 
@@ -24,16 +24,75 @@ The root must be a JSON object with these fields:
 | `id` | string | Map ID using only letters, numbers, `_`, and `-`. |
 | `name` | non-empty string | Display name. |
 | `description` | non-empty string | Map description. |
-| `seed` | integer | Fixed seed used by random rotations. Recipe input only; the map format does not store it. |
+| `seed` | integer | Fixed seed used by random rotations and scatter. Recipe input only; the map format does not store it. |
 | `base_tile` | tile object | Tile initially placed in every cell. |
-| `regions` | array | Rectangles applied in array order; later rectangles replace earlier cells. Optional; defaults to `[]`. |
+| `regions` | array | Legacy filled rectangles. Optional; defaults to `[]`. |
+| `operations` | array | Ordered placement operations. Optional; defaults to `[]`. |
 
-A recipe does not define map dimensions: all generated maps are 32 x 32. The names `width` and `height` remain part of each rectangular region because they describe the rectangle, not the map. Supplying either field at the recipe root is an error.
+A recipe does not define map dimensions: all generated maps are 32 x 32. Coordinates start at the top-left. Every shape must fit entirely within the map; operations are never silently clipped.
 
-A tile object has a required `id` from the selected `Tiles.json` and an optional `rotation`. Rotation is `0`, `90`, `180`, `270`, or `"random"`. A region has non-negative integer `x` and `y`, positive integer `width` and `height`, and a `tile`. Region coordinates start at the top-left, and the rectangle must fit within the fixed 32 x 32 map. A region's `tile` may be `null`; this writes the project's empty-tile representation, `{}`.
+A tile object has a required `id` from the selected `Tiles.json` and an optional `rotation`. Rotation is `0`, `90`, `180`, `270`, or `"random"`. Operation tiles may be `null`, which writes the project's empty-tile representation, `{}`.
 
-The generator rejects unknown fields at every recipe level, root-level dimension fields, malformed or out-of-bounds regions, malformed tile databases, unknown tile IDs, invalid rotations, invalid Unicode, and non-object recipes. It validates generated data with `Tools/map_validator.py` before publishing the output.
+Legacy `regions` are applied first in array order, followed by `operations` in array order. Later placements overwrite earlier cells. `regions` remain supported for version-one recipes and use the same filled-rectangle placement implementation as `rectangle` operations.
 
-## Generated map defaults and limitations
+## Placement operations
 
-The output uses 21 levels, with the generated row-major grid at index 10. It sets `categories` to `[]`, `weight` to `1000`, and all four connections to `"ground"`. It omits `areas`, matching `DMap.get_data()` when the area list is empty. Version 1 does not generate areas, features, roads, buildings, towns, additional levels, or complex templates. The same recipe and seed produce the same map data.
+Every operation requires a `type`. Unknown operation types and fields are errors.
+
+### `set`
+
+Places one tile. Fields: `type`, `x`, `y`, and `tile`.
+
+```json
+{"type": "set", "x": 16, "y": 15, "tile": {"id": "grass_flowers_01"}}
+```
+
+### `rectangle`
+
+Fills a rectangle. Fields: `type`, `x`, `y`, positive `width`, positive `height`, and `tile`.
+
+```json
+{"type": "rectangle", "x": 10, "y": 9, "width": 12, "height": 14, "tile": {"id": "grass_plain_01"}}
+```
+
+### `rectangle_outline`
+
+Places only the rectangle border and uses the same fields as `rectangle`. If width or height is `1`, every cell in the resulting one-cell-wide shape is border.
+
+```json
+{"type": "rectangle_outline", "x": 10, "y": 9, "width": 12, "height": 14, "tile": {"id": "grass_dirt_00"}}
+```
+
+### `line`
+
+Places an inclusive, one-tile-wide line between integer `[x, y]` endpoints. Fields: `type`, `from`, `to`, and `tile`. Lines use the integer Bresenham algorithm, so horizontal, vertical, diagonal, steep, and reversed lines are deterministic.
+
+```json
+{"type": "line", "from": [0, 16], "to": [31, 16], "tile": {"id": "dirt_light_00"}}
+```
+
+### `scatter`
+
+Selects unique cells in a rectangular `region` using the recipe's seeded random-number generator. Fields: `type`, `region`, exactly one of `count` or `density`, and `tile`.
+
+- `count` is an integer from zero through the number of cells in the region.
+- `density` is a number from `0` through `1`; the placement count is `floor(region area × density)`.
+- Selected cells replace their existing tiles.
+- The same complete recipe and seed produce the same selection and output.
+
+```json
+{
+  "type": "scatter",
+  "region": {"x": 0, "y": 0, "width": 32, "height": 32},
+  "density": 0.1,
+  "tile": {"id": "grass_flowers_00", "rotation": "random"}
+}
+```
+
+## Validation and limitations
+
+The generator rejects unknown fields at every recipe level, root-level dimension fields, malformed or out-of-bounds placements, malformed tile databases, unknown tile IDs, invalid rotations, invalid Unicode, and non-object recipes. It validates generated data with `Tools/map_validator.py` before publishing the output.
+
+The output uses 21 levels, with the generated row-major grid at index 10. It sets `categories` to `[]`, `weight` to `1000`, and all four connections to `"ground"`. It omits `areas`, matching `DMap.get_data()` when the area list is empty.
+
+The generator does not yet create palettes, features, furniture, areas, roads as semantic objects, buildings, towns, additional levels, or complex templates. Structural validity also does not yet guarantee walkability or gameplay quality.

--- a/Tools/examples/map_recipe.json
+++ b/Tools/examples/map_recipe.json
@@ -1,29 +1,70 @@
 {
-  "id": "generated_meadow_prototype",
-  "name": "Generated Meadow Prototype",
-  "description": "A deterministic meadow generated from a compact recipe.",
-  "seed": 20260715,
-  "base_tile": {
-    "id": "grass_plain_01",
-    "rotation": "random"
-  },
-  "regions": [
-    {
-      "x": 2,
-      "y": 2,
-      "width": 5,
-      "height": 3,
-      "tile": {
-        "id": "dirt_light_00",
-        "rotation": 0
-      }
-    },
-    {
-      "x": 4,
-      "y": 3,
-      "width": 1,
-      "height": 1,
-      "tile": null
-    }
-  ]
+	"id": "generated_meadow_prototype",
+	"name": "Generated Meadow Prototype",
+	"description": "A deterministic meadow with a clearing, path, and scattered flowers.",
+	"seed": 20260715,
+	"base_tile": {
+		"id": "grass_plain_01",
+		"rotation": "random"
+	},
+	"operations": [
+		{
+			"type": "scatter",
+			"region": {
+				"x": 0,
+				"y": 0,
+				"width": 32,
+				"height": 32
+			},
+			"count": 90,
+			"tile": {
+				"id": "grass_flowers_00",
+				"rotation": "random"
+			}
+		},
+		{
+			"type": "rectangle",
+			"x": 10,
+			"y": 9,
+			"width": 12,
+			"height": 14,
+			"tile": {
+				"id": "grass_plain_01",
+				"rotation": "random"
+			}
+		},
+		{
+			"type": "rectangle_outline",
+			"x": 10,
+			"y": 9,
+			"width": 12,
+			"height": 14,
+			"tile": {
+				"id": "grass_dirt_00",
+				"rotation": "random"
+			}
+		},
+		{
+			"type": "line",
+			"from": [
+				0,
+				16
+			],
+			"to": [
+				31,
+				16
+			],
+			"tile": {
+				"id": "dirt_light_00"
+			}
+		},
+		{
+			"type": "set",
+			"x": 16,
+			"y": 15,
+			"tile": {
+				"id": "grass_flowers_01"
+			}
+		}
+	]
 }

--- a/Tools/map_generator.py
+++ b/Tools/map_generator.py
@@ -32,6 +32,12 @@ DEFAULT_CONNECTIONS = {
 VALID_ROTATIONS = (0, 90, 180, 270)
 TILE_FIELDS = {"id", "rotation"}
 REGION_FIELDS = {"x", "y", "width", "height", "tile"}
+SET_FIELDS = {"type", "x", "y", "tile"}
+RECTANGLE_FIELDS = {"type", "x", "y", "width", "height", "tile"}
+LINE_FIELDS = {"type", "from", "to", "tile"}
+SCATTER_FIELDS = {"type", "region", "tile", "count", "density"}
+SCATTER_REGION_FIELDS = {"x", "y", "width", "height"}
+OPERATION_TYPES = {"set", "rectangle", "rectangle_outline", "line", "scatter"}
 RECIPE_FIELDS = {
     "id",
     "name",
@@ -39,6 +45,7 @@ RECIPE_FIELDS = {
     "seed",
     "base_tile",
     "regions",
+    "operations",
 }
 
 
@@ -128,16 +135,15 @@ def _tile_ids(tiles_path: Path) -> set[str]:
     }
 
 
-def _make_tile(
+def _validate_tile_spec(
     spec: Any,
-    rng: random.Random,
     known_tiles: set[str],
     context: str,
     *,
     allow_empty: bool = False,
-) -> dict[str, Any]:
+) -> tuple[str | None, int | str]:
     if spec is None and allow_empty:
-        return {}
+        return None, 0
     if not isinstance(spec, dict):
         empty_hint = " or null" if allow_empty else ""
         raise RecipeError(f"{context} must be an object{empty_hint}")
@@ -151,14 +157,225 @@ def _make_tile(
     if tile_id not in known_tiles:
         raise RecipeError(f"{context}.id references unknown tile '{tile_id}'")
     rotation = spec.get("rotation", 0)
+    if rotation != "random" and (
+        type(rotation) is not int or rotation not in VALID_ROTATIONS
+    ):
+        raise RecipeError(f"{context}.rotation must be 0, 90, 180, 270, or 'random'")
+    return tile_id, rotation
+
+
+def _make_tile(
+    spec: Any,
+    rng: random.Random,
+    known_tiles: set[str],
+    context: str,
+    *,
+    allow_empty: bool = False,
+) -> dict[str, Any]:
+    tile_id, rotation = _validate_tile_spec(
+        spec, known_tiles, context, allow_empty=allow_empty
+    )
+    if tile_id is None:
+        return {}
     if rotation == "random":
         rotation = rng.choice(VALID_ROTATIONS)
-    if type(rotation) is not int or rotation not in VALID_ROTATIONS:
-        raise RecipeError(f"{context}.rotation must be 0, 90, 180, 270, or 'random'")
     tile: dict[str, Any] = {"id": tile_id}
     if rotation:
         tile["rotation"] = rotation
     return tile
+
+
+def _coordinate(value: Any, context: str, maximum: int) -> int:
+    if type(value) is not int or not 0 <= value < maximum:
+        raise RecipeError(
+            f"{context} must be an integer between 0 and {maximum - 1}"
+        )
+    return value
+
+
+def _apply_set(
+    level: list[dict[str, Any]],
+    operation: dict[str, Any],
+    rng: random.Random,
+    known_tiles: set[str],
+    context: str,
+) -> None:
+    unknown_fields = sorted(set(operation) - SET_FIELDS)
+    if unknown_fields:
+        raise RecipeError(f"unknown {context} field '{unknown_fields[0]}'")
+    x = _coordinate(operation.get("x"), f"{context}.x", MAP_WIDTH)
+    y = _coordinate(operation.get("y"), f"{context}.y", MAP_HEIGHT)
+    level[y * MAP_WIDTH + x] = _make_tile(
+        operation.get("tile"), rng, known_tiles, f"{context}.tile", allow_empty=True
+    )
+
+
+def _rectangle_dimensions(spec: dict[str, Any], context: str) -> dict[str, int]:
+    dimensions: dict[str, int] = {}
+    for field in ("x", "y", "width", "height"):
+        value = spec.get(field)
+        minimum = 0 if field in ("x", "y") else 1
+        if type(value) is not int or value < minimum:
+            qualifier = "non-negative" if minimum == 0 else "positive"
+            raise RecipeError(f"{context}.{field} must be a {qualifier} integer")
+        dimensions[field] = value
+    if (
+        dimensions["x"] + dimensions["width"] > MAP_WIDTH
+        or dimensions["y"] + dimensions["height"] > MAP_HEIGHT
+    ):
+        raise RecipeError(f"{context} extends outside the {MAP_WIDTH}x{MAP_HEIGHT} map")
+    return dimensions
+
+
+def _apply_rectangle(
+    level: list[dict[str, Any]],
+    spec: dict[str, Any],
+    rng: random.Random,
+    known_tiles: set[str],
+    context: str,
+    fields: set[str],
+) -> None:
+    unknown_fields = sorted(set(spec) - fields)
+    if unknown_fields:
+        raise RecipeError(f"unknown {context} field '{unknown_fields[0]}'")
+    dimensions = _rectangle_dimensions(spec, context)
+    for y in range(dimensions["y"], dimensions["y"] + dimensions["height"]):
+        for x in range(dimensions["x"], dimensions["x"] + dimensions["width"]):
+            level[y * MAP_WIDTH + x] = _make_tile(
+                spec.get("tile"),
+                rng,
+                known_tiles,
+                f"{context}.tile",
+                allow_empty=True,
+            )
+
+
+def _apply_rectangle_outline(
+    level: list[dict[str, Any]],
+    operation: dict[str, Any],
+    rng: random.Random,
+    known_tiles: set[str],
+    context: str,
+) -> None:
+    unknown_fields = sorted(set(operation) - RECTANGLE_FIELDS)
+    if unknown_fields:
+        raise RecipeError(f"unknown {context} field '{unknown_fields[0]}'")
+    dimensions = _rectangle_dimensions(operation, context)
+    left = dimensions["x"]
+    right = left + dimensions["width"] - 1
+    top = dimensions["y"]
+    bottom = top + dimensions["height"] - 1
+    for y in range(top, bottom + 1):
+        for x in range(left, right + 1):
+            if x in (left, right) or y in (top, bottom):
+                level[y * MAP_WIDTH + x] = _make_tile(
+                    operation.get("tile"),
+                    rng,
+                    known_tiles,
+                    f"{context}.tile",
+                    allow_empty=True,
+                )
+
+
+def _point(value: Any, context: str) -> tuple[int, int]:
+    if not isinstance(value, list) or len(value) != 2:
+        raise RecipeError(f"{context} must be a two-integer array")
+    return (
+        _coordinate(value[0], f"{context}[0]", MAP_WIDTH),
+        _coordinate(value[1], f"{context}[1]", MAP_HEIGHT),
+    )
+
+
+def _apply_line(
+    level: list[dict[str, Any]],
+    operation: dict[str, Any],
+    rng: random.Random,
+    known_tiles: set[str],
+    context: str,
+) -> None:
+    unknown_fields = sorted(set(operation) - LINE_FIELDS)
+    if unknown_fields:
+        raise RecipeError(f"unknown {context} field '{unknown_fields[0]}'")
+    x, y = _point(operation.get("from"), f"{context}.from")
+    target_x, target_y = _point(operation.get("to"), f"{context}.to")
+    delta_x = abs(target_x - x)
+    step_x = 1 if x < target_x else -1
+    delta_y = -abs(target_y - y)
+    step_y = 1 if y < target_y else -1
+    error = delta_x + delta_y
+    while True:
+        level[y * MAP_WIDTH + x] = _make_tile(
+            operation.get("tile"),
+            rng,
+            known_tiles,
+            f"{context}.tile",
+            allow_empty=True,
+        )
+        if x == target_x and y == target_y:
+            break
+        doubled_error = 2 * error
+        if doubled_error >= delta_y:
+            error += delta_y
+            x += step_x
+        if doubled_error <= delta_x:
+            error += delta_x
+            y += step_y
+
+
+def _apply_scatter(
+    level: list[dict[str, Any]],
+    operation: dict[str, Any],
+    rng: random.Random,
+    known_tiles: set[str],
+    context: str,
+) -> None:
+    unknown_fields = sorted(set(operation) - SCATTER_FIELDS)
+    if unknown_fields:
+        raise RecipeError(f"unknown {context} field '{unknown_fields[0]}'")
+    region = operation.get("region")
+    if not isinstance(region, dict):
+        raise RecipeError(f"{context}.region must be an object")
+    unknown_region_fields = sorted(set(region) - SCATTER_REGION_FIELDS)
+    if unknown_region_fields:
+        raise RecipeError(
+            f"unknown {context}.region field '{unknown_region_fields[0]}'"
+        )
+    dimensions = _rectangle_dimensions(region, f"{context}.region")
+    has_count = "count" in operation
+    has_density = "density" in operation
+    if has_count == has_density:
+        raise RecipeError(f"{context} must define exactly one of count or density")
+    area = dimensions["width"] * dimensions["height"]
+    if has_count:
+        count = operation["count"]
+        if type(count) is not int or not 0 <= count <= area:
+            raise RecipeError(
+                f"{context}.count must be an integer between 0 and {area}"
+            )
+    else:
+        density = operation["density"]
+        if type(density) not in (int, float) or not 0 <= density <= 1:
+            raise RecipeError(f"{context}.density must be a number between 0 and 1")
+        count = int(area * density)
+    _validate_tile_spec(
+        operation.get("tile"),
+        known_tiles,
+        f"{context}.tile",
+        allow_empty=True,
+    )
+    candidates = [
+        y * MAP_WIDTH + x
+        for y in range(dimensions["y"], dimensions["y"] + dimensions["height"])
+        for x in range(dimensions["x"], dimensions["x"] + dimensions["width"])
+    ]
+    for level_index in rng.sample(candidates, count):
+        level[level_index] = _make_tile(
+            operation.get("tile"),
+            rng,
+            known_tiles,
+            f"{context}.tile",
+            allow_empty=True,
+        )
 
 
 def generate_map(recipe: dict[str, Any], tiles_path: Path) -> dict[str, Any]:
@@ -196,33 +413,34 @@ def generate_map(recipe: dict[str, Any], tiles_path: Path) -> dict[str, Any]:
         context = f"regions[{index}]"
         if not isinstance(region, dict):
             raise RecipeError(f"{context} must be an object")
-        unknown_fields = sorted(set(region) - REGION_FIELDS)
-        if unknown_fields:
-            raise RecipeError(f"unknown {context} field '{unknown_fields[0]}'")
-        dimensions: dict[str, int] = {}
-        for field in ("x", "y", "width", "height"):
-            value = region.get(field)
-            minimum = 0 if field in ("x", "y") else 1
-            if type(value) is not int or value < minimum:
-                qualifier = "non-negative" if minimum == 0 else "positive"
-                raise RecipeError(f"{context}.{field} must be a {qualifier} integer")
-            dimensions[field] = value
-        if (
-            dimensions["x"] + dimensions["width"] > MAP_WIDTH
-            or dimensions["y"] + dimensions["height"] > MAP_HEIGHT
-        ):
-            raise RecipeError(
-                f"{context} extends outside the {MAP_WIDTH}x{MAP_HEIGHT} map"
+        _apply_rectangle(level, region, rng, known_tiles, context, REGION_FIELDS)
+
+    operations = recipe.get("operations", [])
+    if not isinstance(operations, list):
+        raise RecipeError("operations must be an array")
+    for index, operation in enumerate(operations):
+        context = f"operations[{index}]"
+        if not isinstance(operation, dict):
+            raise RecipeError(f"{context} must be an object")
+        operation_type = operation.get("type")
+        if operation_type in OPERATION_TYPES and "tile" not in operation:
+            raise RecipeError(f"{context}.tile is required")
+        if operation_type == "set":
+            _apply_set(level, operation, rng, known_tiles, context)
+        elif operation_type == "rectangle":
+            _apply_rectangle(
+                level, operation, rng, known_tiles, context, RECTANGLE_FIELDS
             )
-        for y in range(dimensions["y"], dimensions["y"] + dimensions["height"]):
-            for x in range(dimensions["x"], dimensions["x"] + dimensions["width"]):
-                level[y * MAP_WIDTH + x] = _make_tile(
-                    region.get("tile"),
-                    rng,
-                    known_tiles,
-                    f"{context}.tile",
-                    allow_empty=True,
-                )
+        elif operation_type == "rectangle_outline":
+            _apply_rectangle_outline(level, operation, rng, known_tiles, context)
+        elif operation_type == "line":
+            _apply_line(level, operation, rng, known_tiles, context)
+        elif operation_type == "scatter":
+            _apply_scatter(level, operation, rng, known_tiles, context)
+        else:
+            raise RecipeError(
+                f"{context}.type has unknown operation '{operation_type}'"
+            )
 
     levels = [[] for _ in range(LEVEL_COUNT)]
     levels[POPULATED_LEVEL_INDEX] = level

--- a/Tools/tests/test_map_generator.py
+++ b/Tools/tests/test_map_generator.py
@@ -89,6 +89,267 @@ class MapGeneratorTests(unittest.TestCase):
 
         self.assertEqual(generated["levels"][10][0], {})
 
+    def test_set_operation_places_one_tile(self):
+        recipe = valid_recipe()
+        recipe["base_tile"] = {"id": "grass_plain_01"}
+        recipe["operations"] = [
+            {"type": "set", "x": 3, "y": 2, "tile": {"id": "dirt_light_00"}}
+        ]
+
+        level = generate_map(recipe, TILES_PATH)["levels"][10]
+
+        self.assertEqual(level[2 * 32 + 3], {"id": "dirt_light_00"})
+        self.assertEqual(level[2 * 32 + 2], {"id": "grass_plain_01"})
+
+    def test_rectangle_operation_is_filled_and_later_operations_overwrite(self):
+        recipe = valid_recipe()
+        recipe["base_tile"] = {"id": "grass_plain_01"}
+        recipe["operations"] = [
+            {
+                "type": "rectangle",
+                "x": 1,
+                "y": 1,
+                "width": 3,
+                "height": 2,
+                "tile": {"id": "dirt_light_00"},
+            },
+            {"type": "set", "x": 2, "y": 1, "tile": None},
+        ]
+
+        level = generate_map(recipe, TILES_PATH)["levels"][10]
+
+        for index in {33, 35, 65, 66, 67}:
+            self.assertEqual(level[index], {"id": "dirt_light_00"})
+        self.assertEqual(level[34], {})
+
+    def test_rectangle_outline_places_only_border_and_handles_thin_rectangles(self):
+        recipe = valid_recipe()
+        recipe["base_tile"] = {"id": "grass_plain_01"}
+        recipe["operations"] = [
+            {
+                "type": "rectangle_outline",
+                "x": 1,
+                "y": 1,
+                "width": 3,
+                "height": 3,
+                "tile": {"id": "dirt_light_00"},
+            },
+            {
+                "type": "rectangle_outline",
+                "x": 6,
+                "y": 1,
+                "width": 1,
+                "height": 3,
+                "tile": None,
+            },
+        ]
+
+        level = generate_map(recipe, TILES_PATH)["levels"][10]
+
+        self.assertEqual(level[2 * 32 + 2], {"id": "grass_plain_01"})
+        for x, y in ((1, 1), (2, 1), (3, 1), (1, 2), (3, 2), (1, 3), (2, 3), (3, 3)):
+            self.assertEqual(level[y * 32 + x], {"id": "dirt_light_00"})
+        for y in range(1, 4):
+            self.assertEqual(level[y * 32 + 6], {})
+
+    def test_line_operation_handles_horizontal_vertical_and_diagonal_lines(self):
+        recipe = valid_recipe()
+        recipe["base_tile"] = {"id": "grass_plain_01"}
+        recipe["operations"] = [
+            {
+                "type": "line",
+                "from": [1, 1],
+                "to": [4, 1],
+                "tile": {"id": "dirt_light_00"},
+            },
+            {
+                "type": "line",
+                "from": [6, 1],
+                "to": [6, 4],
+                "tile": {"id": "dirt_light_00"},
+            },
+            {
+                "type": "line",
+                "from": [8, 1],
+                "to": [11, 4],
+                "tile": None,
+            },
+        ]
+
+        level = generate_map(recipe, TILES_PATH)["levels"][10]
+
+        for x in range(1, 5):
+            self.assertEqual(level[1 * 32 + x], {"id": "dirt_light_00"})
+        for y in range(1, 5):
+            self.assertEqual(level[y * 32 + 6], {"id": "dirt_light_00"})
+        for x, y in ((8, 1), (9, 2), (10, 3), (11, 4)):
+            self.assertEqual(level[y * 32 + x], {})
+
+    def test_scatter_count_is_exact_deterministic_and_replaces_existing_tiles(self):
+        recipe = valid_recipe()
+        recipe["base_tile"] = {"id": "grass_plain_01"}
+        recipe["operations"] = [
+            {
+                "type": "scatter",
+                "region": {"x": 4, "y": 5, "width": 4, "height": 3},
+                "count": 5,
+                "tile": {"id": "dirt_light_00"},
+            }
+        ]
+
+        first = generate_map(recipe, TILES_PATH)["levels"][10]
+        second = generate_map(recipe, TILES_PATH)["levels"][10]
+        scattered = {
+            (index % 32, index // 32)
+            for index, tile in enumerate(first)
+            if tile == {"id": "dirt_light_00"}
+        }
+
+        self.assertEqual(first, second)
+        self.assertEqual(len(scattered), 5)
+        self.assertTrue(all(4 <= x < 8 and 5 <= y < 8 for x, y in scattered))
+
+    def test_scatter_density_uses_floor_of_region_area(self):
+        recipe = valid_recipe()
+        recipe["base_tile"] = {"id": "grass_plain_01"}
+        recipe["operations"] = [
+            {
+                "type": "scatter",
+                "region": {"x": 0, "y": 0, "width": 3, "height": 3},
+                "density": 0.5,
+                "tile": {"id": "dirt_light_00"},
+            }
+        ]
+
+        level = generate_map(recipe, TILES_PATH)["levels"][10]
+
+        self.assertEqual(level.count({"id": "dirt_light_00"}), 4)
+
+    def test_invalid_operations_are_rejected_with_clear_errors(self):
+        base_region = {"x": 0, "y": 0, "width": 2, "height": 2}
+        cases = [
+            ("not-an-array", "operations must be an array"),
+            ([{"type": "unknown"}], "unknown operation 'unknown'"),
+            (
+                [{"type": "set", "x": 32, "y": 0, "tile": None}],
+                "operations\\[0\\].x must be an integer between 0 and 31",
+            ),
+            (
+                [{"type": "set", "x": 0, "y": 0, "tile": None, "extra": 1}],
+                "unknown operations\\[0\\] field 'extra'",
+            ),
+            (
+                [
+                    {
+                        "type": "rectangle",
+                        "x": 31,
+                        "y": 0,
+                        "width": 2,
+                        "height": 1,
+                        "tile": None,
+                    }
+                ],
+                "extends outside the 32x32 map",
+            ),
+            (
+                [{"type": "line", "from": [0, 0], "to": [32, 0], "tile": None}],
+                "operations\\[0\\].to\\[0\\] must be an integer between 0 and 31",
+            ),
+            (
+                [{"type": "scatter", "region": base_region, "tile": None}],
+                "must define exactly one of count or density",
+            ),
+            (
+                [
+                    {
+                        "type": "scatter",
+                        "region": base_region,
+                        "count": 1,
+                        "density": 0.5,
+                        "tile": None,
+                    }
+                ],
+                "must define exactly one of count or density",
+            ),
+            (
+                [
+                    {
+                        "type": "scatter",
+                        "region": base_region,
+                        "count": 5,
+                        "tile": None,
+                    }
+                ],
+                "count must be an integer between 0 and 4",
+            ),
+            (
+                [
+                    {
+                        "type": "scatter",
+                        "region": base_region,
+                        "count": 0,
+                        "tile": {"id": "missing_tile"},
+                    }
+                ],
+                "unknown tile 'missing_tile'",
+            ),
+            (
+                [
+                    {
+                        "type": "scatter",
+                        "region": base_region,
+                        "density": True,
+                        "tile": None,
+                    }
+                ],
+                "density must be a number between 0 and 1",
+            ),
+            (
+                [
+                    {
+                        "type": "scatter",
+                        "region": {**base_region, "extra": 1},
+                        "count": 1,
+                        "tile": None,
+                    }
+                ],
+                "unknown operations\\[0\\].region field 'extra'",
+            ),
+        ]
+        for operations, expected_message in cases:
+            with self.subTest(operations=operations):
+                recipe = valid_recipe()
+                recipe["operations"] = operations
+                with self.assertRaisesRegex(RecipeError, expected_message):
+                    generate_map(recipe, TILES_PATH)
+
+    def test_operations_require_an_explicit_tile_field(self):
+        operations = [
+            {"type": "set", "x": 0, "y": 0},
+            {"type": "rectangle", "x": 0, "y": 0, "width": 1, "height": 1},
+            {
+                "type": "rectangle_outline",
+                "x": 0,
+                "y": 0,
+                "width": 1,
+                "height": 1,
+            },
+            {"type": "line", "from": [0, 0], "to": [1, 1]},
+            {
+                "type": "scatter",
+                "region": {"x": 0, "y": 0, "width": 1, "height": 1},
+                "count": 0,
+            },
+        ]
+        for operation in operations:
+            with self.subTest(operation=operation):
+                recipe = valid_recipe()
+                recipe["operations"] = [operation]
+                with self.assertRaisesRegex(
+                    RecipeError, "operations\\[0\\].tile is required"
+                ):
+                    generate_map(recipe, TILES_PATH)
+
     def test_invalid_recipes_are_rejected_with_clear_errors(self):
         cases = [
             (


### PR DESCRIPTION
This PR implements Phase 3 of the [map generation plan](Documentation/Game_design/Map_generation_plan.md): a set of general-purpose tile placement primitives that form the vocabulary needed for authored maps before buildings, furniture, or gameplay content are added.

#### What changed

**New operations API** — The recipe now accepts an optional `operations` array executed in order after legacy `regions`. Five operation types:
- **`set`** — place one tile at `(x, y)`
- **`rectangle`** — fill a rectangle (same semantics as legacy regions)
- **`rectangle_outline`** — place only the border of a rectangle; handles degenerate 1-cell-wide shapes
- **`line`** — inclusive Bresenham line between two endpoints (horizontal, vertical, diagonal, steep, and reversed)
- **`scatter`** — deterministic random tile placement in a region by `count` or `density`

**Refactored core** — Region logic was extracted into `_apply_rectangle`, so legacy regions reuse the same placement path. Tile validation is split from RNG-dependent rotation via `_validate_tile_spec`. Coordinate and bounds helpers are shared across all operations.

**Strict validation** — Unknown fields and unknown operation types produce errors with clear messages. Out-of-bounds coordinates are rejected rather than silently clipped. `scatter` enforces exactly one of `count` or `density`. Every operation requires an explicit `tile` field.

**Backward compatibility** — Legacy `regions` recipes continue to work unchanged.

#### Tests
24 tests pass (up from 16), including:
- Each primitive individually
- Operation ordering and overwrite behavior
- Horizontal, vertical, and diagonal Bresenham lines
- Thin rectangle outlines
- Scatter determinism (same seed → same output)
- Scatter density floor behavior
- 13 validation error cases via subTests

#### Example
`Tools/examples/map_recipe.json` now demonstrates all five operations, producing a recognizable outdoor layout with scattered flowers, a bounded clearing with a dirt border, and a horizontal dirt path.

#### What this does NOT do
- Add tile palettes or named presets (Phase 4)
- Add furniture, semantic areas, buildings, roads, towns, or additional levels
- Change the fixed 32×32 map dimensions or level structure

### Next steps
Phase 4 — Tile palettes and deterministic variation.