### PR TITLE
Verify generated slope runtime geometry

### DIFF
--- a/Documentation/Game_design/Map_generation_plan.md
+++ b/Documentation/Game_design/Map_generation_plan.md
@@ -157,7 +157,7 @@ level-array index: logical z + 10
 
 ## 5. Generator and validator tests: complete for version 1
 
-The current Python test suite contains 53 tests and passes.
+The current Python test suite contains 53 tests and passes. A focused four-test GUT suite also verifies the slope rotation contract across runtime geometry paths.
 
 Coverage includes:
 
@@ -183,6 +183,9 @@ Coverage includes:
 * duplicate, ambiguous, malformed, and nested z-definition rejection;
 * exact 21-level output and validator rejection of incorrect level counts;
 * maintained two-level hill and depression recipes with structurally supported slope endpoints;
+* editor-facing slope rotation conversion and rendered-mesh high edges in Godot;
+* matching collision high edges for all four slope rotations;
+* matching navigation-source high edges for all four slope rotations;
 * invalid metadata;
 * malformed tile databases;
 * out-of-bounds placement;
@@ -451,7 +454,9 @@ Delivered:
 * automatic preservation of all-empty levels as `[]` and exactly 1024 entries for every populated level;
 * independent validator enforcement of exactly 21 level arrays;
 * maintained two-level hill and depression recipes using known `shape: "slope"` transition tiles;
-* focused tests for vertical bounds, compatibility, every placement type, deterministic ordering, malformed schemas, exact level shape, and slope endpoint support.
+* focused tests for vertical bounds, compatibility, every placement type, deterministic ordering, malformed schemas, exact level shape, and slope endpoint support;
+* focused GUT tests for editor-to-runtime slope conversion and matching mesh, collider, and navigation-source high edges;
+* robust convex slope-collider construction that initializes the shape before assigning it to a collision node.
 
 Recommended compatibility form for individual placement:
 
@@ -483,7 +488,7 @@ For larger recipes, prefer grouping content by logical level rather than repeati
 }
 ```
 
-The detailed schema must define whether legacy root-level placement can coexist with a `levels` entry for `z: 0`. Ambiguous ordering must be rejected unless an explicit merge contract is adopted.
+Legacy root-level `base_tile`, `regions`, and `operations` cannot coexist with grouped `levels`. The generator rejects that ambiguous layout instead of inventing merge or overwrite ordering.
 
 Initial structural validation:
 
@@ -504,13 +509,15 @@ Runtime investigation established:
 * `Chunk.get_block_rotation()` converts those newly loaded slope values before mesh, collision, and navigation code uses its internal orientation, so recipes must preserve the editor-facing values rather than pre-converting them;
 * existing hills, holes, and buildings place slope tiles on the upper of the two connected logical levels;
 * the maintained examples can therefore validate occupied high-side and lower-level low-side endpoints without inventing a broader support model.
+* focused GUT coverage confirms all four editor rotations produce matching high edges in rendered mesh vertices, convex collision geometry, and navigation-source faces.
 
 Runtime investigation must still determine:
 
 * whether transitions require corresponding tiles on both levels;
 * how floors, walls, roofs, ceilings, and intentional air gaps occupy stacked levels;
 * whether support is determined by tile presence, collision shape, or another runtime rule;
-* which transition, support, and reachability checks can be reproduced reliably in Python.
+* whether the asynchronously baked navigation mesh joins the lower and upper walkable surfaces for every slope orientation;
+* which broader transition, support, and reachability checks belong in Python, Godot unit tests, or later gameplay validation.
 
 Reference fixtures should include existing hills, depressions, deep craters, buildings, and underground maps such as `field_grass_hill_00`, `field_grass_hole_00`, `crater_small`, `two_story_house`, and `underground_lab`.
 
@@ -518,7 +525,7 @@ Reference fixtures should include existing hills, depressions, deep craters, bui
 
 Generate and validate one two-level hill and one two-level depression from recipes. Each map has correctly sized populated levels, preserves unused levels as `[]`, uses valid transition tiles, loads in Godot, and permits runtime traversal between generated elevations.
 
-The structural generation, validation, transition-tile layout, and headless Godot editor-loading portions are delivered. Interactive player traversal remains to be verified before Phase 4C is complete.
+The structural generation, validation, transition-tile layout, headless Godot editor loading, and deterministic mesh/collision/navigation-source orientation checks are delivered. Asynchronous navigation baking and interactive player traversal remain to be verified before Phase 4C is complete.
 
 ## Phase 5 — Features and furniture
 
@@ -811,11 +818,11 @@ An agent can create a new playable, potentially multi-level map from a concise d
 
 # Recommended immediate next task
 
-The next contribution should finish **Phase 4C runtime traversal verification and transition validation** without expanding into furniture or buildings.
+The next contribution should finish **Phase 4C baked-navigation and player-traversal verification** without expanding into furniture or buildings.
 
-First generate `map_recipe_two_level_hill.json` and `map_recipe_two_level_depression.json` into a development mod, inspect both in the content editor, and verify with a controllable player or an equivalent project-supported runtime test that all four slope rotations permit movement between the intended adjacent levels. Record any mismatch between mesh, collision, navigation, and player movement rather than changing the recipe contract speculatively.
+Generate `map_recipe_two_level_hill.json` and `map_recipe_two_level_depression.json` into a development mod, inspect both in the content editor, and verify with a controllable player that all four slope rotations permit movement between the intended adjacent levels in both directions. Record any mismatch between the already-tested mesh, collision, and navigation-source high edges and the asynchronously baked navigation mesh or player movement.
 
-Then convert only confirmed runtime behavior into focused automated checks. At minimum, determine whether a reliable Godot integration test can load a generated map, construct its chunk geometry, and verify slope endpoints or navigation connectivity. Keep the existing Python endpoint check structural: it may require occupied high and low neighbors, but it must not claim general walkability. Document which support and transition checks remain runtime-only.
+If the navigation bake can be awaited reliably without making GUT slow or flaky, add a narrow Godot integration test that confirms lower and upper surfaces are connected for each rotation. Otherwise, document baked connectivity and player traversal as manual runtime checks. Keep the Python endpoint check structural; it may require occupied high and low neighbors, but it must not claim general walkability.
 
 If traversal succeeds and an appropriate repeatable verification is in place, mark Phase 4C complete and make Phase 5 feature/furniture schema investigation next. If traversal exposes an engine issue, keep Phase 4C in progress and address the smallest runtime or recipe-example correction with regression coverage.
 
@@ -845,7 +852,7 @@ Do not commit or push unless explicitly requested.
 [Complete] Palettes, reusable cell patterns, and deterministic variation
 [In progress] Vertical-level schema and 3D placement foundations
 [Delivered] Structural multi-level recipes, validation, and slope examples
-[Next]     Runtime traversal verification and confirmed transition checks
+[Next]     Baked-navigation and player-traversal verification
 [Planned]  Features and furniture
 [Planned]  Level-aware areas and buildings
 [Planned]  Roads and map connections

--- a/Documentation/Modding/map_example_generation.md
+++ b/Documentation/Modding/map_example_generation.md
@@ -28,6 +28,16 @@ The maintained recipe examples are:
 
 For both multi-level examples, slope rotations use the map editor convention: `0` has its high edge north, `90` east, `180` south, and `270` west. The generator writes those values directly; Godot performs the slope-specific runtime conversion when loading a newly generated map.
 
+When manually testing either multi-level example, check every slope from both directions:
+
+1. approach from the lower-level side;
+2. walk up the visible slope and onto the high-side tile;
+3. turn around and walk back down;
+4. confirm there is no invisible wall or collision plane with a different orientation;
+5. repeat for north, east, south, and west high edges.
+
+Automated GUT coverage verifies that conversion, rendering vertices, collision geometry, and navigation-source faces agree on each high edge. Manual testing is still required to confirm the asynchronously baked navigation mesh and player controller traverse the complete transition correctly.
+
 Copy the corresponding command for the map you want to inspect:
 
 ```bash
@@ -215,6 +225,15 @@ Show all command options:
 
 ```bash
 python3 Tools/generate_map_examples.py --help
+```
+
+Run the focused Godot slope-geometry regression suite:
+
+```bash
+godot --headless --path . \
+  -s addons/gut/gut_cmdln.gd \
+  -gtest=Tests/Unit/test_chunk_slope_rotation.gd \
+  -gexit
 ```
 
 Validate all generated maps in a temporary output directory:

--- a/Documentation/Modding/map_recipe_generator.md
+++ b/Documentation/Modding/map_recipe_generator.md
@@ -235,4 +235,6 @@ Slope rotations in recipes use the same values shown by the map editor:
 | `180` | south |
 | `270` | west |
 
-The generator preserves these editor-facing values in map JSON. When a newly generated map is loaded, `Chunk.get_block_rotation()` applies the slope's shape-specific 90-degree conversion before rendered mesh, collision, and navigation geometry use the internal orientation. Do not pre-convert recipe rotations to the internal `calculate_slope_vertices()` mapping. The maintained examples exercise these known slope endpoints; they are not a general-purpose transition validator.
+The generator preserves these editor-facing values in map JSON. When a newly generated map is loaded, `Chunk.get_block_rotation()` applies the slope's shape-specific conversion before rendered mesh, collision, and navigation geometry use the internal orientation. Do not pre-convert recipe rotations to the internal `calculate_slope_vertices()` mapping.
+
+`Tests/Unit/test_chunk_slope_rotation.gd` verifies all four editor rotations against the converted runtime rotation and confirms matching high edges in rendered mesh vertices, convex collision geometry, and navigation-source faces. The Python example test separately confirms that the authored high-side tile and lower-level low-side tile are occupied. These checks do not bake a navigation mesh or drive a player, so final walkability in both directions remains a Godot runtime verification.

--- a/Scripts/Chunk.gd
+++ b/Scripts/Chunk.gd
@@ -1158,15 +1158,18 @@ func _create_cube_collider(block_sub_position: Vector3) -> CollisionShape3D:
 # Creates a collider for a slope and puts it at the right place and rotation
 func _create_slope_collider(block_sub_position: Vector3, block_rotation: int) -> CollisionShape3D:
 	var collider = CollisionShape3D.new()
-	collider.shape = ConvexPolygonShape3D.new()
-	collider.shape.points = [
-		Vector3(0.5, 0.5, 0.5),
-		Vector3(0.5, 0.5, -0.5),
-		Vector3(-0.5, -0.5, 0.5),
-		Vector3(0.5, -0.5, 0.5),
-		Vector3(0.5, -0.5, -0.5),
-		Vector3(-0.5, -0.5, -0.5)
-	]
+	var shape = ConvexPolygonShape3D.new()
+	shape.points = PackedVector3Array(
+		[
+			Vector3(0.5, 0.5, 0.5),
+			Vector3(0.5, 0.5, -0.5),
+			Vector3(-0.5, -0.5, 0.5),
+			Vector3(0.5, -0.5, 0.5),
+			Vector3(0.5, -0.5, -0.5),
+			Vector3(-0.5, -0.5, -0.5)
+		]
+	)
+	collider.shape = shape
 	# Apply rotation for slopes
 	var rotation_transform = Transform3D(
 		Basis().rotated(Vector3.UP, deg_to_rad(block_rotation)), Vector3.ZERO

--- a/Tests/Unit/test_chunk_slope_rotation.gd
+++ b/Tests/Unit/test_chunk_slope_rotation.gd
@@ -1,0 +1,107 @@
+extends GutTest
+
+const SLOPE_CASES := [
+	{"editor_rotation": 0, "internal_rotation": 90, "high_edge": Vector2i(0, -1)},
+	{"editor_rotation": 90, "internal_rotation": 0, "high_edge": Vector2i(1, 0)},
+	{"editor_rotation": 180, "internal_rotation": 270, "high_edge": Vector2i(0, 1)},
+	{"editor_rotation": 270, "internal_rotation": 180, "high_edge": Vector2i(-1, 0)},
+]
+
+var test_chunk: Chunk
+
+
+func before_each():
+	test_chunk = Chunk.new()
+	test_chunk.source_geometry_data = NavigationMeshSourceGeometryData3D.new()
+
+
+func after_each():
+	if test_chunk and is_instance_valid(test_chunk):
+		test_chunk.free()
+
+
+func test_editor_slope_rotations_convert_to_internal_rotations():
+	for slope_case in SLOPE_CASES:
+		assert_eq(
+			test_chunk.get_block_rotation("slope", slope_case.editor_rotation),
+			slope_case.internal_rotation,
+			"Editor rotation %d should use internal rotation %d."
+			% [slope_case.editor_rotation, slope_case.internal_rotation]
+		)
+
+
+func test_converted_slope_mesh_has_expected_high_edge():
+	for slope_case in SLOPE_CASES:
+		var vertices := test_chunk.calculate_slope_vertices(
+			slope_case.internal_rotation, Vector3.ZERO
+		)
+		assert_eq(
+			_high_edge_from_vertices(vertices.slice(0, 4), Vector2.ZERO),
+			slope_case.high_edge,
+			"Editor rotation %d should produce the expected mesh high edge."
+			% slope_case.editor_rotation
+		)
+
+
+func test_converted_slope_collider_has_expected_high_edge():
+	for slope_case in SLOPE_CASES:
+		var collider := test_chunk._create_slope_collider(
+			Vector3.ZERO, slope_case.internal_rotation
+		)
+		add_child(collider)
+		await get_tree().process_frame
+
+		var transformed_points := PackedVector3Array()
+		for point in collider.shape.points:
+			transformed_points.append(collider.transform.basis * point)
+		assert_eq(
+			_high_edge_from_vertices(transformed_points, Vector2.ZERO),
+			slope_case.high_edge,
+			"Editor rotation %d should produce the expected collider high edge."
+			% slope_case.editor_rotation
+		)
+		collider.queue_free()
+		await get_tree().process_frame
+
+
+func test_converted_slope_navigation_faces_have_expected_high_edge():
+	var block_position := Vector3(16, 0, 16)
+	var block_center := Vector2(block_position.x + 0.5, block_position.z + 0.5)
+	for slope_case in SLOPE_CASES:
+		test_chunk.source_geometry_data.clear()
+		test_chunk.add_mesh_to_navigation_data(
+			block_position, slope_case.internal_rotation, "slope"
+		)
+		assert_eq(
+			_high_edge_from_vertices(
+				_navigation_vertices(test_chunk.source_geometry_data.get_vertices()), block_center
+			),
+			slope_case.high_edge,
+			"Editor rotation %d should produce the expected navigation high edge."
+			% slope_case.editor_rotation
+		)
+
+
+func _navigation_vertices(values: PackedFloat32Array) -> PackedVector3Array:
+	var vertices := PackedVector3Array()
+	for index in range(0, values.size(), 3):
+		vertices.append(Vector3(values[index], values[index + 1], values[index + 2]))
+	return vertices
+
+
+func _high_edge_from_vertices(vertices: PackedVector3Array, center: Vector2) -> Vector2i:
+	var highest_y := -INF
+	for vertex in vertices:
+		highest_y = max(highest_y, vertex.y)
+
+	var high_center := Vector2.ZERO
+	var high_count := 0
+	for vertex in vertices:
+		if is_equal_approx(vertex.y, highest_y):
+			high_center += Vector2(vertex.x, vertex.z)
+			high_count += 1
+	high_center = high_center / high_count - center
+
+	if abs(high_center.x) > abs(high_center.y):
+		return Vector2i(int(sign(high_center.x)), 0)
+	return Vector2i(0, int(sign(high_center.y)))

--- a/Tests/Unit/test_chunk_slope_rotation.gd.uid
+++ b/Tests/Unit/test_chunk_slope_rotation.gd.uid
@@ -1,0 +1,1 @@
+uid://b4pnrl3e7l186


### PR DESCRIPTION
## Summary

Advance Phase 4C of the recipe-driven map-generation plan by
automating the deterministic Godot slope-geometry contract.

- add focused GUT coverage for all four editor-facing slope rotations;
- verify editor-to-runtime rotation conversion;
- verify rendered mesh high-edge orientation;
- verify convex collider high-edge orientation;
- verify navigation-source high-edge orientation;
- initialize convex slope shapes before assigning them to collision nodes;
- document the remaining baked-navigation and player-traversal checks;
- update the map-generation roadmap and manual example workflow.

## Rotation contract

| Editor rotation | High edge | Runtime rotation |
|---:|---|---:|
| 0 | north | 90 |
| 90 | east | 0 |
| 180 | south | 270 |
| 270 | west | 180 |

Recipe rotations remain editor-facing and are preserved in generated
map JSON. `Chunk.get_block_rotation()` performs the runtime conversion.

## Collider fix

The new collision test exposed a Godot convex-hull error caused by
assigning an empty `ConvexPolygonShape3D` to a collision node before
setting its points.

The shape is now fully initialized with a `PackedVector3Array` before
being assigned to `CollisionShape3D`.

Fixes #713 

## Validation

- Python map-tool tests: 53/53 passed
- Full Godot GUT suite: 72/72 passed, 315 assertions
- Focused slope GUT suite: 4/4 passed, 16 assertions
- Two-level hill generated and validated
- Two-level depression generated and validated
- Every populated generated level contains 1024 entries
- Python compilation passed
- Godot 4.7 headless editor initialization passed
- `git diff --check` passed

Existing unrelated GUT warnings, orphan reports, optional-directory
messages, and shutdown leak diagnostics remain visible.

## Remaining Phase 4C work

This PR verifies deterministic mesh, collision, and navigation-source
geometry. It does not claim that asynchronous navigation baking or
player-controller traversal is correct.

The next Phase 4C task is to test all four slopes in both maintained
examples from both directions with a controllable player. If reliable,
baked navigation connectivity may then be added as a narrow Godot
integration test.