### PR TITLE
feat(map-generator): Add Phase 4A manual map generation and evaluation harness

### DIFF
--- a/Documentation/Game_design/Map_generation_plan.md
+++ b/Documentation/Game_design/Map_generation_plan.md
@@ -1,4 +1,4 @@
-You have now completed the **foundation, minimal generator, and general placement-primitives milestones**. The project can generate a structurally valid, visually recognizable 32×32 outdoor Dimensionfall map from a compact recipe, but it cannot yet place gameplay features or buildings.
+You have now completed the **foundation, minimal generator, general placement-primitives, and manual evaluation-harness milestones**. The project can generate and batch-test structurally valid, visually recognizable 32×32 outdoor Dimensionfall maps from compact recipes, but it cannot yet place gameplay features or buildings.
 
 ## Overall goal
 
@@ -149,7 +149,7 @@ unused levels: []
 
 ## 5. Generator and validator tests: complete for version 1
 
-The current Python test suite contains 24 tests and passes.
+The current Python test suite contains 34 tests and passes.
 
 Coverage includes:
 
@@ -199,6 +199,20 @@ Your working directory remains:
 ~/hermes/dimensionfall/workspace/Dimensionfall-test-runner
 ```
 
+## 7. Manual example generation and evaluation: complete
+
+The project now includes:
+
+```text
+Tools/generate_map_examples.py
+Tools/tests/test_generate_map_examples.py
+Documentation/Modding/map_example_generation.md
+```
+
+The runner generates one or more deterministic seed variants from maintained recipes, delegates validation and atomic publication to the existing generator, and can place outputs directly in a mod's `Maps` directory for content-editor inspection. It validates the complete batch and rejects duplicate output paths before publication. Newly created outputs and their SHA-256 digests are recorded in a non-JSON manifest so cleanup removes only unchanged runner-owned files.
+
+Ten focused tests cover variant IDs, complete map shape, determinism, CLI generation and cleanup, overwrite ownership, changed-file preservation, malformed recipes, duplicate outputs, and failed-publication safety.
+
 ---
 
 # What the generator cannot do yet
@@ -223,7 +237,7 @@ It does not currently support:
 * walkability checks;
 * accessibility or connectivity checks;
 * encounters, creatures, items, or spawn points;
-* visual previews;
+* standalone image or HTML previews outside Godot; generated map JSON can already be opened with the existing content-editor map preview;
 * importing an existing map into a recipe;
 * regeneration while preserving hand-authored changes.
 
@@ -311,7 +325,26 @@ A recipe can generate a visually recognizable outdoor layout containing:
 
 No furniture or buildings yet. This criterion is met by `Tools/examples/map_recipe.json`.
 
-## Phase 4 — Tile palettes and reusable patterns
+## Phase 4A — Manual example generation and evaluation harness
+
+**Status: complete**
+
+Delivered:
+
+* a Python CLI that reuses the existing generator rather than duplicating it;
+* one-command generation of multiple deterministic seed variants;
+* unique map IDs and matching filenames;
+* configurable recipe, tile database, output directory, variant count, and starting seed;
+* overwrite protection inherited from the generator;
+* a non-JSON ownership manifest with SHA-256 identity checks and exact-file cleanup;
+* direct output to a mod's `Maps` directory for inspection in the existing content-editor preview;
+* focused tests and a manual tester guide with example commands.
+
+### Success criterion
+
+A developer can run one documented command, launch Godot, and inspect at least three deterministic generated variants in the content editor without manually editing recipes or renaming output files. Cleanup leaves unrelated maps untouched.
+
+## Phase 4B — Tile palettes and reusable patterns
 
 **Status: next**
 
@@ -608,13 +641,13 @@ An agent can create a new playable map from a concise design request, run all re
 
 # Recommended immediate next task
 
-The next contribution should stay narrow: **tile palettes and deterministic variation**.
+The next contribution should stay narrow: **Phase 4B tile palettes and deterministic variation**.
 
 Keep the completed placement-operation schema stable. Add named, recipe-level tile palettes that can be referenced anywhere an operation currently accepts a tile. Palette entries should use validated tile IDs and positive integer weights, select deterministically from the recipe seed, preserve explicit tile objects and `null`, and reject unknown palette names or malformed entries.
 
 The branch should not add furniture, areas, buildings, semantic roads, towns, or additional levels. Its success criterion is visibly varied terrain without one recipe entry per cell.
 
-Before implementation, inspect the current generator, tests, tile database, recipe documentation, and example. Define how palette selection interacts with `"random"` rotation and RNG ordering, add focused compatibility and validation tests, update the example and documentation, generate and validate the example map, inspect dimensions and tile count, and run `git diff --check`.
+Before implementation, inspect the current generator, tests, tile database, recipe documentation, and example. Define how palette selection interacts with `"random"` rotation and RNG ordering, add focused compatibility and validation tests, update the example and documentation, use `Tools/generate_map_examples.py` to compare at least three deterministic variants in the content-editor preview, validate the generated maps, inspect dimensions and tile count, and run `git diff --check`.
 
 Do not commit or push unless explicitly requested.
 
@@ -630,6 +663,7 @@ Do not commit or push unless explicitly requested.
 [Complete] Deterministic 32×32 generator
 [Complete] Base tile and rectangle overlays
 [Complete] General tile-placement primitives
+[Complete] Manual example generation and evaluation harness
 [Complete] Generator and validator test suite
 [Complete] Documentation and recognizable outdoor example
 [Complete] Development moved to snipercup/CataX

--- a/Documentation/Modding/map_example_generation.md
+++ b/Documentation/Modding/map_example_generation.md
@@ -1,0 +1,173 @@
+# Manual example-map generation
+
+`Tools/generate_map_examples.py` generates deterministic variants of maintained map recipes for manual inspection. It delegates map construction, validation, overwrite protection, and atomic publication to `Tools/map_generator.py`; it does not contain a second generator implementation.
+
+Run all commands from the repository root. On the standard Hermes host checkout:
+
+```bash
+cd ~/local/dimensionfall/repository
+```
+
+## Safe first run
+
+Generate three variants in a temporary directory:
+
+```bash
+python3 Tools/generate_map_examples.py \
+  --output-dir /tmp/dimensionfall-map-examples
+```
+
+The default recipe is `Tools/examples/map_recipe.json`. Each variant receives:
+
+- a unique ID and matching filename ending in `_example_001`, `_example_002`, and so on;
+- a sequential seed, beginning with the recipe's seed unless `--seed` is supplied;
+- complete 32 x 32 map data validated before publication.
+
+Inspect the generated files with the validator if desired:
+
+```bash
+python3 Tools/map_validator.py /tmp/dimensionfall-map-examples
+```
+
+## Choose the number of variants and starting seed
+
+Generate five reproducible variants using seeds `1000` through `1004`:
+
+```bash
+python3 Tools/generate_map_examples.py \
+  --output-dir /tmp/dimensionfall-map-examples \
+  --variants 5 \
+  --seed 1000
+```
+
+Running the same complete recipe with the same starting seed produces the same map JSON. Changing the seed changes seeded scatter placement and random tile rotations.
+
+## Inspect generated maps in the content editor
+
+Place examples in the core mod's map directory:
+
+```bash
+python3 Tools/generate_map_examples.py \
+  --output-dir Mods/Dimensionfall/Maps \
+  --variants 3 \
+  --seed 1000
+```
+
+Launch Godot after generation and run the Dimensionfall project.
+In the running project, navigate to:
+
+```text
+Content Manager
+  → Content Editor
+  → select the Dimensionfall mod
+  → Expand the Maps category if it is still collapsed
+  → open a generated map by doubleclicking it in the map list
+  → View Map in the editor, click `save and test` to test it manually
+```
+
+If Godot was already running when files were generated, restart it so mod content is loaded again. The existing map-editor preview displays generated map JSON; the Python tool does not create a separate image or HTML preview.
+
+Dimensionfall also looks for a same-named `.png` map sprite during startup. The runner intentionally generates map JSON only, so Godot currently logs a non-fatal missing-resource error for that sprite. This does not prevent the JSON map from loading or the map editor's tile-grid preview from rendering it.
+
+## Generate from specific recipes
+
+Pass one or more recipe paths before the options. The runner generates the requested number of variants for every recipe:
+
+```bash
+python3 Tools/generate_map_examples.py \
+  Tools/examples/map_recipe.json \
+  --output-dir /tmp/dimensionfall-map-examples \
+  --variants 2 \
+  --seed 500
+```
+
+Use a different tile database when testing another mod's recipe:
+
+```bash
+python3 Tools/generate_map_examples.py \
+  path/to/recipe.json \
+  --output-dir /tmp/dimensionfall-map-examples \
+  --tiles path/to/Tiles.json
+```
+
+## Overwrite protection
+
+Existing output files are protected by default. A repeated command using the same IDs reports an error instead of replacing them.
+
+To deliberately regenerate those files, add `--overwrite`:
+
+```bash
+python3 Tools/generate_map_examples.py \
+  --output-dir /tmp/dimensionfall-map-examples \
+  --variants 3 \
+  --seed 1000 \
+  --overwrite
+```
+
+An overwritten file that was not originally created by this runner is not claimed by its cleanup manifest and will not be deleted by `--clean`.
+
+## Safe cleanup
+
+The runner records newly created output filenames and SHA-256 digests in:
+
+```text
+.dimensionfall-map-examples-manifest
+```
+
+The manifest has no `.json` extension, so it is not treated as a map. Cleanup removes only recorded map files whose contents still match their generated SHA-256 digest:
+
+```bash
+python3 Tools/generate_map_examples.py \
+  --output-dir /tmp/dimensionfall-map-examples \
+  --clean
+```
+
+Remove examples installed for editor inspection with:
+
+```bash
+python3 Tools/generate_map_examples.py \
+  --output-dir Mods/Dimensionfall/Maps \
+  --clean
+```
+
+Unrelated maps in the output directory are left untouched. A generated path that has since been changed or replaced is also preserved. If the manifest is missing, cleanup removes nothing. If it is malformed, cleanup stops rather than guessing which files are safe to delete.
+
+## Useful checks
+
+Show all command options:
+
+```bash
+python3 Tools/generate_map_examples.py --help
+```
+
+Validate all generated maps in a temporary output directory:
+
+```bash
+python3 Tools/map_validator.py /tmp/dimensionfall-map-examples
+```
+
+Confirm generated map dimensions and populated levels:
+
+```bash
+python3 - <<'PY'
+import json
+from pathlib import Path
+
+for path in sorted(Path("/tmp/dimensionfall-map-examples").glob("*.json")):
+    data = json.loads(path.read_text(encoding="utf-8"))
+    populated = [index for index, level in enumerate(data["levels"]) if level]
+    print(
+        path.name,
+        f"{data['mapwidth']}x{data['mapheight']}",
+        f"ground tiles={len(data['levels'][10])}",
+        f"populated levels={populated}",
+    )
+PY
+```
+
+## Current limitations
+
+- Variants change the recipe seed; they do not synthesize new recipe operations.
+- Generated maps contain terrain only. Furniture, areas, buildings, semantic roads, and additional populated levels are not supported yet.
+- The maps can be inspected with the existing content-editor preview, but the runner does not launch Godot or inject maps into an already-running editor session.
+- Installing examples under `Mods/Dimensionfall/Maps` makes them available to the content editor, but does not automatically reference them from overmap-area generation.

--- a/Documentation/Modding/map_recipe_generator.md
+++ b/Documentation/Modding/map_recipe_generator.md
@@ -15,6 +15,8 @@ python3 Tools/map_validator.py /tmp/generated_meadow_prototype.json
 
 The output filename must be `<id>.json`, matching the map loader's filename-derived ID. Existing output is protected. Pass `--overwrite` only when replacement is intended. Use `--tiles PATH` to validate tile IDs against a tile database other than `Mods/Dimensionfall/Tiles/Tiles.json`.
 
+For batch generation of deterministic seed variants and instructions for inspecting them in Godot's content editor, see [`map_example_generation.md`](map_example_generation.md).
+
 ## Recipe format
 
 The root must be a JSON object with these fields:

--- a/Tools/generate_map_examples.py
+++ b/Tools/generate_map_examples.py
@@ -1,0 +1,218 @@
+#!/usr/bin/env python3
+"""Generate deterministic example-map variants from maintained recipes."""
+
+from __future__ import annotations
+
+import argparse
+import copy
+import hashlib
+import json
+import os
+import sys
+import tempfile
+from pathlib import Path
+
+try:
+    from .map_generator import generate_map, load_recipe, write_map
+except ImportError:  # Direct execution from Tools/.
+    from map_generator import generate_map, load_recipe, write_map
+
+
+MANIFEST_NAME = ".dimensionfall-map-examples-manifest"
+ROOT = Path(__file__).resolve().parents[1]
+DEFAULT_RECIPE_PATH = ROOT / "Tools" / "examples" / "map_recipe.json"
+DEFAULT_TILES_PATH = ROOT / "Mods" / "Dimensionfall" / "Tiles" / "Tiles.json"
+
+
+def _manifest_path(output_dir: Path) -> Path:
+    return output_dir / MANIFEST_NAME
+
+
+def _load_manifest(output_dir: Path) -> dict[str, str]:
+    manifest_path = _manifest_path(output_dir)
+    if not manifest_path.exists():
+        return {}
+    with manifest_path.open(encoding="utf-8") as handle:
+        manifest = json.load(handle)
+    if not isinstance(manifest, dict) or manifest.get("version") != 2:
+        raise ValueError(f"invalid example-map manifest: {manifest_path}")
+    files = manifest.get("files")
+    if not isinstance(files, dict):
+        raise ValueError(f"invalid example-map manifest: {manifest_path}")
+    for filename, digest in files.items():
+        if (
+            not isinstance(filename, str)
+            or Path(filename).name != filename
+            or not filename.endswith(".json")
+            or not isinstance(digest, str)
+            or len(digest) != 64
+            or any(character not in "0123456789abcdef" for character in digest)
+        ):
+            raise ValueError(f"invalid example-map manifest entry: {filename!r}")
+    return files
+
+
+def _write_manifest(output_dir: Path, files: dict[str, str]) -> None:
+    output_dir.mkdir(parents=True, exist_ok=True)
+    manifest_path = _manifest_path(output_dir)
+    temporary_path: Path | None = None
+    try:
+        with tempfile.NamedTemporaryFile(
+            mode="w",
+            encoding="utf-8",
+            dir=output_dir,
+            prefix=f".{MANIFEST_NAME}.",
+            delete=False,
+        ) as temporary:
+            json.dump({"version": 2, "files": files}, temporary, indent=2)
+            temporary.write("\n")
+            temporary_path = Path(temporary.name)
+        os.replace(temporary_path, manifest_path)
+        temporary_path = None
+    finally:
+        if temporary_path is not None:
+            temporary_path.unlink(missing_ok=True)
+
+
+def _file_digest(path: Path) -> str:
+    return hashlib.sha256(path.read_bytes()).hexdigest()
+
+
+def clean_examples(output_dir: Path) -> list[Path]:
+    """Remove unchanged files recorded in the example-runner manifest."""
+    output_dir = Path(output_dir)
+    files = _load_manifest(output_dir)
+    removed_paths: list[Path] = []
+    for filename, expected_digest in files.items():
+        path = output_dir / filename
+        if path.is_file() and _file_digest(path) == expected_digest:
+            path.unlink()
+            removed_paths.append(path)
+    _manifest_path(output_dir).unlink(missing_ok=True)
+    return removed_paths
+
+
+def generate_examples(
+    recipe_paths: list[Path],
+    output_dir: Path,
+    tiles_path: Path,
+    *,
+    variants: int = 3,
+    starting_seed: int | None = None,
+    overwrite: bool = False,
+) -> list[Path]:
+    """Generate validated seed variants and return their output paths."""
+    if type(variants) is not int or variants < 1:
+        raise ValueError("variants must be a positive integer")
+
+    output_dir = Path(output_dir)
+    tiles_path = Path(tiles_path)
+    owned_files = _load_manifest(output_dir)
+    planned_outputs: list[tuple[dict, Path]] = []
+    output_paths: set[Path] = set()
+
+    for recipe_path in recipe_paths:
+        source_recipe = load_recipe(Path(recipe_path))
+        generate_map(source_recipe, tiles_path)
+        base_seed = (
+            source_recipe.get("seed") if starting_seed is None else starting_seed
+        )
+        if type(base_seed) is not int:
+            raise ValueError("starting seed must be an integer")
+
+        for variant_index in range(variants):
+            variant_number = variant_index + 1
+            recipe = copy.deepcopy(source_recipe)
+            recipe["id"] = f"{source_recipe['id']}_example_{variant_number:03d}"
+            recipe["name"] = f"{source_recipe['name']} Example {variant_number:03d}"
+            recipe["description"] = (
+                f"{source_recipe['description']} "
+                f"Example seed: {base_seed + variant_index}."
+            )
+            recipe["seed"] = base_seed + variant_index
+            generate_map(recipe, tiles_path)
+            output_path = output_dir / f"{recipe['id']}.json"
+            if output_path in output_paths:
+                raise ValueError(f"duplicate output path: {output_path}")
+            output_paths.add(output_path)
+            planned_outputs.append((recipe, output_path))
+
+    if not overwrite:
+        existing_paths = [path for _, path in planned_outputs if path.exists()]
+        if existing_paths:
+            raise FileExistsError(
+                f"output already exists: {existing_paths[0]}; "
+                "use --overwrite to replace it"
+            )
+
+    generated_paths: list[Path] = []
+    for recipe, output_path in planned_outputs:
+        existed_before = output_path.exists()
+
+        with tempfile.NamedTemporaryFile(
+            mode="w", encoding="utf-8", suffix=".json", delete=False
+        ) as temporary:
+            json.dump(recipe, temporary, ensure_ascii=False)
+            temporary_path = Path(temporary.name)
+        try:
+            write_map(temporary_path, output_path, tiles_path, overwrite)
+        finally:
+            temporary_path.unlink(missing_ok=True)
+        if not existed_before or output_path.name in owned_files:
+            owned_files[output_path.name] = _file_digest(output_path)
+            try:
+                _write_manifest(output_dir, owned_files)
+            except Exception:
+                output_path.unlink(missing_ok=True)
+                raise
+        generated_paths.append(output_path)
+
+    return generated_paths
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "recipes",
+        nargs="*",
+        type=Path,
+        help="recipe paths (defaults to Tools/examples/map_recipe.json)",
+    )
+    parser.add_argument("--output-dir", type=Path, required=True)
+    parser.add_argument("--variants", type=int, default=3)
+    parser.add_argument("--seed", type=int)
+    parser.add_argument("--overwrite", action="store_true")
+    parser.add_argument("--clean", action="store_true")
+    parser.add_argument("--tiles", type=Path, default=DEFAULT_TILES_PATH)
+    args = parser.parse_args(argv)
+
+    try:
+        if args.clean:
+            if args.recipes or args.overwrite or args.seed is not None:
+                parser.error(
+                    "--clean cannot be combined with recipes, --overwrite, or --seed"
+                )
+            removed_paths = clean_examples(args.output_dir)
+            print(f"Removed {len(removed_paths)} example map(s) from {args.output_dir}")
+            return 0
+
+        recipe_paths = args.recipes or [DEFAULT_RECIPE_PATH]
+        generated_paths = generate_examples(
+            recipe_paths,
+            args.output_dir,
+            args.tiles,
+            variants=args.variants,
+            starting_seed=args.seed,
+            overwrite=args.overwrite,
+        )
+    except (OSError, ValueError, json.JSONDecodeError) as error:
+        parser.exit(2, f"error: {error}\n")
+
+    print(f"Generated {len(generated_paths)} example map(s):")
+    for path in generated_paths:
+        print(f"  {path}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/Tools/tests/test_generate_map_examples.py
+++ b/Tools/tests/test_generate_map_examples.py
@@ -1,0 +1,239 @@
+import contextlib
+import io
+import json
+import tempfile
+import unittest
+from pathlib import Path
+
+from Tools.generate_map_examples import (
+    MANIFEST_NAME,
+    clean_examples,
+    generate_examples,
+    main,
+)
+
+
+ROOT = Path(__file__).resolve().parents[2]
+RECIPE_PATH = ROOT / "Tools" / "examples" / "map_recipe.json"
+TILES_PATH = ROOT / "Mods" / "Dimensionfall" / "Tiles" / "Tiles.json"
+
+
+class GenerateMapExamplesTests(unittest.TestCase):
+    def test_generates_requested_seed_variants_with_unique_ids(self):
+        with tempfile.TemporaryDirectory() as directory:
+            output_dir = Path(directory)
+
+            generated_paths = generate_examples(
+                [RECIPE_PATH],
+                output_dir,
+                TILES_PATH,
+                variants=3,
+                starting_seed=700,
+            )
+
+            self.assertEqual(
+                [path.name for path in generated_paths],
+                [
+                    "generated_meadow_prototype_example_001.json",
+                    "generated_meadow_prototype_example_002.json",
+                    "generated_meadow_prototype_example_003.json",
+                ],
+            )
+            maps = [
+                json.loads(path.read_text(encoding="utf-8"))
+                for path in generated_paths
+            ]
+            self.assertEqual(
+                [data["id"] for data in maps],
+                [path.stem for path in generated_paths],
+            )
+            self.assertTrue(
+                all(
+                    data["mapwidth"] == 32
+                    and data["mapheight"] == 32
+                    and len(data["levels"][10]) == 1024
+                    for data in maps
+                )
+            )
+            self.assertNotEqual(maps[0]["levels"][10], maps[1]["levels"][10])
+
+    def test_cleanup_removes_only_manifest_owned_maps(self):
+        with tempfile.TemporaryDirectory() as directory:
+            output_dir = Path(directory)
+            unrelated_path = output_dir / "existing_map.json"
+            unrelated_path.write_text("{}", encoding="utf-8")
+            generated_paths = generate_examples(
+                [RECIPE_PATH], output_dir, TILES_PATH, variants=2
+            )
+
+            manifest_path = output_dir / MANIFEST_NAME
+            self.assertTrue(manifest_path.is_file())
+
+            removed_paths = clean_examples(output_dir)
+
+            self.assertEqual(removed_paths, generated_paths)
+            self.assertTrue(unrelated_path.is_file())
+            self.assertTrue(all(not path.exists() for path in generated_paths))
+            self.assertFalse(manifest_path.exists())
+
+    def test_cli_generates_and_cleans_default_recipe(self):
+        with tempfile.TemporaryDirectory() as directory:
+            output_dir = Path(directory)
+            stdout = io.StringIO()
+
+            with contextlib.redirect_stdout(stdout):
+                result = main(
+                    [
+                        "--output-dir",
+                        str(output_dir),
+                        "--variants",
+                        "2",
+                        "--seed",
+                        "900",
+                    ]
+                )
+
+            self.assertEqual(result, 0)
+            self.assertEqual(len(list(output_dir.glob("*.json"))), 2)
+            self.assertIn("Generated 2 example map(s)", stdout.getvalue())
+
+            with contextlib.redirect_stdout(stdout):
+                result = main(["--output-dir", str(output_dir), "--clean"])
+
+            self.assertEqual(result, 0)
+            self.assertEqual(list(output_dir.glob("*.json")), [])
+
+    def test_overwritten_unowned_map_is_not_added_to_cleanup_manifest(self):
+        with tempfile.TemporaryDirectory() as directory:
+            output_dir = Path(directory)
+            output_path = output_dir / "generated_meadow_prototype_example_001.json"
+            output_path.write_text("original", encoding="utf-8")
+
+            with self.assertRaises(FileExistsError):
+                generate_examples(
+                    [RECIPE_PATH], output_dir, TILES_PATH, variants=1
+                )
+            self.assertEqual(output_path.read_text(encoding="utf-8"), "original")
+
+            generate_examples(
+                [RECIPE_PATH],
+                output_dir,
+                TILES_PATH,
+                variants=1,
+                overwrite=True,
+            )
+
+            self.assertEqual(clean_examples(output_dir), [])
+            self.assertTrue(output_path.is_file())
+
+    def test_invalid_recipe_does_not_publish_an_output_or_manifest(self):
+        with tempfile.TemporaryDirectory() as directory:
+            directory_path = Path(directory)
+            output_dir = directory_path / "output"
+            recipe = json.loads(RECIPE_PATH.read_text(encoding="utf-8"))
+            recipe["base_tile"] = {"id": "missing_tile"}
+            recipe_path = directory_path / "invalid_recipe.json"
+            recipe_path.write_text(json.dumps(recipe), encoding="utf-8")
+
+            with self.assertRaisesRegex(ValueError, "unknown tile 'missing_tile'"):
+                generate_examples([recipe_path], output_dir, TILES_PATH, variants=1)
+
+            self.assertEqual(list(output_dir.glob("*.json")), [])
+            self.assertFalse((output_dir / MANIFEST_NAME).exists())
+
+    def test_malformed_recipe_is_rejected_before_variant_naming(self):
+        with tempfile.TemporaryDirectory() as directory:
+            directory_path = Path(directory)
+            recipe = json.loads(RECIPE_PATH.read_text(encoding="utf-8"))
+            recipe.pop("id")
+            recipe_path = directory_path / "malformed_recipe.json"
+            recipe_path.write_text(json.dumps(recipe), encoding="utf-8")
+
+            with self.assertRaisesRegex(ValueError, "id must be a non-empty string"):
+                generate_examples(
+                    [recipe_path], directory_path / "output", TILES_PATH, variants=1
+                )
+
+    def test_same_recipe_and_seed_produce_identical_variants(self):
+        with (
+            tempfile.TemporaryDirectory() as first_directory,
+            tempfile.TemporaryDirectory() as second_directory,
+        ):
+            first_paths = generate_examples(
+                [RECIPE_PATH],
+                Path(first_directory),
+                TILES_PATH,
+                variants=2,
+                starting_seed=50,
+            )
+            second_paths = generate_examples(
+                [RECIPE_PATH],
+                Path(second_directory),
+                TILES_PATH,
+                variants=2,
+                starting_seed=50,
+            )
+
+            self.assertEqual(
+                [path.read_text(encoding="utf-8") for path in first_paths],
+                [path.read_text(encoding="utf-8") for path in second_paths],
+            )
+
+    def test_duplicate_recipe_ids_are_rejected_before_publication(self):
+        with tempfile.TemporaryDirectory() as directory:
+            directory_path = Path(directory)
+            output_dir = directory_path / "output"
+            first_recipe = directory_path / "first.json"
+            second_recipe = directory_path / "second.json"
+            recipe_text = RECIPE_PATH.read_text(encoding="utf-8")
+            first_recipe.write_text(recipe_text, encoding="utf-8")
+            second_recipe.write_text(recipe_text, encoding="utf-8")
+
+            with self.assertRaisesRegex(ValueError, "duplicate output path"):
+                generate_examples(
+                    [first_recipe, second_recipe],
+                    output_dir,
+                    TILES_PATH,
+                    variants=2,
+                    overwrite=True,
+                )
+
+            self.assertFalse(output_dir.exists())
+
+    def test_cleanup_preserves_generated_path_replaced_by_other_content(self):
+        with tempfile.TemporaryDirectory() as directory:
+            output_dir = Path(directory)
+            generated_path = generate_examples(
+                [RECIPE_PATH], output_dir, TILES_PATH, variants=1
+            )[0]
+            replacement = '{"unrelated": true}\n'
+            generated_path.write_text(replacement, encoding="utf-8")
+
+            removed_paths = clean_examples(output_dir)
+
+            self.assertEqual(removed_paths, [])
+            self.assertEqual(generated_path.read_text(encoding="utf-8"), replacement)
+            self.assertFalse((output_dir / MANIFEST_NAME).exists())
+
+    def test_existing_later_output_is_rejected_before_any_publication(self):
+        with tempfile.TemporaryDirectory() as directory:
+            output_dir = Path(directory)
+            existing_path = (
+                output_dir / "generated_meadow_prototype_example_002.json"
+            )
+            existing_path.write_text("existing", encoding="utf-8")
+
+            with self.assertRaises(FileExistsError):
+                generate_examples(
+                    [RECIPE_PATH], output_dir, TILES_PATH, variants=2
+                )
+
+            self.assertFalse(
+                (output_dir / "generated_meadow_prototype_example_001.json").exists()
+            )
+            self.assertEqual(existing_path.read_text(encoding="utf-8"), "existing")
+            self.assertFalse((output_dir / MANIFEST_NAME).exists())
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- add a Python CLI for generating deterministic map-recipe variants
- prevalidate complete batches and reject duplicate output targets
- support custom recipes, output directories, seeds, and variant counts
- preserve existing files unless overwrite is explicitly enabled
- add SHA-256 manifest ownership for safe cleanup
- preserve generated paths that were subsequently changed or replaced
- document generation, validation, cleanup, and content-editor inspection
- mark Phase 4A complete and Phase 4B palettes as next
- clarify that visual inspection uses Godot's existing map preview

## Validation

- 34 Python tests passed
- generated and validated three deterministic variants
- confirmed 32×32 output with 1,024 entries on level 10
- verified duplicate targets are rejected before publication
- verified existing output conflicts do not cause partial publication
- verified digest-aware cleanup preserves replaced files
- verified generated maps load during Godot headless startup
- git diff --check passed

## Known limitation

Dimensionfall attempts to load a same-named PNG sprite for each map. The
example runner generates map JSON only, so Godot logs a non-fatal missing
sprite warning. The content editor's tile-grid preview can still render the
generated map data.