### PR TITLE
Add reusable cell patterns to the map recipe generator

### DIFF
--- a/Documentation/Game_design/Map_generation_plan.md
+++ b/Documentation/Game_design/Map_generation_plan.md
@@ -126,6 +126,8 @@ The generator currently supports:
 * ordered `set`, `rectangle`, `rectangle_outline`, `line`, and `scatter` operations;
 * inclusive Bresenham line rasterization;
 * deterministic scatter by count or density;
+* root-level reusable cell-pattern definitions;
+* ordered pattern placement at an anchor with fixed quarter-turn rotation;
 * root-level weighted tile palettes referenced by base tiles and placement operations;
 * fixed tile rotations;
 * deterministic random rotations;
@@ -150,7 +152,7 @@ unused levels: []
 
 ## 5. Generator and validator tests: complete for version 1
 
-The current Python test suite contains 38 tests and passes.
+The current Python test suite contains 44 tests and passes.
 
 Coverage includes:
 
@@ -169,6 +171,7 @@ Coverage includes:
 * invalid IDs;
 * unknown tile IDs;
 * palette references, weighted deterministic selection, and malformed palette rejection;
+* reusable pattern expansion, rotation, ordering, determinism, compatibility, and validation;
 * invalid metadata;
 * malformed tile databases;
 * out-of-bounds placement;
@@ -388,12 +391,16 @@ Delivered:
 * palette references from `base_tile`, legacy `regions`, and every placement operation;
 * strict palette validation and known tile-ID checking;
 * updated example recipe using palettes for ground, clearing, paths, and flowers.
+* named reusable cell patterns with signed offsets;
+* anchored pattern operations with fixed quarter-turn rotation;
+* strict pattern-definition, reference, field, and expanded-bounds validation;
+* deterministic cell-order expansion using existing tile and palette semantics;
+* updated example recipe reusing one flower-cluster pattern at three orientations.
 
 Remaining goals:
 
-* reusable pattern definitions beyond weighted tile sets;
 * richer automatic rotation rules;
-* additional examples that reduce raw IDs throughout recipes.
+* richer reusable patterns built from shapes or nested composition.
 
 ### Success criterion
 
@@ -648,13 +655,13 @@ An agent can create a new playable map from a concise design request, run all re
 
 # Recommended immediate next task
 
-The next contribution should stay narrow: **Phase 4B tile palettes and deterministic variation**.
+The next contribution should stay narrow: **complete Phase 4B pattern rotation and composition rules**.
 
-Keep the completed placement-operation schema stable. Add named, recipe-level tile palettes that can be referenced anywhere an operation currently accepts a tile. Palette entries should use validated tile IDs and positive integer weights, select deterministically from the recipe seed, preserve explicit tile objects and `null`, and reject unknown palette names or malformed entries.
+Keep the completed placement-operation and cell-pattern schemas stable. Extend pattern invocation with a deterministic `"random"` quarter-turn rotation, define its RNG ordering precisely, and investigate whether one minimal shape-based or nested composition rule can be added without creating a second placement engine.
 
-The branch should not add furniture, areas, buildings, semantic roads, towns, or additional levels. Its success criterion is visibly varied terrain without one recipe entry per cell.
+The branch should not add furniture, areas, buildings, semantic roads, towns, or additional levels. Its success criterion is deterministic pattern-level variation and one demonstrably useful composition rule without weakening strict bounds or unknown-field validation.
 
-Before implementation, inspect the current generator, tests, tile database, recipe documentation, and example. Define how palette selection interacts with `"random"` rotation and RNG ordering, add focused compatibility and validation tests, update the example and documentation, use `Tools/generate_map_examples.py` to compare at least three deterministic variants in the content-editor preview, validate the generated maps, inspect dimensions and tile count, and run `git diff --check`.
+Before implementation, inspect the current generator, tests, recipe documentation, and example. Define how pattern rotation interacts with palette selection, tile-level `"random"` rotation, and RNG ordering; add focused compatibility and validation tests; update the example and documentation; use `Tools/generate_map_examples.py` to compare at least three deterministic variants in the content-editor preview; validate the generated maps; inspect dimensions and tile count; and run `git diff --check`.
 
 Do not commit or push unless explicitly requested.
 
@@ -675,7 +682,8 @@ Do not commit or push unless explicitly requested.
 [Complete] Documentation and recognizable outdoor example
 [Complete] Development moved to snipercup/CataX
 
-[Next]     Palettes and deterministic variation
+[In progress] Palettes, reusable cell patterns, and deterministic variation
+[Next]     Pattern-level random rotation and richer composition
 [Planned]  Features and furniture
 [Planned]  Areas and buildings
 [Planned]  Roads and map connections

--- a/Documentation/Modding/map_recipe_generator.md
+++ b/Documentation/Modding/map_recipe_generator.md
@@ -26,9 +26,10 @@ The root must be a JSON object with these fields:
 | `id` | string | Map ID using only letters, numbers, `_`, and `-`. |
 | `name` | non-empty string | Display name. |
 | `description` | non-empty string | Map description. |
-| `seed` | integer | Fixed seed used by random rotations and scatter. Recipe input only; the map format does not store it. |
+| `seed` | integer | Fixed seed used by palettes, random tile rotations, scatter, and pattern cells. Recipe input only; the map format does not store it. |
 | `base_tile` | tile object | Tile initially placed in every cell. |
 | `palette` | object | Named weighted tile sets that tile objects can reference. Optional; defaults to `{}`. |
+| `patterns` | object | Named arrays of relative tile placements used by `pattern` operations. Optional; defaults to `{}`. |
 | `regions` | array | Legacy filled rectangles. Optional; defaults to `[]`. |
 | `operations` | array | Ordered placement operations. Optional; defaults to `[]`. |
 
@@ -59,7 +60,25 @@ Palette entries are objects with `id`, optional positive integer `weight` (defau
 }
 ```
 
-Legacy `regions` are applied first in array order, followed by `operations` in array order. Later placements overwrite earlier cells. `regions` remain supported for version-one recipes and use the same filled-rectangle placement implementation as `rectangle` operations.
+Legacy `regions` are applied first in array order, followed by `operations` in array order. Pattern cells are expanded in their definition order at the position of the invoking operation. Later placements overwrite earlier cells, including repeated offsets inside one pattern. `regions` remain supported for version-one recipes and use the same filled-rectangle placement implementation as `rectangle` operations.
+
+## Reusable cell patterns
+
+`patterns` maps a name to a non-empty array of relative tile placements. Pattern names follow the same naming rules as palettes. Every cell has an integer `[x, y]` offset in `at` and a `tile`; offsets may be negative, and tiles may use raw IDs, palettes, rotations, or `null` just like operation tiles.
+
+Pattern definitions do not consume random numbers. An invoked pattern consumes randomness in cell-array order only when a cell uses a palette or `"random"` tile rotation. Unused definitions therefore do not change generated output.
+
+```json
+{
+  "patterns": {
+    "wildflower_cluster": [
+      {"at": [0, 0], "tile": {"palette": "flowers"}},
+      {"at": [1, 0], "tile": {"palette": "flowers"}},
+      {"at": [-1, 1], "tile": {"palette": "flowers"}}
+    ]
+  }
+}
+```
 
 ## Placement operations
 
@@ -115,10 +134,25 @@ Selects unique cells in a rectangular `region` using the recipe's seeded random-
 }
 ```
 
+### `pattern`
+
+Places every cell from a named pattern relative to an anchor. Fields: `type`, `pattern`, `at`, and optional `rotation`. Rotation defaults to `0` and accepts fixed clockwise quarter turns: `0`, `90`, `180`, or `270`.
+
+Offsets rotate around the anchor: `90` maps `[x, y]` to `[-y, x]`. The generator preflights the complete expansion and rejects the operation if any resulting cell is outside the map; patterns are never clipped or partially applied.
+
+```json
+{
+  "type": "pattern",
+  "pattern": "wildflower_cluster",
+  "at": [16, 12],
+  "rotation": 90
+}
+```
+
 ## Validation and limitations
 
 The generator rejects unknown fields at every recipe level, root-level dimension fields, malformed or out-of-bounds placements, malformed tile databases, unknown tile IDs, invalid rotations, invalid Unicode, and non-object recipes. It validates generated data with `Tools/map_validator.py` before publishing the output.
 
 The output uses 21 levels, with the generated row-major grid at index 10. It sets `categories` to `[]`, `weight` to `1000`, and all four connections to `"ground"`. It omits `areas`, matching `DMap.get_data()` when the area list is empty.
 
-The generator does not yet create features, furniture, areas, roads as semantic objects, buildings, towns, additional levels, or complex templates. Structural validity also does not yet guarantee walkability or gameplay quality.
+The generator does not yet create features, furniture, areas, roads as semantic objects, buildings, towns, additional levels, nested patterns, or shape-based templates. Structural validity also does not yet guarantee walkability or gameplay quality.

--- a/Tools/examples/map_recipe.json
+++ b/Tools/examples/map_recipe.json
@@ -1,7 +1,7 @@
 {
 	"id": "generated_meadow_prototype",
 	"name": "Generated Meadow Prototype",
-	"description": "A deterministic meadow with a clearing, path, and scattered flowers.",
+	"description": "A deterministic meadow with a clearing, path, scattered flowers, and reusable flower clusters.",
 	"seed": 20260715,
 	"base_tile": {
 		"palette": "ground"
@@ -55,12 +55,30 @@
 			}
 		},
 		{
-			"type": "set",
-			"x": 16,
-			"y": 15,
-			"tile": {
-				"id": "grass_flowers_01"
-			}
+			"type": "pattern",
+			"pattern": "wildflower_cluster",
+			"at": [
+				15,
+				12
+			]
+		},
+		{
+			"type": "pattern",
+			"pattern": "wildflower_cluster",
+			"at": [
+				19,
+				20
+			],
+			"rotation": 90
+		},
+		{
+			"type": "pattern",
+			"pattern": "wildflower_cluster",
+			"at": [
+				12,
+				20
+			],
+			"rotation": 270
 		}
 	],
 	"palette": {
@@ -109,6 +127,55 @@
 				"id": "grass_flowers_01",
 				"weight": 1,
 				"rotation": "random"
+			}
+		]
+	},
+	"patterns": {
+		"wildflower_cluster": [
+			{
+				"at": [
+					0,
+					0
+				],
+				"tile": {
+					"palette": "flowers"
+				}
+			},
+			{
+				"at": [
+					1,
+					0
+				],
+				"tile": {
+					"palette": "flowers"
+				}
+			},
+			{
+				"at": [
+					-1,
+					1
+				],
+				"tile": {
+					"palette": "flowers"
+				}
+			},
+			{
+				"at": [
+					0,
+					1
+				],
+				"tile": {
+					"palette": "flowers"
+				}
+			},
+			{
+				"at": [
+					1,
+					1
+				],
+				"tile": {
+					"palette": "flowers"
+				}
 			}
 		]
 	}

--- a/Tools/map_generator.py
+++ b/Tools/map_generator.py
@@ -32,14 +32,16 @@ DEFAULT_CONNECTIONS = {
 VALID_ROTATIONS = (0, 90, 180, 270)
 TILE_FIELDS = {"id", "palette", "rotation"}
 PALETTE_FIELDS = {"id", "weight", "rotation"}
-PALETTE_NAME_PATTERN = re.compile(r"[A-Za-z0-9_-]+")
+DEFINITION_NAME_PATTERN = re.compile(r"[A-Za-z0-9_-]+")
 REGION_FIELDS = {"x", "y", "width", "height", "tile"}
 SET_FIELDS = {"type", "x", "y", "tile"}
 RECTANGLE_FIELDS = {"type", "x", "y", "width", "height", "tile"}
 LINE_FIELDS = {"type", "from", "to", "tile"}
 SCATTER_FIELDS = {"type", "region", "tile", "count", "density"}
 SCATTER_REGION_FIELDS = {"x", "y", "width", "height"}
-OPERATION_TYPES = {"set", "rectangle", "rectangle_outline", "line", "scatter"}
+PATTERN_CELL_FIELDS = {"at", "tile"}
+PATTERN_OPERATION_FIELDS = {"type", "pattern", "at", "rotation"}
+TILE_OPERATION_TYPES = {"set", "rectangle", "rectangle_outline", "line", "scatter"}
 RECIPE_FIELDS = {
     "id",
     "name",
@@ -47,6 +49,7 @@ RECIPE_FIELDS = {
     "seed",
     "base_tile",
     "palette",
+    "patterns",
     "regions",
     "operations",
 }
@@ -167,9 +170,10 @@ def _validate_palette(
         if not isinstance(name, str) or not name.strip():
             raise RecipeError("palette names must be non-empty strings")
         _validate_unicode(name, f"palette.{name}")
-        if PALETTE_NAME_PATTERN.fullmatch(name) is None:
+        if DEFINITION_NAME_PATTERN.fullmatch(name) is None:
             raise RecipeError(
-                f"palette name '{name}' may contain only letters, numbers, underscores, and hyphens"
+                f"palette name '{name}' may contain only letters, numbers, "
+                "underscores, and hyphens"
             )
         if not isinstance(entries, list) or not entries:
             raise RecipeError(f"palette.{name} must be a non-empty array")
@@ -177,6 +181,60 @@ def _validate_palette(
             _validate_palette_entry(entry, known_tiles, f"palette.{name}[{index}]")
             for index, entry in enumerate(entries)
         ]
+    return validated
+
+
+def _validate_pattern_offset(value: Any, context: str) -> tuple[int, int]:
+    if (
+        not isinstance(value, list)
+        or len(value) != 2
+        or any(type(coordinate) is not int for coordinate in value)
+    ):
+        raise RecipeError(f"{context} must be a two-integer array")
+    return value[0], value[1]
+
+
+def _validate_patterns(
+    patterns: Any,
+    known_tiles: set[str],
+    palette: dict[str, list[dict[str, Any]]],
+) -> dict[str, list[dict[str, Any]]]:
+    if not isinstance(patterns, dict):
+        raise RecipeError("patterns must be an object")
+    validated: dict[str, list[dict[str, Any]]] = {}
+    for name, cells in patterns.items():
+        if not isinstance(name, str) or not name.strip():
+            raise RecipeError("pattern names must be non-empty strings")
+        _validate_unicode(name, f"patterns.{name}")
+        if DEFINITION_NAME_PATTERN.fullmatch(name) is None:
+            raise RecipeError(
+                f"pattern name '{name}' may contain only letters, numbers, "
+                "underscores, and hyphens"
+            )
+        if not isinstance(cells, list) or not cells:
+            raise RecipeError(f"patterns.{name} must be a non-empty array")
+        validated_cells: list[dict[str, Any]] = []
+        for index, cell in enumerate(cells):
+            context = f"patterns.{name}[{index}]"
+            if not isinstance(cell, dict):
+                raise RecipeError(f"{context} must be an object")
+            unknown_fields = sorted(set(cell) - PATTERN_CELL_FIELDS)
+            if unknown_fields:
+                raise RecipeError(f"unknown {context} field '{unknown_fields[0]}'")
+            if "at" not in cell:
+                raise RecipeError(f"{context}.at is required")
+            if "tile" not in cell:
+                raise RecipeError(f"{context}.tile is required")
+            offset = _validate_pattern_offset(cell["at"], f"{context}.at")
+            _validate_tile_spec(
+                cell["tile"],
+                known_tiles,
+                f"{context}.tile",
+                allow_empty=True,
+                palette=palette,
+            )
+            validated_cells.append({"at": offset, "tile": cell["tile"]})
+        validated[name] = validated_cells
     return validated
 
 
@@ -475,6 +533,65 @@ def _apply_scatter(
         )
 
 
+def _rotate_offset(x: int, y: int, rotation: int) -> tuple[int, int]:
+    if rotation == 90:
+        return -y, x
+    if rotation == 180:
+        return -x, -y
+    if rotation == 270:
+        return y, -x
+    return x, y
+
+
+def _apply_pattern(
+    level: list[dict[str, Any]],
+    operation: dict[str, Any],
+    rng: random.Random,
+    known_tiles: set[str],
+    palette: dict[str, list[dict[str, Any]]],
+    patterns: dict[str, list[dict[str, Any]]],
+    context: str,
+) -> None:
+    unknown_fields = sorted(set(operation) - PATTERN_OPERATION_FIELDS)
+    if unknown_fields:
+        raise RecipeError(f"unknown {context} field '{unknown_fields[0]}'")
+    pattern_name = operation.get("pattern")
+    if not isinstance(pattern_name, str) or not pattern_name.strip():
+        raise RecipeError(f"{context}.pattern must be a non-empty string")
+    _validate_unicode(pattern_name, f"{context}.pattern")
+    if pattern_name not in patterns:
+        raise RecipeError(
+            f"{context}.pattern references unknown pattern '{pattern_name}'"
+        )
+    anchor_x, anchor_y = _point(operation.get("at"), f"{context}.at")
+    rotation = operation.get("rotation", 0)
+    if type(rotation) is not int or rotation not in VALID_ROTATIONS:
+        raise RecipeError(f"{context}.rotation must be 0, 90, 180, or 270")
+
+    placements: list[tuple[int, int, Any]] = []
+    for index, cell in enumerate(patterns[pattern_name]):
+        cell_x, cell_y = cell["at"]
+        offset_x, offset_y = _rotate_offset(cell_x, cell_y, rotation)
+        x = anchor_x + offset_x
+        y = anchor_y + offset_y
+        if not 0 <= x < MAP_WIDTH or not 0 <= y < MAP_HEIGHT:
+            raise RecipeError(
+                f"{context} places patterns.{pattern_name}[{index}] outside the "
+                f"{MAP_WIDTH}x{MAP_HEIGHT} map at [{x}, {y}]"
+            )
+        placements.append((x, y, cell["tile"]))
+
+    for index, (x, y, tile_spec) in enumerate(placements):
+        level[y * MAP_WIDTH + x] = _make_tile(
+            tile_spec,
+            rng,
+            known_tiles,
+            f"{context}.pattern.{pattern_name}[{index}].tile",
+            allow_empty=True,
+            palette=palette,
+        )
+
+
 def generate_map(recipe: dict[str, Any], tiles_path: Path) -> dict[str, Any]:
     """Validate a recipe and return map data matching DMap's saved format."""
     if not isinstance(recipe, dict):
@@ -498,6 +615,7 @@ def generate_map(recipe: dict[str, Any], tiles_path: Path) -> dict[str, Any]:
         raise RecipeError("seed must be an integer")
     known_tiles = _tile_ids(Path(tiles_path))
     palette = _validate_palette(recipe.get("palette", {}), known_tiles)
+    patterns = _validate_patterns(recipe.get("patterns", {}), known_tiles, palette)
     rng = random.Random(seed)
     level = [
         _make_tile(
@@ -525,7 +643,7 @@ def generate_map(recipe: dict[str, Any], tiles_path: Path) -> dict[str, Any]:
         if not isinstance(operation, dict):
             raise RecipeError(f"{context} must be an object")
         operation_type = operation.get("type")
-        if operation_type in OPERATION_TYPES and "tile" not in operation:
+        if operation_type in TILE_OPERATION_TYPES and "tile" not in operation:
             raise RecipeError(f"{context}.tile is required")
         if operation_type == "set":
             _apply_set(level, operation, rng, known_tiles, palette, context)
@@ -541,6 +659,10 @@ def generate_map(recipe: dict[str, Any], tiles_path: Path) -> dict[str, Any]:
             _apply_line(level, operation, rng, known_tiles, palette, context)
         elif operation_type == "scatter":
             _apply_scatter(level, operation, rng, known_tiles, palette, context)
+        elif operation_type == "pattern":
+            _apply_pattern(
+                level, operation, rng, known_tiles, palette, patterns, context
+            )
         else:
             raise RecipeError(
                 f"{context}.type has unknown operation '{operation_type}'"

--- a/Tools/tests/test_map_generator.py
+++ b/Tools/tests/test_map_generator.py
@@ -222,6 +222,189 @@ class MapGeneratorTests(unittest.TestCase):
 
         self.assertEqual(level.count({"id": "dirt_light_00"}), 4)
 
+    def test_pattern_operation_places_relative_cells_with_quarter_turn_rotation(self):
+        recipe = valid_recipe()
+        recipe["base_tile"] = {"id": "grass_plain_01"}
+        recipe["patterns"] = {
+            "corner": [
+                {"at": [0, 0], "tile": {"id": "dirt_light_00"}},
+                {"at": [1, 0], "tile": {"id": "grass_flowers_01"}},
+                {"at": [0, 1], "tile": None},
+            ]
+        }
+        recipe["operations"] = [
+            {
+                "type": "pattern",
+                "pattern": "corner",
+                "at": [10, 10],
+                "rotation": 90,
+            }
+        ]
+
+        level = generate_map(recipe, TILES_PATH)["levels"][10]
+
+        self.assertEqual(level[10 * 32 + 10], {"id": "dirt_light_00"})
+        self.assertEqual(level[11 * 32 + 10], {"id": "grass_flowers_01"})
+        self.assertEqual(level[10 * 32 + 9], {})
+
+    def test_pattern_cells_and_later_operations_follow_ordered_overwrite_semantics(
+        self,
+    ):
+        recipe = valid_recipe()
+        recipe["base_tile"] = {"id": "grass_plain_01"}
+        recipe["patterns"] = {
+            "overlap": [
+                {"at": [0, 0], "tile": {"id": "dirt_light_00"}},
+                {"at": [0, 0], "tile": {"id": "grass_flowers_01"}},
+            ]
+        }
+        recipe["operations"] = [
+            {"type": "pattern", "pattern": "overlap", "at": [4, 5]},
+            {"type": "set", "x": 4, "y": 5, "tile": None},
+        ]
+
+        level = generate_map(recipe, TILES_PATH)["levels"][10]
+
+        self.assertEqual(level[5 * 32 + 4], {})
+
+    def test_pattern_palette_selection_is_deterministic(self):
+        recipe = valid_recipe()
+        recipe["base_tile"] = {"id": "grass_plain_01"}
+        recipe["palette"] = {
+            "detail": [
+                {"id": "grass_flowers_00", "weight": 1, "rotation": "random"},
+                {"id": "grass_flowers_01", "weight": 1, "rotation": "random"},
+            ]
+        }
+        recipe["patterns"] = {
+            "details": [
+                {"at": [0, 0], "tile": {"palette": "detail"}},
+                {"at": [1, 0], "tile": {"palette": "detail"}},
+                {"at": [2, 0], "tile": {"palette": "detail"}},
+            ]
+        }
+        recipe["operations"] = [
+            {"type": "pattern", "pattern": "details", "at": [5, 5]}
+        ]
+
+        first = generate_map(recipe, TILES_PATH)
+        second = generate_map(recipe, TILES_PATH)
+
+        self.assertEqual(first, second)
+
+    def test_unused_pattern_definition_does_not_change_rng_order(self):
+        recipe = valid_recipe()
+        expected = generate_map(recipe, TILES_PATH)
+        recipe["patterns"] = {
+            "unused": [
+                {
+                    "at": [0, 0],
+                    "tile": {"id": "grass_flowers_00", "rotation": "random"},
+                }
+            ]
+        }
+
+        self.assertEqual(generate_map(recipe, TILES_PATH), expected)
+
+    def test_pattern_definitions_are_strictly_validated_even_when_unused(self):
+        cases = [
+            ({"patterns": []}, "patterns must be an object"),
+            (
+                {"patterns": {"": [{"at": [0, 0], "tile": None}]}},
+                "pattern names must be non-empty strings",
+            ),
+            (
+                {"patterns": {"bad name": [{"at": [0, 0], "tile": None}]}},
+                "may contain only letters",
+            ),
+            (
+                {"patterns": {"empty": []}},
+                "patterns.empty must be a non-empty array",
+            ),
+            (
+                {"patterns": {"bad": [42]}},
+                r"patterns.bad\[0\] must be an object",
+            ),
+            (
+                {"patterns": {"bad": [{"tile": None}]}},
+                r"patterns.bad\[0\].at is required",
+            ),
+            (
+                {"patterns": {"bad": [{"at": [0, 0]}]}},
+                r"patterns.bad\[0\].tile is required",
+            ),
+            (
+                {"patterns": {"bad": [{"at": [True, 0], "tile": None}]}},
+                "must be a two-integer array",
+            ),
+            (
+                {
+                    "patterns": {
+                        "bad": [{"at": [0, 0], "tile": None, "extra": 1}]
+                    }
+                },
+                r"unknown patterns.bad\[0\] field 'extra'",
+            ),
+            (
+                {
+                    "patterns": {
+                        "bad": [
+                            {"at": [0, 0], "tile": {"id": "missing_tile"}}
+                        ]
+                    }
+                },
+                "unknown tile 'missing_tile'",
+            ),
+        ]
+        for changes, expected_message in cases:
+            with self.subTest(changes=changes):
+                recipe = valid_recipe()
+                recipe.update(changes)
+                with self.assertRaisesRegex(RecipeError, expected_message):
+                    generate_map(recipe, TILES_PATH)
+
+    def test_pattern_operations_reject_invalid_references_fields_and_bounds(self):
+        base_pattern = {"patterns": {"one": [{"at": [1, 0], "tile": None}]}}
+        cases = [
+            (
+                {"type": "pattern", "pattern": "missing", "at": [1, 1]},
+                "unknown pattern 'missing'",
+            ),
+            (
+                {"type": "pattern", "pattern": "one", "at": [1]},
+                "must be a two-integer array",
+            ),
+            (
+                {
+                    "type": "pattern",
+                    "pattern": "one",
+                    "at": [1, 1],
+                    "rotation": "random",
+                },
+                "rotation must be 0, 90, 180, or 270",
+            ),
+            (
+                {
+                    "type": "pattern",
+                    "pattern": "one",
+                    "at": [1, 1],
+                    "extra": 1,
+                },
+                r"unknown operations\[0\] field 'extra'",
+            ),
+            (
+                {"type": "pattern", "pattern": "one", "at": [31, 0]},
+                "outside the 32x32 map at \\[32, 0\\]",
+            ),
+        ]
+        for operation, expected_message in cases:
+            with self.subTest(operation=operation):
+                recipe = valid_recipe()
+                recipe.update(base_pattern)
+                recipe["operations"] = [operation]
+                with self.assertRaisesRegex(RecipeError, expected_message):
+                    generate_map(recipe, TILES_PATH)
+
     def test_invalid_operations_are_rejected_with_clear_errors(self):
         base_region = {"x": 0, "y": 0, "width": 2, "height": 2}
         cases = [


### PR DESCRIPTION
## Summary

Adds reusable cell patterns to the recipe-driven map generator so recipes
can define small tile arrangements once and place them repeatedly.

This advances Phase 4B without adding furniture, areas, buildings,
semantic roads, or additional map levels.

## Changes

- Add root-level `patterns` definitions.
- Add ordered `pattern` placement operations.
- Support signed relative cell offsets.
- Support fixed `0`, `90`, `180`, and `270` degree rotation around an
  explicit anchor.
- Reuse existing raw tile, palette, tile rotation, `null`, RNG, and
  overwrite behavior.
- Validate malformed and unused pattern definitions.
- Reject unknown pattern references and operation fields.
- Preflight complete pattern expansions so out-of-bounds patterns are
  never clipped or partially applied.
- Update the maintained meadow recipe to place one wildflower pattern
  at three orientations.
- Document the schema, rotation transform, ordering, RNG behavior, and
  limitations.
- Update the map-generation roadmap and test count.

## Determinism and compatibility

Pattern definitions do not consume random numbers during validation.
Randomness is consumed only when invoked cells use palettes or random
tile rotation, in pattern cell-array order.

As a result, adding an unused pattern definition does not alter output
from an existing recipe.

Legacy recipes without `patterns` continue using the existing generation
path and behavior.

## Validation

- `python3 -m unittest discover -s Tools/tests`
  - 44 tests passed
- Generated three deterministic example variants
- Validated each variant with `Tools/map_validator.py`
- Confirmed each map is 32×32 with exactly 1024 ground-level cells
- Confirmed all three variants are distinct
- `godot --headless --path . --editor --quit`
  - exited successfully
  - reported existing quest-manager zoom and duplicate athletics texture
    UID diagnostics unrelated to this change
- `git diff --check`
  - passed

## Out of scope

- Random pattern-level rotation
- Nested patterns
- Shape-based pattern composition
- Furniture and features
- Areas and buildings
- Semantic roads
- Additional populated levels