### PR TITLE
Add level-aware single-cell furniture generation

### DIFF
--- a/Documentation/Game_design/Map_generation_plan.md
+++ b/Documentation/Game_design/Map_generation_plan.md
@@ -459,6 +459,7 @@ Delivered:
 * focused GUT tests for editor-to-runtime slope conversion and matching mesh, collider, and navigation-source high edges;
 * robust convex slope-collider construction that initializes the shape before assigning it to a collision node;
 * an explicit `navigation_mesh_baked` completion signal for deterministic asynchronous verification;
+* safe handling of stale asynchronous bake callbacks when a chunk has already begun unloading;
 * focused Godot integration coverage that bakes one chunk navigation map and verifies low-to-high and high-to-low paths for every slope orientation;
 * manual player-controller verification on the maintained two-level hill and depression maps, covering all four slope orientations in both directions without traversal or invisible-collision problems.
 
@@ -534,51 +535,55 @@ This success criterion is met. The maintained recipes generate valid two-level m
 
 ## Phase 5 — Features and furniture
 
-**Status: next; requires schema investigation**
+**Status: in progress; schema investigation and explicit single-cell placement delivered**
 
 This is where generated maps start becoming playable rather than merely visual.
 
-The agent should first determine:
+Schema investigation established:
 
-* how features are represented;
-* how furniture or objects are stored;
-* whether objects belong directly to tiles or separate arrays;
-* how rotation and state are encoded;
-* how IDs are validated;
-* whether occupied tiles require supporting terrain;
-* how multi-tile objects work;
-* whether tall features occupy or block cells on adjacent logical levels.
+* newly generated furniture is stored as one `feature` dictionary embedded directly in a non-empty terrain tile, not in a separate map-level object array;
+* the serialized feature uses `type: "furniture"`, a furniture `id`, an editor-facing quarter-turn `rotation`, and optional `itemgroups`;
+* no state or mode field is present in authored map features; blueprint `mode` appears only in saved runtime furniture data;
+* logical height is inherited from the containing level-array index, and `Chunk.process_level_data()` converts index `i` to world height `i - 10`;
+* runtime furniture data chooses the static or physics spawner from the referenced furniture definition's `moveable` property;
+* furniture IDs come from the merged furniture definitions; the generator validates against the selected `Furniture.json` database for this initial core-mod workflow;
+* the map editor permits only one feature dictionary per terrain cell and writes an empty `itemgroups` array when no container contents are selected;
+* existing map data does not encode a general multi-tile footprint or adjacent-level occupancy contract, so neither is inferred in this first slice.
 
-Likely recipe concepts:
+Delivered recipe concept:
 
 ```json
 {
-  "features": [
-    {
-      "template": "tree",
-      "at": [5, 8],
-      "z": 0
-    },
-    {
-      "template": "bench",
-      "at": [15, 13],
-      "z": 0,
-      "rotation": 90
-    }
-  ]
+  "type": "furniture",
+  "x": 15,
+  "y": 13,
+  "z": 0,
+  "id": "bench_garden",
+  "rotation": 90
 }
 ```
 
-Necessary validation:
+Delivered:
 
-* known feature IDs;
-* horizontal and vertical bounds;
-* occupied-cell conflicts;
-* support rules on the target logical level;
-* conflicts with incompatible geometry above or below;
-* prohibited overlap;
-* deterministic scatter;
-* placement failure reporting.
+* root-level furniture operations with optional logical `z`, defaulting to `0` consistently with existing operations;
+* grouped-level furniture operations that inherit the enclosing logical level and reject repeated nested `z`;
+* strict operation fields, horizontal and vertical bounds, known furniture-ID checks, and fixed quarter-turn rotation validation;
+* required supporting terrain on the target cell and rejection when that tile already has a feature;
+* explicit ordered behavior: a duplicate furniture placement conflicts, while a later terrain operation replaces the complete earlier tile and feature;
+* established map/editor serialization with `type`, `id`, `rotation`, and empty `itemgroups`;
+* lazy furniture-database loading so terrain-only recipes remain compatible and do not require furniture data;
+* independent structural validator checks for furniture feature fields, ID shape, rotation, and itemgroup arrays;
+* a maintained `generated_furnished_clearing` recipe at logical `z: 0` using a garden bench, tree, and pine tree;
+* Python coverage for root and grouped logical levels, exact serialization, support and feature conflicts, operation ordering, strict validation, compatibility, and maintained-example output;
+* Godot coverage confirming `Chunk.process_level_data()` preserves the feature and derives the expected world height from its serialized logical level.
+
+Still required before Phase 5 is complete:
+
+* deterministic furniture palettes and/or scatter suitable for natural outdoor distribution;
+* a broader maintained outdoor composition containing representative trees, rocks, vegetation, and simple decorative or interactable objects;
+* conflict-aware scatter candidate selection and clear failure reporting when requested density cannot fit;
+* decisions about furniture itemgroup authoring, movable furniture examples, multi-tile footprints, tall features, and adjacent-level conflicts, each introduced only when supported by runtime evidence;
+* runtime/manual inspection of the maintained furnished clearing.
 
 ### Success criterion
 
@@ -823,15 +828,13 @@ An agent can create a new playable, potentially multi-level map from a concise d
 
 # Recommended immediate next task
 
-The next contribution should begin **Phase 5 feature and furniture schema investigation**, followed by the smallest useful level-aware implementation.
+The next contribution should advance **Phase 5** with deterministic, conflict-aware outdoor furniture distribution while retaining the delivered single-cell feature contract.
 
-First inspect representative maps, `DMap`/`DTile`, runtime furniture data, furniture spawners, and the content editor to establish the existing serialized feature contract. Document how a single-cell furniture feature stores its type, ID, rotation, state or mode, and logical level; how furniture IDs are validated; and which conflicts the runtime already prevents or permits.
+Investigate representative natural furniture IDs and then add one narrow reusable selection mechanism for furniture, preferably named weighted furniture palettes plus a bounded scatter operation. Scatter must select only cells that already have terrain and no feature, consume RNG in documented deterministic order, reject unknown IDs and malformed weights, and fail clearly when the requested count exceeds eligible cells. Keep logical `z` explicit at the root and inherited inside grouped levels.
 
-Then add only the narrowest generator support justified by that investigation: explicit level-aware placement of known single-cell furniture features, strict schema and ID validation, deterministic overwrite or conflict behavior, and one maintained outdoor example at logical `z: 0`. Reuse the existing tile `feature` representation rather than introducing a parallel object array.
+Extend the maintained furnished clearing with representative trees, rocks, vegetation, and one simple decorative or interactable object. Do not add multi-tile furniture, itemgroup population, automatic adjacent-level support inference, rooms, buildings, roads, towns, nested patterns, or generalized feature templates in this contribution.
 
-Do not add multi-tile furniture, automatic support inference, rooms, buildings, roads, towns, nested patterns, or broad placement systems in the first Phase 5 contribution. Preserve backwards compatibility for terrain-only recipes and keep all feature placement explicitly level-aware from its first version.
-
-Run the complete Python suite, relevant Godot tests or smoke checks, both example generations through `Tools/map_validator.py`, and `git diff --check`.
+Run the complete Python suite, relevant Godot tests or smoke checks, all maintained example generations through `Tools/map_validator.py`, and `git diff --check`.
 
 Do not commit or push unless explicitly requested.
 
@@ -855,8 +858,9 @@ Do not commit or push unless explicitly requested.
 [Complete] Palettes, reusable cell patterns, and deterministic variation
 [Complete] Vertical-level schema and 3D placement foundations
 [Complete] Structural generation, slope geometry, baked paths, and player traversal
-[Next]     Feature and furniture schema investigation
-[Planned]  Level-aware single-cell furniture placement
+[Complete] Feature and furniture schema investigation
+[Complete] Level-aware single-cell furniture placement
+[Next]     Deterministic conflict-aware outdoor furniture distribution
 [Planned]  Level-aware areas and buildings
 [Planned]  Roads and map connections
 [Planned]  Multi-level reusable templates and richer composition

--- a/Documentation/Modding/map_example_generation.md
+++ b/Documentation/Modding/map_example_generation.md
@@ -23,6 +23,7 @@ The maintained recipe examples are:
 | Recipe | Output map | Purpose |
 |---|---|---|
 | `Tools/examples/map_recipe.json` | `Mods/Dimensionfall/Maps/generated_meadow_prototype.json` | Ground-level palettes, placement operations, scatter, and reusable patterns. |
+| `Tools/examples/map_recipe_furniture_outdoor.json` | `Mods/Dimensionfall/Maps/generated_furnished_clearing.json` | Explicit known single-cell furniture on supported terrain at logical `z: 0`. |
 | `Tools/examples/map_recipe_two_level_hill.json` | `Mods/Dimensionfall/Maps/generated_two_level_hill.json` | Ground level `z: 0`, raised terrain at `z: 1`, and all four slope rotations. |
 | `Tools/examples/map_recipe_two_level_depression.json` | `Mods/Dimensionfall/Maps/generated_two_level_depression.json` | Ground level `z: 0`, lowered terrain at `z: -1`, and all four slope rotations. |
 
@@ -45,6 +46,11 @@ Copy the corresponding command for the map you want to inspect:
 python3 Tools/map_generator.py \
   Tools/examples/map_recipe.json \
   Mods/Dimensionfall/Maps/generated_meadow_prototype.json
+
+# Ground-level furnished clearing
+python3 Tools/map_generator.py \
+  Tools/examples/map_recipe_furniture_outdoor.json \
+  Mods/Dimensionfall/Maps/generated_furnished_clearing.json
 
 # Two-level hill
 python3 Tools/map_generator.py \
@@ -70,6 +76,7 @@ After generating a map, start or restart Godot and follow the content-editor ste
 
 ```bash
 rm Mods/Dimensionfall/Maps/generated_meadow_prototype.json
+rm Mods/Dimensionfall/Maps/generated_furnished_clearing.json
 rm Mods/Dimensionfall/Maps/generated_two_level_hill.json
 rm Mods/Dimensionfall/Maps/generated_two_level_depression.json
 ```
@@ -135,6 +142,8 @@ Content Manager
 
 If Godot was already running when files were generated, restart it so mod content is loaded again. The existing map-editor preview displays generated map JSON; the Python tool does not create a separate image or HTML preview.
 
+For the maintained furnished clearing, confirm that the editor shows a garden bench at `[16, 16]`, a tree at `[12, 12]`, and a pine tree at `[20, 12]`. Use `save and test` to confirm that the referenced static furniture spawns on the ground-level terrain with the authored rotations. The recipe intentionally leaves `itemgroups` empty and does not exercise container contents, movable furniture, multi-cell occupancy, or cross-level support rules.
+
 Dimensionfall also looks for a same-named `.png` map sprite during startup. The runner intentionally generates map JSON only, so Godot currently logs a non-fatal missing-resource error for that sprite. This does not prevent the JSON map from loading or the map editor's tile-grid preview from rendering it.
 
 ## Generate from specific recipes
@@ -168,7 +177,7 @@ Mods/Dimensionfall/Maps/generated_two_level_depression_example_001.json
 
 Use `map_generator.py` for one exact recipe output. Use `generate_map_examples.py` when you want multiple seeds, multiple recipes in one command, or manifest-based cleanup.
 
-Use a different tile database when testing another mod's recipe:
+Use different tile and furniture databases when testing another mod's furniture recipe:
 
 ```bash
 python3 Tools/generate_map_examples.py \
@@ -176,6 +185,8 @@ python3 Tools/generate_map_examples.py \
   --output-dir /tmp/dimensionfall-map-examples \
   --tiles path/to/Tiles.json
 ```
+
+The example runner infers `Furniture/Furniture.json` beside the selected `Tiles` directory. For a one-map invocation whose furniture database lives elsewhere, use `Tools/map_generator.py --furniture path/to/Furniture.json`.
 
 ## Overwrite protection
 
@@ -265,6 +276,6 @@ PY
 ## Current limitations
 
 - Variants change the recipe seed; they do not synthesize new recipe operations.
-- Generated maps contain terrain only. Multiple populated logical levels, automated baked-path checks, and manually verified player traversal are supported for the maintained slopes, but furniture, areas, buildings, semantic roads, and multi-level templates are not supported yet.
+- Generated maps support terrain plus explicit known single-cell furniture on existing terrain cells. Furniture scatter, furniture palettes, itemgroup contents, multi-tile or tall features, automatic support inference, areas, buildings, semantic roads, and multi-level templates are not supported yet.
 - The maps can be inspected with the existing content-editor preview, but the runner does not launch Godot or inject maps into an already-running editor session.
 - Installing examples under `Mods/Dimensionfall/Maps` makes them available to the content editor, but does not automatically reference them from overmap-area generation.

--- a/Documentation/Modding/map_recipe_generator.md
+++ b/Documentation/Modding/map_recipe_generator.md
@@ -13,7 +13,7 @@ python3 Tools/map_generator.py \
 python3 Tools/map_validator.py /tmp/generated_meadow_prototype.json
 ```
 
-The output filename must be `<id>.json`, matching the map loader's filename-derived ID. Existing output is protected. Pass `--overwrite` only when replacement is intended. Use `--tiles PATH` to validate tile IDs against a tile database other than `Mods/Dimensionfall/Tiles/Tiles.json`.
+The output filename must be `<id>.json`, matching the map loader's filename-derived ID. Existing output is protected. Pass `--overwrite` only when replacement is intended. Use `--tiles PATH` to validate tile IDs against a tile database other than `Mods/Dimensionfall/Tiles/Tiles.json`. Furniture operations validate against `Furniture/Furniture.json` beside the selected `Tiles` directory by default; use `--furniture PATH` when that database is elsewhere.
 
 For batch generation of deterministic seed variants and instructions for inspecting them in Godot's content editor, see [`map_example_generation.md`](map_example_generation.md).
 
@@ -61,7 +61,7 @@ Palette entries are objects with `id`, optional positive integer `weight` (defau
 }
 ```
 
-Legacy `regions` are applied first in array order, followed by `operations` in array order. Pattern cells are expanded in their definition order at the position of the invoking operation. Later placements on the same logical level overwrite earlier cells, including repeated offsets inside one pattern. `regions` remain supported for version-one recipes and use the same filled-rectangle placement implementation as `rectangle` operations.
+Legacy `regions` are applied first in array order, followed by `operations` in array order. Pattern cells are expanded in their definition order at the position of the invoking operation. Later tile placements on the same logical level overwrite earlier cells, including the complete `feature` of an earlier furnished tile. A furniture operation instead rejects a cell that already has a feature. `regions` remain supported for version-one recipes and use the same filled-rectangle placement implementation as `rectangle` operations.
 
 ## Logical levels
 
@@ -216,15 +216,48 @@ Offsets rotate around the anchor: `90` maps `[x, y]` to `[-y, x]`. The generator
 }
 ```
 
+### `furniture`
+
+Embeds one known single-cell furniture feature in an existing terrain tile. Fields: `type`, `x`, `y`, `id`, optional root-level `z`, and optional `rotation`. Rotation defaults to `0` and accepts fixed editor-facing quarter turns: `0`, `90`, `180`, or `270`.
+
+```json
+{
+  "type": "furniture",
+  "x": 16,
+  "y": 16,
+  "z": 0,
+  "id": "bench_garden",
+  "rotation": 90
+}
+```
+
+The target cell must already contain a terrain tile on the selected logical level and must not already contain a feature. The generator validates `id` against the selected furniture database and writes the existing map/editor representation:
+
+```json
+{
+  "id": "grass_dirt_00",
+  "feature": {
+    "type": "furniture",
+    "id": "bench_garden",
+    "rotation": 90,
+    "itemgroups": []
+  }
+}
+```
+
+The operation consumes no randomness. Repeating a furniture operation on the same cell is a conflict error. A later tile operation deliberately replaces the complete tile dictionary and therefore removes an earlier feature, following the established ordered tile-overwrite behavior.
+
+The serialized feature has no logical-level, static/movable, state, or mode field. `Chunk.process_level_data()` derives world height from the containing level-array index, and runtime furniture data selects the static or physics spawner from the referenced furniture definition's `moveable` property. Blueprint `mode` belongs to saved runtime furniture state and is not part of a newly generated map feature.
+
 ## Validation and limitations
 
-The generator rejects unknown fields at every recipe level, root-level dimension fields, malformed or out-of-bounds placements, logical levels outside `-10` through `10`, duplicate grouped levels, ambiguous root/grouped layouts, malformed tile databases, unknown tile IDs, invalid rotations, invalid Unicode, and non-object recipes. It validates generated data with `Tools/map_validator.py` before publishing the output. The validator independently requires exactly 21 level arrays and exactly 1024 entries in every populated level.
+The generator rejects unknown fields at every recipe level, root-level dimension fields, malformed or out-of-bounds placements, logical levels outside `-10` through `10`, duplicate grouped levels, ambiguous root/grouped layouts, malformed tile or furniture databases, unknown tile and furniture IDs, unsupported furniture cells, feature conflicts, invalid rotations, invalid Unicode, and non-object recipes. It validates generated data with `Tools/map_validator.py` before publishing the output. The validator independently requires exactly 21 level arrays and exactly 1024 entries in every populated level, and structurally validates embedded furniture fields, IDs, rotations, and itemgroup arrays.
 
 The output uses 21 levels; logical `z: 0` is row-major grid index `10`. It sets `categories` to `[]`, `weight` to `1000`, and all four connections to `"ground"`. It omits `areas`, matching `DMap.get_data()` when the area list is empty.
 
-The generator does not yet create features, furniture, areas, roads as semantic objects, buildings, towns, nested or multi-level patterns, or shape-based templates. It does not infer support or transition validity from stacked tiles. Structural validity and the presence of slope tiles do not yet guarantee walkability, reachability, or gameplay quality.
+The generator currently creates only explicit, known, single-cell furniture features. It does not yet support furniture scatter or palettes, furniture itemgroup contents, multiple features per cell, multi-tile or tall-object occupancy, automatic support inference, other feature types, areas, roads as semantic objects, buildings, towns, nested or multi-level patterns, or shape-based templates.
 
-Maintained structural examples are available at `Tools/examples/map_recipe_two_level_hill.json` and `Tools/examples/map_recipe_two_level_depression.json`. They use `grass_ramp_00`, whose tile definition has `shape: "slope"`.
+The maintained furniture example is `Tools/examples/map_recipe_furniture_outdoor.json`. Maintained structural examples are available at `Tools/examples/map_recipe_two_level_hill.json` and `Tools/examples/map_recipe_two_level_depression.json`. They use `grass_ramp_00`, whose tile definition has `shape: "slope"`.
 
 Slope rotations in recipes use the same values shown by the map editor:
 

--- a/Mods/Dimensionfall/Furniture/references.json
+++ b/Mods/Dimensionfall/Furniture/references.json
@@ -31,7 +31,8 @@
 			"survivor_gas_station",
 			"forest_clearing",
 			"forest_ruins",
-			"field_farmland"
+			"field_farmland",
+			"generated_furnished_clearing"
 		]
 	},
 	"Tree_00": {
@@ -68,7 +69,8 @@
 			"survivor_gas_station",
 			"forest_clearing",
 			"forest_ruins",
-			"field_farmland"
+			"field_farmland",
+			"generated_furnished_clearing"
 		]
 	},
 	"WillowTree_00": {
@@ -158,7 +160,8 @@
 			"Generichouse",
 			"city_square",
 			"store_electronic_clothing",
-			"field_farmland"
+			"field_farmland",
+			"generated_furnished_clearing"
 		]
 	},
 	"bench_wood": {

--- a/Scripts/Chunk.gd
+++ b/Scripts/Chunk.gd
@@ -622,6 +622,9 @@ func update_navigation_mesh():
 # chunks share the same navigationmap, calling this will cause a stutter because the navigation
 # synchronisation happens on the main thread.
 func _on_finish_baking():
+	# An asynchronous bake can finish after its chunk has begun unloading.
+	if not is_instance_valid(navigation_region) or is_queued_for_deletion():
+		return
 	navigation_region.set_navigation_mesh(navigation_mesh)
 	navigation_mesh_baked.emit()
 

--- a/Tests/Unit/test_chunk.gd
+++ b/Tests/Unit/test_chunk.gd
@@ -128,3 +128,31 @@ func test_processed_level_data_defaults():
 	assert_eq(data.furniture.size(), 0, "Expected no furniture in basic_test_map")
 	assert_eq(data.mobs.size(), 0, "Expected no mobs in basic_test_map")
 	assert_eq(data.itemgroups.size(), 0, "Expected no itemgroups in basic_test_map")
+
+
+func test_process_level_data_preserves_furniture_feature_and_logical_height():
+	await wait_for_signal(test_chunk.chunk_generated, 5)
+	var levels: Array = []
+	levels.resize(Chunk.MAX_LEVELS)
+	levels.fill([])
+	var upper_level: Array = []
+	upper_level.resize(Chunk.LEVEL_WIDTH * Chunk.LEVEL_HEIGHT)
+	upper_level.fill({})
+	var feature := {
+		"type": "furniture",
+		"id": "bench_garden",
+		"rotation": 90,
+		"itemgroups": [],
+	}
+	upper_level[3 * Chunk.LEVEL_WIDTH + 2] = {
+		"id": "grass_plain_01",
+		"feature": feature,
+	}
+	levels[11] = upper_level
+	test_chunk._mapleveldata = levels
+
+	var processed := test_chunk.process_level_data()
+
+	assert_eq(processed.furniture.size(), 1)
+	assert_eq(processed.furniture[0].json, feature)
+	assert_eq(processed.furniture[0].pos, Vector3(2.5, 1.5, 3.5))

--- a/Tools/examples/map_recipe_furniture_outdoor.json
+++ b/Tools/examples/map_recipe_furniture_outdoor.json
@@ -1,0 +1,45 @@
+{
+	"id": "generated_furnished_clearing",
+	"name": "Generated Furnished Clearing",
+	"description": "A deterministic outdoor clearing with known single-cell furniture features on logical ground level.",
+	"seed": 20260801,
+	"base_tile": {
+		"id": "grass_plain_01"
+	},
+	"operations": [
+		{
+			"type": "rectangle",
+			"x": 10,
+			"y": 10,
+			"width": 12,
+			"height": 12,
+			"tile": {
+				"id": "grass_dirt_00"
+			}
+		},
+		{
+			"type": "furniture",
+			"x": 16,
+			"y": 16,
+			"z": 0,
+			"id": "bench_garden",
+			"rotation": 90
+		},
+		{
+			"type": "furniture",
+			"x": 12,
+			"y": 12,
+			"z": 0,
+			"id": "Tree_00",
+			"rotation": 0
+		},
+		{
+			"type": "furniture",
+			"x": 20,
+			"y": 12,
+			"z": 0,
+			"id": "PineTree_00",
+			"rotation": 270
+		}
+	]
+}

--- a/Tools/map_generator.py
+++ b/Tools/map_generator.py
@@ -46,6 +46,7 @@ SCATTER_FIELDS = {"type", "region", "z", "tile", "count", "density"}
 SCATTER_REGION_FIELDS = {"x", "y", "width", "height"}
 PATTERN_CELL_FIELDS = {"at", "tile"}
 PATTERN_OPERATION_FIELDS = {"type", "pattern", "at", "z", "rotation"}
+FURNITURE_OPERATION_FIELDS = {"type", "x", "y", "z", "id", "rotation"}
 TILE_OPERATION_TYPES = {"set", "rectangle", "rectangle_outline", "line", "scatter"}
 LEVEL_FIELDS = {"z", "base_tile", "regions", "operations"}
 RECIPE_FIELDS = {
@@ -86,6 +87,7 @@ def write_map(
     output_path: Path,
     tiles_path: Path,
     overwrite: bool = False,
+    furnitures_path: Path | None = None,
 ) -> None:
     output_path = Path(output_path)
     if output_path.exists() and not overwrite:
@@ -93,7 +95,11 @@ def write_map(
             f"output already exists: {output_path}; use --overwrite to replace it"
         )
 
-    generated = generate_map(load_recipe(Path(recipe_path)), Path(tiles_path))
+    generated = generate_map(
+        load_recipe(Path(recipe_path)),
+        Path(tiles_path),
+        furnitures_path=furnitures_path,
+    )
     expected_name = f"{generated['id']}.json"
     if output_path.name != expected_name:
         raise RecipeError(
@@ -146,6 +152,35 @@ def _tile_ids(tiles_path: Path) -> set[str]:
         for tile in tile_data
         if isinstance(tile, dict) and isinstance(tile.get("id"), str)
     }
+
+
+def _furniture_ids(furnitures_path: Path) -> set[str]:
+    with furnitures_path.open(encoding="utf-8") as handle:
+        furniture_data = json.load(handle)
+    if not isinstance(furniture_data, list):
+        raise RecipeError("furniture database must be a JSON array")
+    return {
+        furniture["id"]
+        for furniture in furniture_data
+        if isinstance(furniture, dict) and isinstance(furniture.get("id"), str)
+    }
+
+
+def _contains_furniture_operations(recipe: dict[str, Any]) -> bool:
+    operation_groups = [recipe.get("operations")]
+    levels = recipe.get("levels")
+    if isinstance(levels, list):
+        operation_groups.extend(
+            level.get("operations")
+            for level in levels
+            if isinstance(level, dict)
+        )
+    return any(
+        isinstance(operation, dict) and operation.get("type") == "furniture"
+        for operations in operation_groups
+        if isinstance(operations, list)
+        for operation in operations
+    )
 
 
 def _validate_palette_entry(
@@ -624,6 +659,45 @@ def _apply_pattern(
         )
 
 
+def _apply_furniture(
+    level: list[dict[str, Any]],
+    operation: dict[str, Any],
+    known_furnitures: set[str],
+    context: str,
+) -> None:
+    unknown_fields = sorted(set(operation) - FURNITURE_OPERATION_FIELDS)
+    if unknown_fields:
+        raise RecipeError(f"unknown {context} field '{unknown_fields[0]}'")
+    x = _coordinate(operation.get("x"), f"{context}.x", MAP_WIDTH)
+    y = _coordinate(operation.get("y"), f"{context}.y", MAP_HEIGHT)
+    furniture_id = operation.get("id")
+    if not isinstance(furniture_id, str) or not furniture_id.strip():
+        raise RecipeError(f"{context}.id must be a non-empty string")
+    _validate_unicode(furniture_id, f"{context}.id")
+    if furniture_id not in known_furnitures:
+        raise RecipeError(
+            f"{context}.id references unknown furniture '{furniture_id}'"
+        )
+    rotation = operation.get("rotation", 0)
+    if type(rotation) is not int or rotation not in VALID_ROTATIONS:
+        raise RecipeError(f"{context}.rotation must be 0, 90, 180, or 270")
+    tile = level[y * MAP_WIDTH + x]
+    if not isinstance(tile.get("id"), str) or not tile["id"]:
+        raise RecipeError(
+            f"{context} requires supporting terrain at [{x}, {y}] on its target level"
+        )
+    if "feature" in tile:
+        raise RecipeError(
+            f"{context} conflicts with an existing feature at [{x}, {y}] on its target level"
+        )
+    tile["feature"] = {
+        "type": "furniture",
+        "id": furniture_id,
+        "rotation": rotation,
+        "itemgroups": [],
+    }
+
+
 def _target_z(
     spec: dict[str, Any], context: str, inherited_z: int | None
 ) -> int:
@@ -644,6 +718,7 @@ def _apply_layout(
     known_tiles: set[str],
     palette: dict[str, list[dict[str, Any]]],
     patterns: dict[str, list[dict[str, Any]]],
+    known_furnitures: set[str],
     context_prefix: str = "",
     inherited_z: int | None = None,
 ) -> None:
@@ -690,6 +765,8 @@ def _apply_layout(
             _apply_pattern(
                 level, operation, rng, known_tiles, palette, patterns, context
             )
+        elif operation_type == "furniture":
+            _apply_furniture(level, operation, known_furnitures, context)
         else:
             raise RecipeError(
                 f"{context}.type has unknown operation '{operation_type}'"
@@ -702,6 +779,7 @@ def _generate_levels(
     known_tiles: set[str],
     palette: dict[str, list[dict[str, Any]]],
     patterns: dict[str, list[dict[str, Any]]],
+    known_furnitures: set[str],
 ) -> list[list[dict[str, Any]]]:
     levels: list[list[dict[str, Any]]] = [[] for _ in range(LEVEL_COUNT)]
     if "levels" not in recipe:
@@ -722,6 +800,7 @@ def _generate_levels(
             known_tiles,
             palette,
             patterns,
+            known_furnitures,
         )
         return levels
 
@@ -773,6 +852,7 @@ def _generate_levels(
             known_tiles,
             palette,
             patterns,
+            known_furnitures,
             context_prefix=f"{context}.",
             inherited_z=logical_z,
         )
@@ -783,7 +863,12 @@ def _generate_levels(
     return levels
 
 
-def generate_map(recipe: dict[str, Any], tiles_path: Path) -> dict[str, Any]:
+def generate_map(
+    recipe: dict[str, Any],
+    tiles_path: Path,
+    *,
+    furnitures_path: Path | None = None,
+) -> dict[str, Any]:
     """Validate a recipe and return map data matching DMap's saved format."""
     if not isinstance(recipe, dict):
         raise RecipeError("recipe must be a JSON object")
@@ -805,10 +890,19 @@ def generate_map(recipe: dict[str, Any], tiles_path: Path) -> dict[str, Any]:
     if type(seed) is not int:
         raise RecipeError("seed must be an integer")
     known_tiles = _tile_ids(Path(tiles_path))
+    known_furnitures: set[str] = set()
+    if _contains_furniture_operations(recipe):
+        if furnitures_path is None:
+            furnitures_path = (
+                Path(tiles_path).parent.parent / "Furniture" / "Furniture.json"
+            )
+        known_furnitures = _furniture_ids(Path(furnitures_path))
     palette = _validate_palette(recipe.get("palette", {}), known_tiles)
     patterns = _validate_patterns(recipe.get("patterns", {}), known_tiles, palette)
     rng = random.Random(seed)
-    levels = _generate_levels(recipe, rng, known_tiles, palette, patterns)
+    levels = _generate_levels(
+        recipe, rng, known_tiles, palette, patterns, known_furnitures
+    )
 
     return {
         "id": recipe["id"],
@@ -840,9 +934,23 @@ def main(argv: list[str] | None = None) -> int:
         ),
         help="tile database path (defaults to the core Dimensionfall tile database)",
     )
+    parser.add_argument(
+        "--furniture",
+        type=Path,
+        help=(
+            "furniture database path (defaults to Furniture/Furniture.json next "
+            "to the selected Tiles directory)"
+        ),
+    )
     args = parser.parse_args(argv)
     try:
-        write_map(args.recipe, args.output, args.tiles, args.overwrite)
+        write_map(
+            args.recipe,
+            args.output,
+            args.tiles,
+            args.overwrite,
+            args.furniture,
+        )
     except (RecipeError, OSError, json.JSONDecodeError) as error:
         parser.exit(2, f"error: {error}\n")
     print(f"Generated {args.output}")

--- a/Tools/map_validator.py
+++ b/Tools/map_validator.py
@@ -151,6 +151,52 @@ class MapValidator:
                         except (ValueError, TypeError):
                              self.add_error(file_path, f"Level {level_idx}, Tile ID '{tile['id']}' has non-numeric rotation: {rot}")
 
+                    # Furniture is stored as a single feature embedded in a terrain tile.
+                    if 'feature' in tile:
+                        feature = tile['feature']
+                        if not isinstance(feature, dict):
+                            self.add_error(
+                                file_path,
+                                f"Level {level_idx}, Tile ID '{tile['id']}' feature is not an object."
+                            )
+                        elif feature.get('type') == 'furniture':
+                            allowed_fields = {'type', 'id', 'rotation', 'itemgroups'}
+                            unknown_fields = sorted(set(feature) - allowed_fields)
+                            if unknown_fields:
+                                self.add_error(
+                                    file_path,
+                                    f"Level {level_idx}, Tile ID '{tile['id']}' furniture feature has unknown field '{unknown_fields[0]}'"
+                                )
+                            furniture_id = feature.get('id')
+                            if not isinstance(furniture_id, str) or not furniture_id:
+                                self.add_error(
+                                    file_path,
+                                    f"Level {level_idx}, Tile ID '{tile['id']}' furniture feature has invalid or missing ID"
+                                )
+                            if 'rotation' in feature:
+                                rotation = feature['rotation']
+                                valid_feature_rotations = {0, 90, 180, 270}
+                                try:
+                                    float_rotation = float(rotation) % 360
+                                    if float_rotation not in valid_feature_rotations:
+                                        self.add_error(
+                                            file_path,
+                                            f"Level {level_idx}, Furniture ID '{furniture_id}' has invalid rotation: {rotation}"
+                                        )
+                                except (ValueError, TypeError):
+                                    self.add_error(
+                                        file_path,
+                                        f"Level {level_idx}, Furniture ID '{furniture_id}' has non-numeric rotation: {rotation}"
+                                    )
+                            if 'itemgroups' in feature and not (
+                                isinstance(feature['itemgroups'], list)
+                                and all(isinstance(itemgroup, str) for itemgroup in feature['itemgroups'])
+                            ):
+                                self.add_error(
+                                    file_path,
+                                    f"Level {level_idx}, Furniture ID '{furniture_id}' itemgroups must be an array of strings"
+                                )
+
                     # Area References Check
                     if 'areas' in tile and isinstance(tile['areas'], list):
                         for area_ref in tile['areas']:

--- a/Tools/tests/test_map_generator.py
+++ b/Tools/tests/test_map_generator.py
@@ -8,6 +8,7 @@ from Tools.map_validator import MapValidator
 
 ROOT = Path(__file__).resolve().parents[2]
 TILES_PATH = ROOT / "Mods" / "Dimensionfall" / "Tiles" / "Tiles.json"
+FURNITURES_PATH = ROOT / "Mods" / "Dimensionfall" / "Furniture" / "Furniture.json"
 
 
 def valid_recipe():
@@ -315,6 +316,147 @@ class MapGeneratorTests(unittest.TestCase):
 
         self.assertEqual(level[2 * 32 + 3], {"id": "dirt_light_00"})
         self.assertEqual(level[2 * 32 + 2], {"id": "grass_plain_01"})
+
+    def test_furniture_operation_embeds_known_feature_on_explicit_logical_level(self):
+        recipe = valid_recipe()
+        recipe["operations"] = [
+            {
+                "type": "set",
+                "x": 4,
+                "y": 5,
+                "z": 1,
+                "tile": {"id": "grass_plain_01"},
+            },
+            {
+                "type": "furniture",
+                "x": 4,
+                "y": 5,
+                "z": 1,
+                "id": "bench_garden",
+                "rotation": 90,
+            },
+        ]
+
+        levels = generate_map(
+            recipe, TILES_PATH, furnitures_path=FURNITURES_PATH
+        )["levels"]
+
+        self.assertEqual(
+            levels[11][5 * 32 + 4],
+            {
+                "id": "grass_plain_01",
+                "feature": {
+                    "type": "furniture",
+                    "id": "bench_garden",
+                    "rotation": 90,
+                    "itemgroups": [],
+                },
+            },
+        )
+
+    def test_grouped_furniture_inherits_level_and_defaults_rotation(self):
+        recipe = valid_recipe()
+        del recipe["base_tile"]
+        del recipe["regions"]
+        recipe["levels"] = [
+            {
+                "z": -1,
+                "base_tile": {"id": "grass_plain_01"},
+                "operations": [
+                    {"type": "furniture", "x": 3, "y": 2, "id": "Tree_00"}
+                ],
+            }
+        ]
+
+        tile = generate_map(recipe, TILES_PATH)["levels"][9][2 * 32 + 3]
+
+        self.assertEqual(tile["feature"]["rotation"], 0)
+        self.assertEqual(tile["feature"]["id"], "Tree_00")
+
+    def test_furniture_requires_terrain_and_rejects_feature_conflicts(self):
+        recipe = valid_recipe()
+        recipe["operations"] = [
+            {
+                "type": "furniture",
+                "x": 1,
+                "y": 1,
+                "z": 1,
+                "id": "bench_garden",
+            }
+        ]
+        with self.assertRaisesRegex(RecipeError, "requires supporting terrain"):
+            generate_map(recipe, TILES_PATH)
+
+        recipe = valid_recipe()
+        recipe["operations"] = [
+            {"type": "furniture", "x": 1, "y": 1, "id": "bench_garden"},
+            {"type": "furniture", "x": 1, "y": 1, "id": "Tree_00"},
+        ]
+        with self.assertRaisesRegex(RecipeError, "conflicts with an existing feature"):
+            generate_map(recipe, TILES_PATH)
+
+    def test_later_tile_operation_explicitly_replaces_furniture_feature(self):
+        recipe = valid_recipe()
+        recipe["base_tile"] = {"id": "grass_plain_01"}
+        recipe["operations"] = [
+            {"type": "furniture", "x": 1, "y": 1, "id": "bench_garden"},
+            {"type": "set", "x": 1, "y": 1, "tile": {"id": "dirt_light_00"}},
+        ]
+
+        tile = generate_map(recipe, TILES_PATH)["levels"][10][1 * 32 + 1]
+
+        self.assertEqual(tile, {"id": "dirt_light_00"})
+
+    def test_furniture_operation_strictly_validates_schema_id_and_rotation(self):
+        cases = [
+            (
+                {"type": "furniture", "x": 1, "y": 1, "id": "missing"},
+                "unknown furniture 'missing'",
+            ),
+            (
+                {"type": "furniture", "x": 1, "y": 1, "id": ""},
+                "id must be a non-empty string",
+            ),
+            (
+                {
+                    "type": "furniture",
+                    "x": 1,
+                    "y": 1,
+                    "id": "bench_garden",
+                    "rotation": "random",
+                },
+                "rotation must be 0, 90, 180, or 270",
+            ),
+            (
+                {
+                    "type": "furniture",
+                    "x": 1,
+                    "y": 1,
+                    "id": "bench_garden",
+                    "extra": True,
+                },
+                r"unknown operations\[0\] field 'extra'",
+            ),
+        ]
+        for operation, expected_message in cases:
+            with self.subTest(operation=operation):
+                recipe = valid_recipe()
+                recipe["operations"] = [operation]
+                with self.assertRaisesRegex(RecipeError, expected_message):
+                    generate_map(recipe, TILES_PATH)
+
+    def test_terrain_only_recipe_does_not_require_furniture_database(self):
+        with tempfile.TemporaryDirectory() as directory:
+            tiles_path = Path(directory) / "Tiles.json"
+            tiles_path.write_text(
+                json.dumps([{"id": "grass_plain_01"}]), encoding="utf-8"
+            )
+            recipe = valid_recipe()
+            recipe["base_tile"] = {"id": "grass_plain_01"}
+
+            generated = generate_map(recipe, tiles_path)
+
+        self.assertEqual(generated["levels"][10][0], {"id": "grass_plain_01"})
 
     def test_rectangle_operation_is_filled_and_later_operations_overwrite(self):
         recipe = valid_recipe()
@@ -933,6 +1075,7 @@ class MapGeneratorTests(unittest.TestCase):
     def test_example_recipes_generate_successfully(self):
         cases = {
             "map_recipe.json": {10},
+            "map_recipe_furniture_outdoor.json": {10},
             "map_recipe_two_level_hill.json": {10, 11},
             "map_recipe_two_level_depression.json": {9, 10},
         }
@@ -955,6 +1098,26 @@ class MapGeneratorTests(unittest.TestCase):
                 )
                 for index in expected_populated_indices:
                     self.assertEqual(len(generated["levels"][index]), 1024)
+
+    def test_furniture_example_uses_known_features_on_supported_ground_tiles(self):
+        recipe_path = ROOT / "Tools" / "examples" / "map_recipe_furniture_outdoor.json"
+        generated = generate_map(
+            json.loads(recipe_path.read_text(encoding="utf-8")), TILES_PATH
+        )
+        furniture_ids = {
+            tile["feature"]["id"]
+            for tile in generated["levels"][10]
+            if tile.get("feature", {}).get("type") == "furniture"
+        }
+
+        self.assertEqual(furniture_ids, {"bench_garden", "Tree_00", "PineTree_00"})
+        self.assertTrue(
+            all(
+                tile.get("id")
+                for tile in generated["levels"][10]
+                if tile.get("feature", {}).get("type") == "furniture"
+            )
+        )
 
     def test_multi_level_examples_have_supported_slope_endpoints(self):
         high_direction = {
@@ -1109,6 +1272,42 @@ class MapValidatorDimensionTests(unittest.TestCase):
                 self.assertTrue(
                     any(f"expected 21, actual {count}" in error for error in errors)
                 )
+
+    def test_validates_furniture_feature_structure(self):
+        invalid_features = [
+            ("not-an-object", "feature is not an object"),
+            ({"type": "furniture", "rotation": 0}, "invalid or missing ID"),
+            (
+                {"type": "furniture", "id": "bench_garden", "rotation": 45},
+                "invalid rotation",
+            ),
+            (
+                {
+                    "type": "furniture",
+                    "id": "bench_garden",
+                    "rotation": 0,
+                    "itemgroups": [1],
+                },
+                "itemgroups must be an array of strings",
+            ),
+            (
+                {
+                    "type": "furniture",
+                    "id": "bench_garden",
+                    "rotation": 0,
+                    "unexpected": True,
+                },
+                "unknown field 'unexpected'",
+            ),
+        ]
+        for feature, expected_message in invalid_features:
+            with self.subTest(feature=feature):
+                map_data = generate_map(valid_recipe(), TILES_PATH)
+                map_data["levels"][10][0]["feature"] = feature
+
+                errors = self.validate(map_data)
+
+                self.assertTrue(any(expected_message in error for error in errors))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

Begin Phase 5 of the map-generation roadmap with the smallest useful
level-aware furniture implementation.

- investigate the existing map, editor, and runtime furniture contract;
- add explicit single-cell `furniture` recipe operations;
- reuse the existing embedded `tile.feature` representation;
- validate furniture IDs against `Furniture.json`;
- support root logical `z` and grouped-level inheritance;
- require supporting terrain on the target level;
- reject existing-feature conflicts;
- preserve deterministic ordered tile overwrite behavior;
- add independent furniture structure validation;
- add a maintained outdoor furnished-clearing recipe;
- verify logical-level extraction in Godot;
- update the roadmap and modding documentation.

## Existing serialization contract

Furniture is stored directly in a terrain tile:

```json
{
  "id": "grass_dirt_00",
  "feature": {
    "type": "furniture",
    "id": "bench_garden",
    "rotation": 90,
    "itemgroups": []
  }
}
```
Phase 5 is in progress.

Completed in this contribution:

    furniture schema investigation;
    explicit level-aware single-cell furniture placement.

The next contribution should add deterministic conflict-aware outdoor
furniture distribution, preferably through weighted furniture palettes
and bounded scatter over eligible terrain cells.

Multi-tile furniture, itemgroup population, automatic adjacent-level
support inference, rooms, buildings, roads, towns, nested patterns,
and generalized feature templates remain out of scope.