### PR TITLE
Add logical z-level support to the map recipe generator

### DIFF
--- a/Documentation/Game_design/Map_generation_plan.md
+++ b/Documentation/Game_design/Map_generation_plan.md
@@ -121,14 +121,16 @@ The generator currently supports:
 * display name;
 * description;
 * deterministic integer seed;
-* one populated level at level-array index 10;
-* a base tile covering the entire map;
+* legacy-compatible ground-level generation at level-array index 10;
+* explicit logical levels from `z: -10` through `z: 10`;
+* multiple populated levels using per-placement `z` or grouped `levels` definitions;
+* a base tile covering the entire legacy ground level or an explicit grouped level;
 * ordered rectangular regions;
-* ordered `set`, `rectangle`, `rectangle_outline`, `line`, and `scatter` operations;
+* ordered, level-aware `set`, `rectangle`, `rectangle_outline`, `line`, and `scatter` operations;
 * inclusive Bresenham line rasterization;
 * deterministic scatter by count or density;
 * root-level reusable cell-pattern definitions;
-* ordered pattern placement at an anchor with fixed quarter-turn rotation;
+* ordered, level-aware pattern placement at an anchor with fixed quarter-turn rotation;
 * root-level weighted tile palettes referenced by base tiles and placement operations;
 * fixed tile rotations;
 * deterministic random rotations;
@@ -149,11 +151,13 @@ mapwidth: 32
 mapheight: 32
 populated level size: 1024
 unused levels: []
+logical z range: -10 through +10
+level-array index: logical z + 10
 ```
 
 ## 5. Generator and validator tests: complete for version 1
 
-The current Python test suite contains 44 tests and passes.
+The current Python test suite contains 53 tests and passes.
 
 Coverage includes:
 
@@ -173,6 +177,12 @@ Coverage includes:
 * unknown tile IDs;
 * palette references, weighted deterministic selection, and malformed palette rejection;
 * reusable pattern expansion, rotation, ordering, determinism, compatibility, and validation;
+* logical-z conversion and bounds;
+* legacy per-placement z targeting across every operation type;
+* grouped multi-level generation, declaration order, local overwrite order, and RNG order;
+* duplicate, ambiguous, malformed, and nested z-definition rejection;
+* exact 21-level output and validator rejection of incorrect level counts;
+* maintained two-level hill and depression recipes with structurally supported slope endpoints;
 * invalid metadata;
 * malformed tile databases;
 * out-of-bounds placement;
@@ -230,7 +240,6 @@ It does not currently support:
 * nested, shape-based, or multi-level pattern composition;
 * circles or irregular regions;
 * terrain blending;
-* multiple populated vertical levels;
 * features or furniture;
 * areas or rooms;
 * doors;
@@ -406,7 +415,7 @@ This criterion is met by weighted palettes, deterministic scatter, and reusable 
 
 ## Phase 4C — Vertical levels and 3D placement foundations
 
-**Status: next; requires schema and runtime investigation**
+**Status: in progress; structural generation delivered, runtime traversal verification remains**
 
 Dimensionfall maps already contain 21 level arrays. Level-array index `10` is logical elevation `0`, with valid logical elevations from `-10` through `+10`:
 
@@ -430,6 +439,19 @@ Goals:
 * define deterministic operation and RNG ordering across levels;
 * validate horizontal bounds, vertical bounds, duplicate level definitions, and complete pattern expansion;
 * investigate slope, stair, support, collision, and traversal semantics before enforcing gameplay rules.
+
+Delivered:
+
+* logical `z` validation from `-10` through `+10` and conversion to the fixed 21 level-array indices;
+* backwards-compatible root placement where omitted `z` remains logical level `0`;
+* optional `z` on legacy regions and every root placement operation, including pattern invocation;
+* strict grouped `levels` definitions with unique `z`, optional per-level base tiles, regions, and operations;
+* rejection of ambiguous mixing between grouped levels and root `base_tile`, `regions`, or `operations`;
+* declaration-order RNG consumption across grouped levels and existing region-before-operation ordering within each level;
+* automatic preservation of all-empty levels as `[]` and exactly 1024 entries for every populated level;
+* independent validator enforcement of exactly 21 level arrays;
+* maintained two-level hill and depression recipes using known `shape: "slope"` transition tiles;
+* focused tests for vertical bounds, compatibility, every placement type, deterministic ordering, malformed schemas, exact level shape, and slope endpoint support.
 
 Recommended compatibility form for individual placement:
 
@@ -474,10 +496,17 @@ Initial structural validation:
 * duplicate or ambiguous per-level definitions are rejected;
 * identical recipes and seeds produce identical output across every populated level.
 
-Runtime investigation must determine:
+Runtime investigation established:
 
-* how tiles with `shape: "slope"` connect adjacent logical levels;
-* how slope and stair rotation determines lower and upper endpoints;
+* `Chunk.create_block_position_dictionary_new_arraymesh()` maps level-array index `i` to world height `i - 10`;
+* tiles with `shape: "slope"` generate sloped mesh, collision, and navigation geometry within one vertical block;
+* recipe and map-editor slope rotation selects the high edge: `0` north, `90` east, `180` south, and `270` west;
+* `Chunk.get_block_rotation()` converts those newly loaded slope values before mesh, collision, and navigation code uses its internal orientation, so recipes must preserve the editor-facing values rather than pre-converting them;
+* existing hills, holes, and buildings place slope tiles on the upper of the two connected logical levels;
+* the maintained examples can therefore validate occupied high-side and lower-level low-side endpoints without inventing a broader support model.
+
+Runtime investigation must still determine:
+
 * whether transitions require corresponding tiles on both levels;
 * how floors, walls, roofs, ceilings, and intentional air gaps occupy stacked levels;
 * whether support is determined by tile presence, collision shape, or another runtime rule;
@@ -488,6 +517,8 @@ Reference fixtures should include existing hills, depressions, deep craters, bui
 ### Success criterion
 
 Generate and validate one two-level hill and one two-level depression from recipes. Each map has correctly sized populated levels, preserves unused levels as `[]`, uses valid transition tiles, loads in Godot, and permits runtime traversal between generated elevations.
+
+The structural generation, validation, transition-tile layout, and headless Godot editor-loading portions are delivered. Interactive player traversal remains to be verified before Phase 4C is complete.
 
 ## Phase 5 — Features and furniture
 
@@ -780,15 +811,17 @@ An agent can create a new playable, potentially multi-level map from a concise d
 
 # Recommended immediate next task
 
-The next contribution should begin **Phase 4C vertical-level schema and 3D placement foundations**.
+The next contribution should finish **Phase 4C runtime traversal verification and transition validation** without expanding into furniture or buildings.
 
-First inspect the runtime, content editor, tile definitions, and representative existing maps to document the authoritative logical-z, slope, stair, support, and transition behavior. Use logical `z` values from `-10` through `+10`, map `z: 0` to level-array index `10`, and keep `[x, y]` as the top-down coordinate format.
+First generate `map_recipe_two_level_hill.json` and `map_recipe_two_level_depression.json` into a development mod, inspect both in the content editor, and verify with a controllable player or an equivalent project-supported runtime test that all four slope rotations permit movement between the intended adjacent levels. Record any mismatch between mesh, collision, navigation, and player movement rather than changing the recipe contract speculatively.
 
-Then add the smallest backwards-compatible multi-level recipe contract: omitted `z` continues targeting logical level `0`; explicit per-level content can populate additional levels; every populated level contains exactly 1024 entries; unused levels remain `[]`; and all existing operations and pattern invocations use the same level-aware placement path. Reject ambiguous duplicate level definitions, invalid z values, and expansions outside horizontal or vertical bounds.
+Then convert only confirmed runtime behavior into focused automated checks. At minimum, determine whether a reliable Godot integration test can load a generated map, construct its chunk geometry, and verify slope endpoints or navigation connectivity. Keep the existing Python endpoint check structural: it may require occupied high and low neighbors, but it must not claim general walkability. Document which support and transition checks remain runtime-only.
 
-Keep this contribution focused on terrain and structural generation. Do not add furniture, semantic areas, buildings, roads, towns, nested patterns, or broad gameplay validation. Do not invent support rules that are not confirmed by the runtime.
+If traversal succeeds and an appropriate repeatable verification is in place, mark Phase 4C complete and make Phase 5 feature/furniture schema investigation next. If traversal exposes an engine issue, keep Phase 4C in progress and address the smallest runtime or recipe-example correction with regression coverage.
 
-Add focused tests for z/index conversion, legacy compatibility, multiple populated levels, determinism and RNG ordering across levels, per-level operation ordering, invalid and duplicate z definitions, horizontal and vertical bounds, exact level sizes, and unused-level preservation. Generate one two-level hill and one two-level depression, validate both maps, inspect them in the content editor, verify traversal in Godot, and run `git diff --check`.
+Do not add furniture, semantic areas, buildings, roads, towns, nested patterns, multi-level templates, or unconfirmed general support rules in this contribution.
+
+Run the complete Python suite, relevant Godot tests or smoke checks, both example generations through `Tools/map_validator.py`, and `git diff --check`.
 
 Do not commit or push unless explicitly requested.
 
@@ -810,7 +843,9 @@ Do not commit or push unless explicitly requested.
 [Complete] Development moved to snipercup/CataX
 
 [Complete] Palettes, reusable cell patterns, and deterministic variation
-[Next]     Vertical-level schema and 3D placement foundations
+[In progress] Vertical-level schema and 3D placement foundations
+[Delivered] Structural multi-level recipes, validation, and slope examples
+[Next]     Runtime traversal verification and confirmed transition checks
 [Planned]  Features and furniture
 [Planned]  Level-aware areas and buildings
 [Planned]  Roads and map connections

--- a/Documentation/Modding/map_example_generation.md
+++ b/Documentation/Modding/map_example_generation.md
@@ -8,6 +8,64 @@ Run all commands from the repository root. On the standard Hermes host checkout:
 cd ~/local/dimensionfall/repository
 ```
 
+## Generate one maintained recipe directly into the mod
+
+Use `Tools/map_generator.py` when you want to select one recipe, preserve its map ID, and publish exactly one map directly into the Dimensionfall mod:
+
+```bash
+python3 Tools/map_generator.py \
+  Tools/examples/map_recipe_two_level_hill.json \
+  Mods/Dimensionfall/Maps/generated_two_level_hill.json
+```
+
+The maintained recipe examples are:
+
+| Recipe | Output map | Purpose |
+|---|---|---|
+| `Tools/examples/map_recipe.json` | `Mods/Dimensionfall/Maps/generated_meadow_prototype.json` | Ground-level palettes, placement operations, scatter, and reusable patterns. |
+| `Tools/examples/map_recipe_two_level_hill.json` | `Mods/Dimensionfall/Maps/generated_two_level_hill.json` | Ground level `z: 0`, raised terrain at `z: 1`, and all four slope rotations. |
+| `Tools/examples/map_recipe_two_level_depression.json` | `Mods/Dimensionfall/Maps/generated_two_level_depression.json` | Ground level `z: 0`, lowered terrain at `z: -1`, and all four slope rotations. |
+
+For both multi-level examples, slope rotations use the map editor convention: `0` has its high edge north, `90` east, `180` south, and `270` west. The generator writes those values directly; Godot performs the slope-specific runtime conversion when loading a newly generated map.
+
+Copy the corresponding command for the map you want to inspect:
+
+```bash
+# Ground-level meadow
+python3 Tools/map_generator.py \
+  Tools/examples/map_recipe.json \
+  Mods/Dimensionfall/Maps/generated_meadow_prototype.json
+
+# Two-level hill
+python3 Tools/map_generator.py \
+  Tools/examples/map_recipe_two_level_hill.json \
+  Mods/Dimensionfall/Maps/generated_two_level_hill.json
+
+# Two-level depression
+python3 Tools/map_generator.py \
+  Tools/examples/map_recipe_two_level_depression.json \
+  Mods/Dimensionfall/Maps/generated_two_level_depression.json
+```
+
+The output filename should match the recipe's `id`, followed by `.json`. The generator validates the map before publishing it and refuses to replace an existing file. To deliberately regenerate the same map after editing its recipe, add `--overwrite`:
+
+```bash
+python3 Tools/map_generator.py \
+  Tools/examples/map_recipe_two_level_hill.json \
+  Mods/Dimensionfall/Maps/generated_two_level_hill.json \
+  --overwrite
+```
+
+After generating a map, start or restart Godot and follow the content-editor steps below. Files created directly with `map_generator.py` are not registered in the example runner's cleanup manifest. Remove them explicitly when manual testing is complete:
+
+```bash
+rm Mods/Dimensionfall/Maps/generated_meadow_prototype.json
+rm Mods/Dimensionfall/Maps/generated_two_level_hill.json
+rm Mods/Dimensionfall/Maps/generated_two_level_depression.json
+```
+
+Only run the removal command for a file you actually generated. These maintained IDs are intended for development examples; do not overwrite a map with the same ID if it has been repurposed as project content.
+
 ## Safe first run
 
 Generate three variants in a temporary directory:
@@ -80,6 +138,25 @@ python3 Tools/generate_map_examples.py \
   --variants 2 \
   --seed 500
 ```
+
+For example, generate one cleanup-managed hill and one cleanup-managed depression directly in the mod folder:
+
+```bash
+python3 Tools/generate_map_examples.py \
+  Tools/examples/map_recipe_two_level_hill.json \
+  Tools/examples/map_recipe_two_level_depression.json \
+  --output-dir Mods/Dimensionfall/Maps \
+  --variants 1
+```
+
+This produces:
+
+```text
+Mods/Dimensionfall/Maps/generated_two_level_hill_example_001.json
+Mods/Dimensionfall/Maps/generated_two_level_depression_example_001.json
+```
+
+Use `map_generator.py` for one exact recipe output. Use `generate_map_examples.py` when you want multiple seeds, multiple recipes in one command, or manifest-based cleanup.
 
 Use a different tile database when testing another mod's recipe:
 
@@ -159,7 +236,7 @@ for path in sorted(Path("/tmp/dimensionfall-map-examples").glob("*.json")):
     print(
         path.name,
         f"{data['mapwidth']}x{data['mapheight']}",
-        f"ground tiles={len(data['levels'][10])}",
+        f"ground entries={len(data['levels'][10])}",
         f"populated levels={populated}",
     )
 PY
@@ -168,6 +245,6 @@ PY
 ## Current limitations
 
 - Variants change the recipe seed; they do not synthesize new recipe operations.
-- Generated maps contain terrain only. Furniture, areas, buildings, semantic roads, and additional populated levels are not supported yet.
+- Generated maps contain terrain only. Multiple populated logical levels are supported, but furniture, areas, buildings, semantic roads, multi-level templates, and automatic traversal validation are not supported yet.
 - The maps can be inspected with the existing content-editor preview, but the runner does not launch Godot or inject maps into an already-running editor session.
 - Installing examples under `Mods/Dimensionfall/Maps` makes them available to the content editor, but does not automatically reference them from overmap-area generation.

--- a/Documentation/Modding/map_recipe_generator.md
+++ b/Documentation/Modding/map_recipe_generator.md
@@ -1,6 +1,6 @@
 # Recipe-driven map generator
 
-`Tools/map_generator.py` converts a compact JSON recipe into a complete Dimensionfall map JSON file. Dimensionfall maps have fixed dimensions of 32 x 32 tiles. The generator creates one populated ground level (level array index `10`) with exactly 1024 entries and leaves the other 20 levels empty.
+`Tools/map_generator.py` converts a compact JSON recipe into a complete Dimensionfall map JSON file. Dimensionfall maps have fixed dimensions of 32 x 32 tiles and 21 possible logical levels from `z: -10` through `z: 10`. Every populated level has exactly 1024 entries; unused levels remain `[]`.
 
 ## Usage
 
@@ -27,13 +27,14 @@ The root must be a JSON object with these fields:
 | `name` | non-empty string | Display name. |
 | `description` | non-empty string | Map description. |
 | `seed` | integer | Fixed seed used by palettes, random tile rotations, scatter, and pattern cells. Recipe input only; the map format does not store it. |
-| `base_tile` | tile object | Tile initially placed in every cell. |
+| `base_tile` | tile object | Legacy-mode tile initially placed in every cell at `z: 0`. Required unless `levels` is used. |
 | `palette` | object | Named weighted tile sets that tile objects can reference. Optional; defaults to `{}`. |
 | `patterns` | object | Named arrays of relative tile placements used by `pattern` operations. Optional; defaults to `{}`. |
 | `regions` | array | Legacy filled rectangles. Optional; defaults to `[]`. |
 | `operations` | array | Ordered placement operations. Optional; defaults to `[]`. |
+| `levels` | non-empty array | Explicit grouped level definitions. Cannot be combined with root `base_tile`, `regions`, or `operations`. |
 
-A recipe does not define map dimensions: all generated maps are 32 x 32. Coordinates start at the top-left. Every shape must fit entirely within the map; operations are never silently clipped.
+A recipe does not define map dimensions: all generated maps are 32 x 32. Top-down `[x, y]` coordinates start at the top-left. Logical `z` is vertical elevation, not a third element in `[x, y]`. Every shape must fit entirely within the map; operations are never silently clipped.
 
 A tile object has exactly one of:
 
@@ -60,7 +61,73 @@ Palette entries are objects with `id`, optional positive integer `weight` (defau
 }
 ```
 
-Legacy `regions` are applied first in array order, followed by `operations` in array order. Pattern cells are expanded in their definition order at the position of the invoking operation. Later placements overwrite earlier cells, including repeated offsets inside one pattern. `regions` remain supported for version-one recipes and use the same filled-rectangle placement implementation as `rectangle` operations.
+Legacy `regions` are applied first in array order, followed by `operations` in array order. Pattern cells are expanded in their definition order at the position of the invoking operation. Later placements on the same logical level overwrite earlier cells, including repeated offsets inside one pattern. `regions` remain supported for version-one recipes and use the same filled-rectangle placement implementation as `rectangle` operations.
+
+## Logical levels
+
+Map level-array index `10` is logical ground level `z: 0`. The conversion is:
+
+```text
+level-array index = logical z + 10
+logical z = level-array index - 10
+```
+
+Valid logical levels are integers from `-10` through `10`. Booleans are not integers for recipe purposes. A populated level contains 1024 row-major cells, while a level containing no non-empty tiles is serialized as unused `[]`.
+
+There are two mutually exclusive authoring modes.
+
+### Legacy-compatible root layout
+
+Existing recipes continue to use root `base_tile`, `regions`, and `operations`. The base tile fills `z: 0`. Every root region and operation accepts optional `z`; omission means `z: 0`. Targeting a previously unused level starts that level as empty cells before applying the placement.
+
+```json
+{
+  "base_tile": {"id": "grass_plain_01"},
+  "operations": [
+    {
+      "type": "pattern",
+      "pattern": "wildflower_cluster",
+      "at": [16, 12],
+      "z": 1,
+      "rotation": 90
+    }
+  ]
+}
+```
+
+Root `regions` are still processed before root `operations`, even when entries target different logical levels. RNG consumption follows this exact processing order.
+
+### Grouped multi-level layout
+
+For substantial multi-level maps, use a root `levels` array. Every entry requires one unique logical `z` and may contain `base_tile`, `regions`, and `operations`. The entry's base tile, when present, fills that level before its regions and operations. Without a base tile, the level starts empty.
+
+```json
+{
+  "levels": [
+    {
+      "z": 0,
+      "base_tile": {"id": "grass_plain_01"}
+    },
+    {
+      "z": 1,
+      "operations": [
+        {
+          "type": "rectangle",
+          "x": 10,
+          "y": 10,
+          "width": 12,
+          "height": 12,
+          "tile": {"id": "grass_plain_01"}
+        }
+      ]
+    }
+  ]
+}
+```
+
+Grouped entries are processed in declaration order. Within each entry, regions precede operations. This declaration order also defines deterministic RNG consumption across levels. Nested regions and operations inherit the entry's `z` and must not repeat a `z` field. Root `base_tile`, `regions`, and `operations` cannot coexist with `levels`; this rejects ambiguous merge and overwrite ordering.
+
+Reusable pattern definitions remain two-dimensional. A root pattern operation selects its target with `z`, while a grouped pattern operation inherits the enclosing level. Multi-level pattern and template composition is outside the current schema.
 
 ## Reusable cell patterns
 
@@ -82,11 +149,11 @@ Pattern definitions do not consume random numbers. An invoked pattern consumes r
 
 ## Placement operations
 
-Every operation requires a `type`. Unknown operation types and fields are errors.
+Every operation requires a `type`. Unknown operation types and fields are errors. At the recipe root, every operation accepts optional logical `z` and defaults to `0`. Inside a grouped level, the operation inherits `z` and must omit the field.
 
 ### `set`
 
-Places one tile. Fields: `type`, `x`, `y`, and `tile`.
+Places one tile. Fields: `type`, `x`, `y`, `tile`, and optional root-level `z`.
 
 ```json
 {"type": "set", "x": 16, "y": 15, "tile": {"id": "grass_flowers_01"}}
@@ -94,7 +161,7 @@ Places one tile. Fields: `type`, `x`, `y`, and `tile`.
 
 ### `rectangle`
 
-Fills a rectangle. Fields: `type`, `x`, `y`, positive `width`, positive `height`, and `tile`.
+Fills a rectangle. Fields: `type`, `x`, `y`, positive `width`, positive `height`, `tile`, and optional root-level `z`.
 
 ```json
 {"type": "rectangle", "x": 10, "y": 9, "width": 12, "height": 14, "tile": {"id": "grass_plain_01"}}
@@ -110,7 +177,7 @@ Places only the rectangle border and uses the same fields as `rectangle`. If wid
 
 ### `line`
 
-Places an inclusive, one-tile-wide line between integer `[x, y]` endpoints. Fields: `type`, `from`, `to`, and `tile`. Lines use the integer Bresenham algorithm, so horizontal, vertical, diagonal, steep, and reversed lines are deterministic.
+Places an inclusive, one-tile-wide line between integer `[x, y]` endpoints. Fields: `type`, `from`, `to`, `tile`, and optional root-level `z`. Lines use the integer Bresenham algorithm, so horizontal, vertical, diagonal, steep, and reversed lines are deterministic.
 
 ```json
 {"type": "line", "from": [0, 16], "to": [31, 16], "tile": {"id": "dirt_light_00"}}
@@ -118,7 +185,7 @@ Places an inclusive, one-tile-wide line between integer `[x, y]` endpoints. Fiel
 
 ### `scatter`
 
-Selects unique cells in a rectangular `region` using the recipe's seeded random-number generator. Fields: `type`, `region`, exactly one of `count` or `density`, and `tile`.
+Selects unique cells in a rectangular `region` using the recipe's seeded random-number generator. Fields: `type`, `region`, exactly one of `count` or `density`, `tile`, and optional root-level `z`.
 
 - `count` is an integer from zero through the number of cells in the region.
 - `density` is a number from `0` through `1`; the placement count is `floor(region area × density)`.
@@ -136,7 +203,7 @@ Selects unique cells in a rectangular `region` using the recipe's seeded random-
 
 ### `pattern`
 
-Places every cell from a named pattern relative to an anchor. Fields: `type`, `pattern`, `at`, and optional `rotation`. Rotation defaults to `0` and accepts fixed clockwise quarter turns: `0`, `90`, `180`, or `270`.
+Places every cell from a named pattern relative to an anchor. Fields: `type`, `pattern`, `at`, optional root-level `z`, and optional `rotation`. Rotation defaults to `0` and accepts fixed clockwise quarter turns: `0`, `90`, `180`, or `270`.
 
 Offsets rotate around the anchor: `90` maps `[x, y]` to `[-y, x]`. The generator preflights the complete expansion and rejects the operation if any resulting cell is outside the map; patterns are never clipped or partially applied.
 
@@ -151,8 +218,21 @@ Offsets rotate around the anchor: `90` maps `[x, y]` to `[-y, x]`. The generator
 
 ## Validation and limitations
 
-The generator rejects unknown fields at every recipe level, root-level dimension fields, malformed or out-of-bounds placements, malformed tile databases, unknown tile IDs, invalid rotations, invalid Unicode, and non-object recipes. It validates generated data with `Tools/map_validator.py` before publishing the output.
+The generator rejects unknown fields at every recipe level, root-level dimension fields, malformed or out-of-bounds placements, logical levels outside `-10` through `10`, duplicate grouped levels, ambiguous root/grouped layouts, malformed tile databases, unknown tile IDs, invalid rotations, invalid Unicode, and non-object recipes. It validates generated data with `Tools/map_validator.py` before publishing the output. The validator independently requires exactly 21 level arrays and exactly 1024 entries in every populated level.
 
-The output uses 21 levels, with the generated row-major grid at index 10. It sets `categories` to `[]`, `weight` to `1000`, and all four connections to `"ground"`. It omits `areas`, matching `DMap.get_data()` when the area list is empty.
+The output uses 21 levels; logical `z: 0` is row-major grid index `10`. It sets `categories` to `[]`, `weight` to `1000`, and all four connections to `"ground"`. It omits `areas`, matching `DMap.get_data()` when the area list is empty.
 
-The generator does not yet create features, furniture, areas, roads as semantic objects, buildings, towns, additional levels, nested patterns, or shape-based templates. Structural validity also does not yet guarantee walkability or gameplay quality.
+The generator does not yet create features, furniture, areas, roads as semantic objects, buildings, towns, nested or multi-level patterns, or shape-based templates. It does not infer support or transition validity from stacked tiles. Structural validity and the presence of slope tiles do not yet guarantee walkability, reachability, or gameplay quality.
+
+Maintained structural examples are available at `Tools/examples/map_recipe_two_level_hill.json` and `Tools/examples/map_recipe_two_level_depression.json`. They use `grass_ramp_00`, whose tile definition has `shape: "slope"`.
+
+Slope rotations in recipes use the same values shown by the map editor:
+
+| Rotation | High edge |
+|---:|---|
+| `0` | north |
+| `90` | east |
+| `180` | south |
+| `270` | west |
+
+The generator preserves these editor-facing values in map JSON. When a newly generated map is loaded, `Chunk.get_block_rotation()` applies the slope's shape-specific 90-degree conversion before rendered mesh, collision, and navigation geometry use the internal orientation. Do not pre-convert recipe rotations to the internal `calculate_slope_vertices()` mapping. The maintained examples exercise these known slope endpoints; they are not a general-purpose transition validator.

--- a/Tools/examples/map_recipe_two_level_depression.json
+++ b/Tools/examples/map_recipe_two_level_depression.json
@@ -1,0 +1,75 @@
+{
+	"id": "generated_two_level_depression",
+	"name": "Generated Two-Level Depression",
+	"description": "A structural multi-level example with a lowered dirt floor and four slopes.",
+	"seed": 4102,
+	"levels": [
+		{
+			"z": 0,
+			"base_tile": {
+				"id": "grass_plain_01"
+			},
+			"operations": [
+				{
+					"type": "rectangle",
+					"x": 10,
+					"y": 10,
+					"width": 12,
+					"height": 12,
+					"tile": null
+				},
+				{
+					"type": "set",
+					"x": 10,
+					"y": 15,
+					"tile": {
+						"id": "grass_ramp_00",
+						"rotation": 270
+					}
+				},
+				{
+					"type": "set",
+					"x": 21,
+					"y": 16,
+					"tile": {
+						"id": "grass_ramp_00",
+						"rotation": 90
+					}
+				},
+				{
+					"type": "set",
+					"x": 15,
+					"y": 10,
+					"tile": {
+						"id": "grass_ramp_00",
+						"rotation": 0
+					}
+				},
+				{
+					"type": "set",
+					"x": 16,
+					"y": 21,
+					"tile": {
+						"id": "grass_ramp_00",
+						"rotation": 180
+					}
+				}
+			]
+		},
+		{
+			"z": -1,
+			"operations": [
+				{
+					"type": "rectangle",
+					"x": 10,
+					"y": 10,
+					"width": 12,
+					"height": 12,
+					"tile": {
+						"id": "dirt_light_00"
+					}
+				}
+			]
+		}
+	]
+}

--- a/Tools/examples/map_recipe_two_level_hill.json
+++ b/Tools/examples/map_recipe_two_level_hill.json
@@ -1,0 +1,65 @@
+{
+	"id": "generated_two_level_hill",
+	"name": "Generated Two-Level Hill",
+	"description": "A structural multi-level example with an elevated grassy platform and four slopes.",
+	"seed": 4101,
+	"levels": [
+		{
+			"z": 0,
+			"base_tile": {
+				"id": "grass_plain_01"
+			}
+		},
+		{
+			"z": 1,
+			"operations": [
+				{
+					"type": "rectangle",
+					"x": 10,
+					"y": 10,
+					"width": 12,
+					"height": 12,
+					"tile": {
+						"id": "grass_plain_01"
+					}
+				},
+				{
+					"type": "set",
+					"x": 9,
+					"y": 15,
+					"tile": {
+						"id": "grass_ramp_00",
+						"rotation": 90
+					}
+				},
+				{
+					"type": "set",
+					"x": 22,
+					"y": 16,
+					"tile": {
+						"id": "grass_ramp_00",
+						"rotation": 270
+					}
+				},
+				{
+					"type": "set",
+					"x": 15,
+					"y": 22,
+					"tile": {
+						"id": "grass_ramp_00",
+						"rotation": 0
+					}
+				},
+				{
+					"type": "set",
+					"x": 16,
+					"y": 9,
+					"tile": {
+						"id": "grass_ramp_00",
+						"rotation": 180
+					}
+				}
+			]
+		}
+	]
+}

--- a/Tools/map_generator.py
+++ b/Tools/map_generator.py
@@ -21,6 +21,8 @@ except ImportError:  # Direct execution from Tools/.
 
 LEVEL_COUNT = 21
 POPULATED_LEVEL_INDEX = 10
+MIN_LOGICAL_Z = -POPULATED_LEVEL_INDEX
+MAX_LOGICAL_Z = LEVEL_COUNT - POPULATED_LEVEL_INDEX - 1
 MAP_WIDTH = 32
 MAP_HEIGHT = 32
 DEFAULT_CONNECTIONS = {
@@ -29,19 +31,23 @@ DEFAULT_CONNECTIONS = {
     "south": "ground",
     "west": "ground",
 }
+# Recipe rotations use the same editor-facing values stored in map JSON. Keep
+# them unchanged here; Chunk.get_block_rotation() applies shape-specific runtime
+# conversion when a newly generated map is loaded.
 VALID_ROTATIONS = (0, 90, 180, 270)
 TILE_FIELDS = {"id", "palette", "rotation"}
 PALETTE_FIELDS = {"id", "weight", "rotation"}
 DEFINITION_NAME_PATTERN = re.compile(r"[A-Za-z0-9_-]+")
-REGION_FIELDS = {"x", "y", "width", "height", "tile"}
-SET_FIELDS = {"type", "x", "y", "tile"}
-RECTANGLE_FIELDS = {"type", "x", "y", "width", "height", "tile"}
-LINE_FIELDS = {"type", "from", "to", "tile"}
-SCATTER_FIELDS = {"type", "region", "tile", "count", "density"}
+REGION_FIELDS = {"x", "y", "z", "width", "height", "tile"}
+SET_FIELDS = {"type", "x", "y", "z", "tile"}
+RECTANGLE_FIELDS = {"type", "x", "y", "z", "width", "height", "tile"}
+LINE_FIELDS = {"type", "from", "to", "z", "tile"}
+SCATTER_FIELDS = {"type", "region", "z", "tile", "count", "density"}
 SCATTER_REGION_FIELDS = {"x", "y", "width", "height"}
 PATTERN_CELL_FIELDS = {"at", "tile"}
-PATTERN_OPERATION_FIELDS = {"type", "pattern", "at", "rotation"}
+PATTERN_OPERATION_FIELDS = {"type", "pattern", "at", "z", "rotation"}
 TILE_OPERATION_TYPES = {"set", "rectangle", "rectangle_outline", "line", "scatter"}
+LEVEL_FIELDS = {"z", "base_tile", "regions", "operations"}
 RECIPE_FIELDS = {
     "id",
     "name",
@@ -52,6 +58,7 @@ RECIPE_FIELDS = {
     "patterns",
     "regions",
     "operations",
+    "levels",
 }
 
 
@@ -333,6 +340,31 @@ def _coordinate(value: Any, context: str, maximum: int) -> int:
     return value
 
 
+def _logical_z(value: Any, context: str) -> int:
+    if type(value) is not int or not MIN_LOGICAL_Z <= value <= MAX_LOGICAL_Z:
+        raise RecipeError(
+            f"{context} must be an integer between {MIN_LOGICAL_Z} and {MAX_LOGICAL_Z}"
+        )
+    return value
+
+
+def _level_index(logical_z: int) -> int:
+    return logical_z + POPULATED_LEVEL_INDEX
+
+
+def _new_empty_level() -> list[dict[str, Any]]:
+    return [{} for _ in range(MAP_WIDTH * MAP_HEIGHT)]
+
+
+def _get_or_create_level(
+    levels: list[list[dict[str, Any]]], logical_z: int
+) -> list[dict[str, Any]]:
+    index = _level_index(logical_z)
+    if not levels[index]:
+        levels[index] = _new_empty_level()
+    return levels[index]
+
+
 def _apply_set(
     level: list[dict[str, Any]],
     operation: dict[str, Any],
@@ -592,56 +624,51 @@ def _apply_pattern(
         )
 
 
-def generate_map(recipe: dict[str, Any], tiles_path: Path) -> dict[str, Any]:
-    """Validate a recipe and return map data matching DMap's saved format."""
-    if not isinstance(recipe, dict):
-        raise RecipeError("recipe must be a JSON object")
-    unknown_fields = sorted(set(recipe) - RECIPE_FIELDS)
-    if unknown_fields:
-        raise RecipeError(f"unknown recipe field '{unknown_fields[0]}'")
+def _target_z(
+    spec: dict[str, Any], context: str, inherited_z: int | None
+) -> int:
+    if inherited_z is not None:
+        if "z" in spec:
+            raise RecipeError(
+                f"{context}.z must be omitted because the enclosing level defines z"
+            )
+        return inherited_z
+    return _logical_z(spec.get("z", 0), f"{context}.z")
 
-    required_strings = ("id", "name", "description")
-    for field in required_strings:
-        if not isinstance(recipe.get(field), str) or not recipe[field].strip():
-            raise RecipeError(f"{field} must be a non-empty string")
-        _validate_unicode(recipe[field], field)
-    if re.fullmatch(r"[A-Za-z0-9_-]+", recipe["id"]) is None:
-        raise RecipeError(
-            "id may contain only letters, numbers, underscores, and hyphens"
-        )
 
-    seed = recipe.get("seed")
-    if type(seed) is not int:
-        raise RecipeError("seed must be an integer")
-    known_tiles = _tile_ids(Path(tiles_path))
-    palette = _validate_palette(recipe.get("palette", {}), known_tiles)
-    patterns = _validate_patterns(recipe.get("patterns", {}), known_tiles, palette)
-    rng = random.Random(seed)
-    level = [
-        _make_tile(
-            recipe.get("base_tile"), rng, known_tiles, "base_tile", palette=palette
-        )
-        for _ in range(MAP_WIDTH * MAP_HEIGHT)
-    ]
-
-    regions = recipe.get("regions", [])
+def _apply_layout(
+    levels: list[list[dict[str, Any]]],
+    regions: Any,
+    operations: Any,
+    rng: random.Random,
+    known_tiles: set[str],
+    palette: dict[str, list[dict[str, Any]]],
+    patterns: dict[str, list[dict[str, Any]]],
+    context_prefix: str = "",
+    inherited_z: int | None = None,
+) -> None:
+    regions_context = f"{context_prefix}regions"
     if not isinstance(regions, list):
-        raise RecipeError("regions must be an array")
+        raise RecipeError(f"{regions_context} must be an array")
     for index, region in enumerate(regions):
-        context = f"regions[{index}]"
+        context = f"{regions_context}[{index}]"
         if not isinstance(region, dict):
             raise RecipeError(f"{context} must be an object")
+        logical_z = _target_z(region, context, inherited_z)
+        level = _get_or_create_level(levels, logical_z)
         _apply_rectangle(
             level, region, rng, known_tiles, palette, context, REGION_FIELDS
         )
 
-    operations = recipe.get("operations", [])
+    operations_context = f"{context_prefix}operations"
     if not isinstance(operations, list):
-        raise RecipeError("operations must be an array")
+        raise RecipeError(f"{operations_context} must be an array")
     for index, operation in enumerate(operations):
-        context = f"operations[{index}]"
+        context = f"{operations_context}[{index}]"
         if not isinstance(operation, dict):
             raise RecipeError(f"{context} must be an object")
+        logical_z = _target_z(operation, context, inherited_z)
+        level = _get_or_create_level(levels, logical_z)
         operation_type = operation.get("type")
         if operation_type in TILE_OPERATION_TYPES and "tile" not in operation:
             raise RecipeError(f"{context}.tile is required")
@@ -668,8 +695,120 @@ def generate_map(recipe: dict[str, Any], tiles_path: Path) -> dict[str, Any]:
                 f"{context}.type has unknown operation '{operation_type}'"
             )
 
-    levels = [[] for _ in range(LEVEL_COUNT)]
-    levels[POPULATED_LEVEL_INDEX] = level
+
+def _generate_levels(
+    recipe: dict[str, Any],
+    rng: random.Random,
+    known_tiles: set[str],
+    palette: dict[str, list[dict[str, Any]]],
+    patterns: dict[str, list[dict[str, Any]]],
+) -> list[list[dict[str, Any]]]:
+    levels: list[list[dict[str, Any]]] = [[] for _ in range(LEVEL_COUNT)]
+    if "levels" not in recipe:
+        ground_level = _get_or_create_level(levels, 0)
+        for index in range(MAP_WIDTH * MAP_HEIGHT):
+            ground_level[index] = _make_tile(
+                recipe.get("base_tile"),
+                rng,
+                known_tiles,
+                "base_tile",
+                palette=palette,
+            )
+        _apply_layout(
+            levels,
+            recipe.get("regions", []),
+            recipe.get("operations", []),
+            rng,
+            known_tiles,
+            palette,
+            patterns,
+        )
+        return levels
+
+    conflicting_fields = [
+        field for field in ("base_tile", "regions", "operations") if field in recipe
+    ]
+    if conflicting_fields:
+        raise RecipeError(
+            f"recipe.{conflicting_fields[0]} cannot be combined with recipe.levels"
+        )
+    level_specs = recipe["levels"]
+    if not isinstance(level_specs, list) or not level_specs:
+        raise RecipeError("levels must be a non-empty array")
+
+    validated_specs: list[tuple[int, dict[str, Any]]] = []
+    seen_z: set[int] = set()
+    for index, level_spec in enumerate(level_specs):
+        context = f"levels[{index}]"
+        if not isinstance(level_spec, dict):
+            raise RecipeError(f"{context} must be an object")
+        unknown_fields = sorted(set(level_spec) - LEVEL_FIELDS)
+        if unknown_fields:
+            raise RecipeError(f"unknown {context} field '{unknown_fields[0]}'")
+        if "z" not in level_spec:
+            raise RecipeError(f"{context}.z is required")
+        logical_z = _logical_z(level_spec["z"], f"{context}.z")
+        if logical_z in seen_z:
+            raise RecipeError(f"{context}.z duplicates logical level {logical_z}")
+        seen_z.add(logical_z)
+        validated_specs.append((logical_z, level_spec))
+
+    for index, (logical_z, level_spec) in enumerate(validated_specs):
+        context = f"levels[{index}]"
+        level = _get_or_create_level(levels, logical_z)
+        if "base_tile" in level_spec:
+            for tile_index in range(MAP_WIDTH * MAP_HEIGHT):
+                level[tile_index] = _make_tile(
+                    level_spec["base_tile"],
+                    rng,
+                    known_tiles,
+                    f"{context}.base_tile",
+                    palette=palette,
+                )
+        _apply_layout(
+            levels,
+            level_spec.get("regions", []),
+            level_spec.get("operations", []),
+            rng,
+            known_tiles,
+            palette,
+            patterns,
+            context_prefix=f"{context}.",
+            inherited_z=logical_z,
+        )
+
+    for index, level in enumerate(levels):
+        if level and not any(level):
+            levels[index] = []
+    return levels
+
+
+def generate_map(recipe: dict[str, Any], tiles_path: Path) -> dict[str, Any]:
+    """Validate a recipe and return map data matching DMap's saved format."""
+    if not isinstance(recipe, dict):
+        raise RecipeError("recipe must be a JSON object")
+    unknown_fields = sorted(set(recipe) - RECIPE_FIELDS)
+    if unknown_fields:
+        raise RecipeError(f"unknown recipe field '{unknown_fields[0]}'")
+
+    required_strings = ("id", "name", "description")
+    for field in required_strings:
+        if not isinstance(recipe.get(field), str) or not recipe[field].strip():
+            raise RecipeError(f"{field} must be a non-empty string")
+        _validate_unicode(recipe[field], field)
+    if re.fullmatch(r"[A-Za-z0-9_-]+", recipe["id"]) is None:
+        raise RecipeError(
+            "id may contain only letters, numbers, underscores, and hyphens"
+        )
+
+    seed = recipe.get("seed")
+    if type(seed) is not int:
+        raise RecipeError("seed must be an integer")
+    known_tiles = _tile_ids(Path(tiles_path))
+    palette = _validate_palette(recipe.get("palette", {}), known_tiles)
+    patterns = _validate_patterns(recipe.get("patterns", {}), known_tiles, palette)
+    rng = random.Random(seed)
+    levels = _generate_levels(recipe, rng, known_tiles, palette, patterns)
 
     return {
         "id": recipe["id"],

--- a/Tools/map_validator.py
+++ b/Tools/map_validator.py
@@ -6,6 +6,7 @@ from typing import List, Dict, Any, Set
 
 MAP_WIDTH = 32
 MAP_HEIGHT = 32
+LEVEL_COUNT = 21
 POPULATED_LEVEL_TILE_COUNT = MAP_WIDTH * MAP_HEIGHT
 
 class MapValidationError(Exception):
@@ -107,6 +108,11 @@ class MapValidator:
         if not isinstance(levels, list):
              self.add_error(file_path, "'levels' must be an array.")
         else:
+            if len(levels) != LEVEL_COUNT:
+                self.add_error(
+                    file_path,
+                    f"Level count: expected {LEVEL_COUNT}, actual {len(levels)}"
+                )
             for level_idx, level in enumerate(levels):
                 if not isinstance(level, list):
                     self.add_error(file_path, f"Level {level_idx} is not an array (list).")

--- a/Tools/tests/test_map_generator.py
+++ b/Tools/tests/test_map_generator.py
@@ -56,6 +56,224 @@ class MapGeneratorTests(unittest.TestCase):
             [270, 0, 180, 180, 90, 180, 270, 90, 180, 0, 270, 180],
         )
 
+    def test_legacy_regions_and_every_operation_can_target_logical_z(self):
+        recipe = valid_recipe()
+        recipe["base_tile"] = {"id": "grass_plain_01"}
+        recipe["patterns"] = {
+            "one": [{"at": [0, 0], "tile": {"id": "grass_flowers_01"}}]
+        }
+        recipe["regions"] = [
+            {
+                "x": 1,
+                "y": 1,
+                "z": -1,
+                "width": 2,
+                "height": 1,
+                "tile": {"id": "dirt_light_00"},
+            }
+        ]
+        recipe["operations"] = [
+            {
+                "type": "set",
+                "x": 1,
+                "y": 1,
+                "z": 1,
+                "tile": {"id": "dirt_light_00"},
+            },
+            {
+                "type": "rectangle",
+                "x": 2,
+                "y": 1,
+                "z": 1,
+                "width": 2,
+                "height": 1,
+                "tile": {"id": "dirt_light_00"},
+            },
+            {
+                "type": "rectangle_outline",
+                "x": 4,
+                "y": 1,
+                "z": 1,
+                "width": 2,
+                "height": 2,
+                "tile": {"id": "dirt_light_00"},
+            },
+            {
+                "type": "line",
+                "from": [6, 1],
+                "to": [7, 1],
+                "z": 1,
+                "tile": {"id": "dirt_light_00"},
+            },
+            {
+                "type": "scatter",
+                "region": {"x": 8, "y": 1, "width": 1, "height": 1},
+                "count": 1,
+                "z": 1,
+                "tile": {"id": "dirt_light_00"},
+            },
+            {"type": "pattern", "pattern": "one", "at": [9, 1], "z": 1},
+        ]
+
+        levels = generate_map(recipe, TILES_PATH)["levels"]
+
+        self.assertEqual(len(levels[9]), 1024)
+        self.assertEqual(levels[9][1 * 32 + 1], {"id": "dirt_light_00"})
+        self.assertEqual(len(levels[10]), 1024)
+        self.assertEqual(len(levels[11]), 1024)
+        for x in range(1, 9):
+            self.assertEqual(levels[11][1 * 32 + x], {"id": "dirt_light_00"})
+        self.assertEqual(levels[11][1 * 32 + 9], {"id": "grass_flowers_01"})
+        self.assertTrue(all(level == [] for level in levels[:9]))
+        self.assertTrue(all(level == [] for level in levels[12:]))
+
+    def test_grouped_levels_apply_in_declaration_order_with_local_overwrites(self):
+        recipe = valid_recipe()
+        del recipe["base_tile"]
+        del recipe["regions"]
+        recipe["levels"] = [
+            {
+                "z": 1,
+                "base_tile": {"id": "grass_plain_01"},
+                "regions": [
+                    {
+                        "x": 2,
+                        "y": 2,
+                        "width": 2,
+                        "height": 1,
+                        "tile": {"id": "dirt_light_00"},
+                    }
+                ],
+                "operations": [
+                    {"type": "set", "x": 2, "y": 2, "tile": None}
+                ],
+            },
+            {"z": 0, "base_tile": {"id": "dirt_light_00"}},
+        ]
+
+        levels = generate_map(recipe, TILES_PATH)["levels"]
+
+        self.assertEqual(levels[11][2 * 32 + 2], {})
+        self.assertEqual(levels[11][2 * 32 + 3], {"id": "dirt_light_00"})
+        self.assertTrue(all(tile == {"id": "dirt_light_00"} for tile in levels[10]))
+
+    def test_grouped_levels_are_deterministic_and_consume_rng_in_declaration_order(self):
+        recipe = valid_recipe()
+        recipe["seed"] = 19
+        recipe["palette"] = {
+            "ground": [
+                {"id": "grass_plain_01", "weight": 1},
+                {"id": "grass_flowers_00", "weight": 1},
+            ]
+        }
+        del recipe["base_tile"]
+        del recipe["regions"]
+        recipe["levels"] = [
+            {"z": 1, "base_tile": {"palette": "ground"}},
+            {"z": 0, "base_tile": {"palette": "ground"}},
+        ]
+
+        first = generate_map(recipe, TILES_PATH)
+        second = generate_map(recipe, TILES_PATH)
+
+        self.assertEqual(first, second)
+        self.assertEqual(
+            [tile["id"] for tile in first["levels"][11][:6]],
+            [
+                "grass_plain_01",
+                "grass_plain_01",
+                "grass_plain_01",
+                "grass_flowers_00",
+                "grass_flowers_00",
+                "grass_flowers_00",
+            ],
+        )
+        self.assertEqual(
+            [tile["id"] for tile in first["levels"][10][:3]],
+            ["grass_flowers_00", "grass_flowers_00", "grass_plain_01"],
+        )
+
+    def test_grouped_levels_reject_ambiguous_or_malformed_definitions(self):
+        cases = [
+            ({"levels": []}, "levels must be a non-empty array"),
+            ({"levels": [42]}, r"levels\[0\] must be an object"),
+            ({"levels": [{}]}, r"levels\[0\].z is required"),
+            (
+                {"levels": [{"z": 0}, {"z": 0}]},
+                r"levels\[1\].z duplicates logical level 0",
+            ),
+            (
+                {"levels": [{"z": 0, "extra": True}]},
+                r"unknown levels\[0\] field 'extra'",
+            ),
+        ]
+        for changes, expected_message in cases:
+            with self.subTest(changes=changes):
+                recipe = valid_recipe()
+                del recipe["base_tile"]
+                del recipe["regions"]
+                recipe.update(changes)
+                with self.assertRaisesRegex(RecipeError, expected_message):
+                    generate_map(recipe, TILES_PATH)
+
+        recipe = valid_recipe()
+        recipe["levels"] = [{"z": 1}]
+        with self.assertRaisesRegex(
+            RecipeError, "recipe.base_tile cannot be combined with recipe.levels"
+        ):
+            generate_map(recipe, TILES_PATH)
+
+    def test_logical_z_rejects_boolean_and_out_of_range_values(self):
+        for invalid_z in (-11, 11, True, 1.5, "1"):
+            with self.subTest(invalid_z=invalid_z):
+                recipe = valid_recipe()
+                recipe["operations"] = [
+                    {
+                        "type": "set",
+                        "x": 0,
+                        "y": 0,
+                        "z": invalid_z,
+                        "tile": None,
+                    }
+                ]
+                with self.assertRaisesRegex(
+                    RecipeError, "must be an integer between -10 and 10"
+                ):
+                    generate_map(recipe, TILES_PATH)
+
+    def test_grouped_operations_inherit_z_and_reject_nested_z(self):
+        recipe = valid_recipe()
+        del recipe["base_tile"]
+        del recipe["regions"]
+        recipe["levels"] = [
+            {
+                "z": -1,
+                "operations": [
+                    {"type": "set", "x": 0, "y": 0, "z": -1, "tile": None}
+                ],
+            }
+        ]
+
+        with self.assertRaisesRegex(
+            RecipeError, "must be omitted because the enclosing level defines z"
+        ):
+            generate_map(recipe, TILES_PATH)
+
+    def test_explicit_level_with_only_empty_tiles_remains_unused(self):
+        recipe = valid_recipe()
+        del recipe["base_tile"]
+        del recipe["regions"]
+        recipe["levels"] = [
+            {
+                "z": 3,
+                "operations": [
+                    {"type": "set", "x": 0, "y": 0, "tile": None}
+                ],
+            }
+        ]
+
+        self.assertEqual(generate_map(recipe, TILES_PATH)["levels"][13], [])
+
     def test_rectangular_regions_replace_tiles_in_row_major_grid(self):
         recipe = valid_recipe()
         recipe["base_tile"] = {"id": "grass_plain_01"}
@@ -712,15 +930,63 @@ class MapGeneratorTests(unittest.TestCase):
                 ):
                     generate_map(recipe, TILES_PATH)
 
-    def test_example_recipe_generates_successfully(self):
-        recipe_path = ROOT / "Tools" / "examples" / "map_recipe.json"
-        generated = generate_map(
-            json.loads(recipe_path.read_text(encoding="utf-8")), TILES_PATH
-        )
+    def test_example_recipes_generate_successfully(self):
+        cases = {
+            "map_recipe.json": {10},
+            "map_recipe_two_level_hill.json": {10, 11},
+            "map_recipe_two_level_depression.json": {9, 10},
+        }
+        for filename, expected_populated_indices in cases.items():
+            with self.subTest(filename=filename):
+                recipe_path = ROOT / "Tools" / "examples" / filename
+                generated = generate_map(
+                    json.loads(recipe_path.read_text(encoding="utf-8")), TILES_PATH
+                )
 
-        self.assertEqual(generated["mapwidth"], 32)
-        self.assertEqual(generated["mapheight"], 32)
-        self.assertEqual(len(generated["levels"][10]), 1024)
+                self.assertEqual(generated["mapwidth"], 32)
+                self.assertEqual(generated["mapheight"], 32)
+                self.assertEqual(
+                    {
+                        index
+                        for index, level in enumerate(generated["levels"])
+                        if level
+                    },
+                    expected_populated_indices,
+                )
+                for index in expected_populated_indices:
+                    self.assertEqual(len(generated["levels"][index]), 1024)
+
+    def test_multi_level_examples_have_supported_slope_endpoints(self):
+        high_direction = {
+            0: (0, -1),
+            90: (1, 0),
+            180: (0, 1),
+            270: (-1, 0),
+        }
+        for filename in (
+            "map_recipe_two_level_hill.json",
+            "map_recipe_two_level_depression.json",
+        ):
+            with self.subTest(filename=filename):
+                recipe_path = ROOT / "Tools" / "examples" / filename
+                generated = generate_map(
+                    json.loads(recipe_path.read_text(encoding="utf-8")), TILES_PATH
+                )
+                slopes = []
+                for level_index, level in enumerate(generated["levels"]):
+                    for tile_index, tile in enumerate(level):
+                        if tile.get("id") == "grass_ramp_00":
+                            slopes.append((level_index, tile_index, tile))
+
+                self.assertEqual(len(slopes), 4)
+                for level_index, tile_index, tile in slopes:
+                    x = tile_index % 32
+                    y = tile_index // 32
+                    delta_x, delta_y = high_direction[tile.get("rotation", 0)]
+                    high_index = (y + delta_y) * 32 + x + delta_x
+                    low_index = (y - delta_y) * 32 + x - delta_x
+                    self.assertTrue(generated["levels"][level_index][high_index])
+                    self.assertTrue(generated["levels"][level_index - 1][low_index])
 
     def test_invalid_unicode_metadata_is_rejected_with_a_clear_error(self):
         with tempfile.TemporaryDirectory() as directory:
@@ -827,6 +1093,22 @@ class MapValidatorDimensionTests(unittest.TestCase):
 
         self.assertEqual(map_data["levels"][0], [])
         self.assertEqual(self.validate(map_data), [])
+
+    def test_rejects_incorrect_level_count(self):
+        for count in (20, 22):
+            with self.subTest(count=count):
+                map_data = generate_map(valid_recipe(), TILES_PATH)
+                if count == 20:
+                    map_data["levels"].pop()
+                else:
+                    map_data["levels"].append([])
+
+                errors = self.validate(map_data)
+
+                self.assertTrue(any("Level count" in error for error in errors))
+                self.assertTrue(
+                    any(f"expected 21, actual {count}" in error for error in errors)
+                )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

Adds the structural foundation for generating Dimensionfall maps with
multiple populated logical levels.

## Changes

- support logical `z` values from `-10` through `10`
- map logical z to level-array index with `index = z + 10`
- preserve existing recipe behavior by defaulting omitted z to `0`
- allow root regions and every placement operation to target a logical level
- add grouped `levels` definitions for substantial multi-level recipes
- reject duplicate levels and ambiguous root/grouped layout combinations
- preserve deterministic RNG and operation ordering across levels
- serialize populated levels with exactly 1024 entries
- preserve unused and all-empty levels as `[]`
- require exactly 21 level arrays in the independent map validator
- add maintained two-level hill and depression recipes
- document slope rotation and the multi-level recipe contract
- update the map-generation roadmap

## Compatibility

Recipes without `levels` continue using the existing root `base_tile`,
`regions`, and `operations` structure. Placements without `z` continue
targeting logical level `0`, corresponding to level-array index `10`.

Grouped `levels` cannot be mixed with root `base_tile`, `regions`, or
`operations`, preventing ambiguous ordering.

## Validation

- `python3 -m unittest discover -s Tools/tests`
  - 53 tests passed
- Python compilation passed
- both multi-level examples generated successfully
- both generated maps passed `Tools/map_validator.py`
- Godot 4.7 headless editor initialization completed successfully
- `git diff --check` passed

## Known remaining work

This PR establishes structural multi-level generation and known slope
endpoint layouts. It does not claim general walkability, support, or
reachability validation.

Interactive player traversal across every slope orientation remains the
next Phase 4C verification step. Furniture, areas, buildings, roads,
nested patterns, and multi-level templates remain out of scope.