### PR TITLE
Add deterministic conflict-aware furniture scatter

### DIFF
--- a/Documentation/Game_design/Map_generation_plan.md
+++ b/Documentation/Game_design/Map_generation_plan.md
@@ -576,14 +576,17 @@ Delivered:
 * a maintained `generated_furnished_clearing` recipe at logical `z: 0` using a garden bench, tree, and pine tree;
 * Python coverage for root and grouped logical levels, exact serialization, support and feature conflicts, operation ordering, strict validation, compatibility, and maintained-example output;
 * Godot coverage confirming `Chunk.process_level_data()` preserves the feature and derives the expected world height from its serialized logical level.
+* named weighted furniture palettes with strict known-ID, positive-weight, and editor-facing rotation validation;
+* bounded `furniture_scatter` operations that enumerate terrain-without-feature candidates in row-major order, sample them without replacement, select weighted furniture deterministically, and fail before placement when count exceeds eligibility;
+* an expanded furnished clearing with explicit garden bench, unlit campfire, and potted plant plus 24 conflict-aware tree, pine, willow, or burned-stump placements;
+* verification that the current core furniture database has no rock, grass, or wild-vegetation furniture definitions, so the maintained recipe deliberately does not claim unavailable asset categories.
 
 Still required before Phase 5 is complete:
 
-* deterministic furniture palettes and/or scatter suitable for natural outdoor distribution;
-* a broader maintained outdoor composition containing representative trees, rocks, vegetation, and simple decorative or interactable objects;
-* conflict-aware scatter candidate selection and clear failure reporting when requested density cannot fit;
-* decisions about furniture itemgroup authoring, movable furniture examples, multi-tile footprints, tall features, and adjacent-level conflicts, each introduced only when supported by runtime evidence;
-* runtime/manual inspection of the maintained furnished clearing.
+* manual runtime inspection of the weighted scatter, including static and movable furniture spawning, authored rotations, and any collision or navigation effects;
+* a real content decision for rocks and wild vegetation: add valid furniture definitions and assets through the normal content workflow, or revise the phase success criterion to use available terrain detail instead of nonexistent furniture IDs;
+* decisions about furniture itemgroup authoring, multi-tile footprints, tall features, and adjacent-level conflicts, each introduced only when supported by runtime evidence;
+* documented inspection results for the maintained furnished clearing, including whether spawned features alter local navigation as intended.
 
 ### Success criterion
 
@@ -828,11 +831,11 @@ An agent can create a new playable, potentially multi-level map from a concise d
 
 # Recommended immediate next task
 
-The next contribution should advance **Phase 5** with deterministic, conflict-aware outdoor furniture distribution while retaining the delivered single-cell feature contract.
+The next contribution should finish the remaining evidence and content decision needed for **Phase 5**, without widening the generator schema.
 
-Investigate representative natural furniture IDs and then add one narrow reusable selection mechanism for furniture, preferably named weighted furniture palettes plus a bounded scatter operation. Scatter must select only cells that already have terrain and no feature, consume RNG in documented deterministic order, reject unknown IDs and malformed weights, and fail clearly when the requested count exceeds eligible cells. Keep logical `z` explicit at the root and inherited inside grouped levels.
+First, generate `generated_furnished_clearing` and inspect it in the map editor and with `save and test`. Verify the three explicit features, the 24 seeded scatter features, rotations, static-versus-movable spawning, collision, and local navigation behavior. Record the real-player result in the map plan and modding guide.
 
-Extend the maintained furnished clearing with representative trees, rocks, vegetation, and one simple decorative or interactable object. Do not add multi-tile furniture, itemgroup population, automatic adjacent-level support inference, rooms, buildings, roads, towns, nested patterns, or generalized feature templates in this contribution.
+Then resolve the documented asset gap through the normal content workflow: either add actual core furniture definitions and assets for rocks and wild vegetation, with their own content validation and runtime inspection, or revise the Phase 5 success criterion to rely on the available terrain-detail system rather than inventing furniture IDs. Do not add unbacked IDs, multi-tile footprints, itemgroup generation, automatic support inference, rooms, buildings, roads, towns, nested patterns, or generalized feature templates.
 
 Run the complete Python suite, relevant Godot tests or smoke checks, all maintained example generations through `Tools/map_validator.py`, and `git diff --check`.
 
@@ -860,7 +863,8 @@ Do not commit or push unless explicitly requested.
 [Complete] Structural generation, slope geometry, baked paths, and player traversal
 [Complete] Feature and furniture schema investigation
 [Complete] Level-aware single-cell furniture placement
-[Next]     Deterministic conflict-aware outdoor furniture distribution
+[Complete] Deterministic conflict-aware outdoor furniture distribution
+[Next]     Phase 5 runtime inspection and outdoor-content decision
 [Planned]  Level-aware areas and buildings
 [Planned]  Roads and map connections
 [Planned]  Multi-level reusable templates and richer composition

--- a/Documentation/Modding/map_example_generation.md
+++ b/Documentation/Modding/map_example_generation.md
@@ -23,7 +23,7 @@ The maintained recipe examples are:
 | Recipe | Output map | Purpose |
 |---|---|---|
 | `Tools/examples/map_recipe.json` | `Mods/Dimensionfall/Maps/generated_meadow_prototype.json` | Ground-level palettes, placement operations, scatter, and reusable patterns. |
-| `Tools/examples/map_recipe_furniture_outdoor.json` | `Mods/Dimensionfall/Maps/generated_furnished_clearing.json` | Explicit known single-cell furniture on supported terrain at logical `z: 0`. |
+| `Tools/examples/map_recipe_furniture_outdoor.json` | `Mods/Dimensionfall/Maps/generated_furnished_clearing.json` | Explicit decor plus weighted, conflict-aware tree and stump scatter on supported terrain at logical `z: 0`. |
 | `Tools/examples/map_recipe_two_level_hill.json` | `Mods/Dimensionfall/Maps/generated_two_level_hill.json` | Ground level `z: 0`, raised terrain at `z: 1`, and all four slope rotations. |
 | `Tools/examples/map_recipe_two_level_depression.json` | `Mods/Dimensionfall/Maps/generated_two_level_depression.json` | Ground level `z: 0`, lowered terrain at `z: -1`, and all four slope rotations. |
 
@@ -115,7 +115,7 @@ python3 Tools/generate_map_examples.py \
   --seed 1000
 ```
 
-Running the same complete recipe with the same starting seed produces the same map JSON. Changing the seed changes seeded scatter placement and random tile rotations.
+Running the same complete recipe with the same starting seed produces the same map JSON. Changing the seed changes seeded tile scatter, furniture scatter, palette selection, and random rotations.
 
 ## Inspect generated maps in the content editor
 
@@ -142,7 +142,7 @@ Content Manager
 
 If Godot was already running when files were generated, restart it so mod content is loaded again. The existing map-editor preview displays generated map JSON; the Python tool does not create a separate image or HTML preview.
 
-For the maintained furnished clearing, confirm that the editor shows a garden bench at `[16, 16]`, a tree at `[12, 12]`, and a pine tree at `[20, 12]`. Use `save and test` to confirm that the referenced static furniture spawns on the ground-level terrain with the authored rotations. The recipe intentionally leaves `itemgroups` empty and does not exercise container contents, movable furniture, multi-cell occupancy, or cross-level support rules.
+For the maintained furnished clearing, confirm that the editor shows a garden bench at `[16, 16]`, an unlit campfire at `[15, 16]`, and a potted plant at `[17, 16]`. It also deterministically scatters 24 trees or burned stumps over the 16×16 clearing while leaving those three authored features untouched. Use `save and test` to confirm that static and movable furniture spawn on ground-level terrain with their generated rotations. The core furniture database currently has no rock, grass, or wild-vegetation furniture definitions, so this maintained example does not claim to generate those unavailable asset categories. The recipe intentionally leaves `itemgroups` empty and does not exercise container contents, multi-cell occupancy, or cross-level support rules.
 
 Dimensionfall also looks for a same-named `.png` map sprite during startup. The runner intentionally generates map JSON only, so Godot currently logs a non-fatal missing-resource error for that sprite. This does not prevent the JSON map from loading or the map editor's tile-grid preview from rendering it.
 
@@ -276,6 +276,6 @@ PY
 ## Current limitations
 
 - Variants change the recipe seed; they do not synthesize new recipe operations.
-- Generated maps support terrain plus explicit known single-cell furniture on existing terrain cells. Furniture scatter, furniture palettes, itemgroup contents, multi-tile or tall features, automatic support inference, areas, buildings, semantic roads, and multi-level templates are not supported yet.
+- Generated maps support terrain plus explicit known single-cell furniture and deterministic weighted furniture scatter over eligible terrain cells. Itemgroup contents, multi-tile or tall features, automatic support inference, areas, buildings, semantic roads, and multi-level templates are not supported yet.
 - The maps can be inspected with the existing content-editor preview, but the runner does not launch Godot or inject maps into an already-running editor session.
 - Installing examples under `Mods/Dimensionfall/Maps` makes them available to the content editor, but does not automatically reference them from overmap-area generation.

--- a/Documentation/Modding/map_recipe_generator.md
+++ b/Documentation/Modding/map_recipe_generator.md
@@ -26,9 +26,10 @@ The root must be a JSON object with these fields:
 | `id` | string | Map ID using only letters, numbers, `_`, and `-`. |
 | `name` | non-empty string | Display name. |
 | `description` | non-empty string | Map description. |
-| `seed` | integer | Fixed seed used by palettes, random tile rotations, scatter, and pattern cells. Recipe input only; the map format does not store it. |
+| `seed` | integer | Fixed seed used by tile and furniture palettes, random rotations, scatter, and pattern cells. Recipe input only; the map format does not store it. |
 | `base_tile` | tile object | Legacy-mode tile initially placed in every cell at `z: 0`. Required unless `levels` is used. |
 | `palette` | object | Named weighted tile sets that tile objects can reference. Optional; defaults to `{}`. |
+| `furniture_palette` | object | Named weighted furniture sets used by `furniture_scatter`. Optional; defaults to `{}`. |
 | `patterns` | object | Named arrays of relative tile placements used by `pattern` operations. Optional; defaults to `{}`. |
 | `regions` | array | Legacy filled rectangles. Optional; defaults to `[]`. |
 | `operations` | array | Ordered placement operations. Optional; defaults to `[]`. |
@@ -43,7 +44,7 @@ A tile object has exactly one of:
 
 It may also include an optional `rotation` when using `id`. Rotation is `0`, `90`, `180`, `270`, or `"random"`. Operation tiles may be `null`, which writes the project's empty-tile representation, `{}`.
 
-Palette entries are objects with `id`, optional positive integer `weight` (default `1`), and optional `rotation`. Palette names may contain only letters, numbers, underscores, and hyphens. Palette selection uses the same seeded random-number generator as scatter and random rotation, so the same complete recipe and seed produce identical output. Changing a recipe from a raw tile to a palette reference may change later random choices because palette selection consumes random numbers.
+Palette entries are objects with `id`, optional positive integer `weight` (default `1`), and optional `rotation`. Palette names may contain only letters, numbers, underscores, and hyphens. Palette selection uses the same seeded random-number generator as scatter, furniture scatter, and random rotation, so the same complete recipe and seed produce identical output. Changing a recipe from a raw tile to a palette reference may change later random choices because palette selection consumes random numbers.
 
 ```json
 {
@@ -147,6 +148,25 @@ Pattern definitions do not consume random numbers. An invoked pattern consumes r
 }
 ```
 
+## Furniture palettes
+
+`furniture_palette` maps a name to a non-empty weighted array of known furniture entries. Entries have `id`, optional positive integer `weight` (default `1`), and optional editor-facing `rotation` (`0`, `90`, `180`, `270`, or `"random"`). Furniture palette names use the same letters/numbers/underscore/hyphen rule as tile palettes. Every entry is validated against the selected furniture database, including unused palette definitions.
+
+```json
+{
+  "furniture_palette": {
+    "clearing_trees": [
+      {"id": "Tree_00", "weight": 4, "rotation": "random"},
+      {"id": "PineTree_00", "weight": 3, "rotation": "random"},
+      {"id": "WillowTree_00", "weight": 1, "rotation": "random"},
+      {"id": "burned_tree_stump", "weight": 2, "rotation": "random"}
+    ]
+  }
+}
+```
+
+Definitions themselves consume no randomness. An invoked `furniture_scatter` first samples eligible cells, in row-major candidate order, and then selects one palette entry and resolves any random rotation for each sampled cell in the sample order. This is part of the shared recipe RNG stream: moving, adding, or removing an earlier RNG-consuming operation can change later selections.
+
 ## Placement operations
 
 Every operation requires a `type`. Unknown operation types and fields are errors. At the recipe root, every operation accepts optional logical `z` and defaults to `0`. Inside a grouped level, the operation inherits `z` and must omit the field.
@@ -249,13 +269,34 @@ The operation consumes no randomness. Repeating a furniture operation on the sam
 
 The serialized feature has no logical-level, static/movable, state, or mode field. `Chunk.process_level_data()` derives world height from the containing level-array index, and runtime furniture data selects the static or physics spawner from the referenced furniture definition's `moveable` property. Blueprint `mode` belongs to saved runtime furniture state and is not part of a newly generated map feature.
 
+### `furniture_scatter`
+
+Places a bounded number of single-cell furniture features selected from a named `furniture_palette`. Fields: `type`, `region`, `palette`, exactly one of `count` or `density`, and optional root-level `z`.
+
+- `count` is an integer from zero through the geometric region area.
+- `density` is a number from `0` through `1`; the requested placement count is `floor(region area × density)`.
+- Eligible cells must already contain terrain on the target logical level and must not already have a feature.
+- If the requested count exceeds the remaining eligible cells, generation fails before mutating the scatter operation's target cells.
+- Candidate coordinates are enumerated in row-major order, then sampled without replacement with the recipe RNG. Each sampled cell selects one weighted furniture entry and resolves its rotation in sample order.
+- Scatter embeds the same `feature` object as explicit `furniture`; it does not infer footprints, itemgroups, or adjacent-level occupancy.
+
+```json
+{
+  "type": "furniture_scatter",
+  "region": {"x": 8, "y": 8, "width": 16, "height": 16},
+  "z": 0,
+  "count": 24,
+  "palette": "clearing_trees"
+}
+```
+
 ## Validation and limitations
 
-The generator rejects unknown fields at every recipe level, root-level dimension fields, malformed or out-of-bounds placements, logical levels outside `-10` through `10`, duplicate grouped levels, ambiguous root/grouped layouts, malformed tile or furniture databases, unknown tile and furniture IDs, unsupported furniture cells, feature conflicts, invalid rotations, invalid Unicode, and non-object recipes. It validates generated data with `Tools/map_validator.py` before publishing the output. The validator independently requires exactly 21 level arrays and exactly 1024 entries in every populated level, and structurally validates embedded furniture fields, IDs, rotations, and itemgroup arrays.
+The generator rejects unknown fields at every recipe level, root-level dimension fields, malformed or out-of-bounds placements, logical levels outside `-10` through `10`, duplicate grouped levels, ambiguous root/grouped layouts, malformed tile or furniture databases, unknown tile and furniture IDs, malformed weights, unsupported furniture cells, feature conflicts, scatter requests that exceed eligible cells, invalid rotations, invalid Unicode, and non-object recipes. It validates generated data with `Tools/map_validator.py` before publishing the output. The validator independently requires exactly 21 level arrays and exactly 1024 entries in every populated level, and structurally validates embedded furniture fields, IDs, rotations, and itemgroup arrays.
 
 The output uses 21 levels; logical `z: 0` is row-major grid index `10`. It sets `categories` to `[]`, `weight` to `1000`, and all four connections to `"ground"`. It omits `areas`, matching `DMap.get_data()` when the area list is empty.
 
-The generator currently creates only explicit, known, single-cell furniture features. It does not yet support furniture scatter or palettes, furniture itemgroup contents, multiple features per cell, multi-tile or tall-object occupancy, automatic support inference, other feature types, areas, roads as semantic objects, buildings, towns, nested or multi-level patterns, or shape-based templates.
+The generator currently creates explicit, known, single-cell furniture features and deterministic weighted furniture scatter over eligible terrain. It does not yet support furniture itemgroup contents, multiple features per cell, multi-tile or tall-object occupancy, automatic support inference, other feature types, areas, roads as semantic objects, buildings, towns, nested or multi-level patterns, or shape-based templates.
 
 The maintained furniture example is `Tools/examples/map_recipe_furniture_outdoor.json`. Maintained structural examples are available at `Tools/examples/map_recipe_two_level_hill.json` and `Tools/examples/map_recipe_two_level_depression.json`. They use `grass_ramp_00`, whose tile definition has `shape: "slope"`.
 

--- a/Tools/examples/map_recipe_furniture_outdoor.json
+++ b/Tools/examples/map_recipe_furniture_outdoor.json
@@ -1,18 +1,42 @@
 {
 	"id": "generated_furnished_clearing",
 	"name": "Generated Furnished Clearing",
-	"description": "A deterministic outdoor clearing with known single-cell furniture features on logical ground level.",
-	"seed": 20260801,
+	"description": "A deterministic outdoor clearing with weighted, conflict-aware single-cell furniture distribution on logical ground level.",
+	"seed": 20260802,
 	"base_tile": {
 		"id": "grass_plain_01"
+	},
+	"furniture_palette": {
+		"clearing_trees": [
+			{
+				"id": "Tree_00",
+				"weight": 4,
+				"rotation": "random"
+			},
+			{
+				"id": "PineTree_00",
+				"weight": 3,
+				"rotation": "random"
+			},
+			{
+				"id": "WillowTree_00",
+				"weight": 1,
+				"rotation": "random"
+			},
+			{
+				"id": "burned_tree_stump",
+				"weight": 2,
+				"rotation": "random"
+			}
+		]
 	},
 	"operations": [
 		{
 			"type": "rectangle",
-			"x": 10,
-			"y": 10,
-			"width": 12,
-			"height": 12,
+			"x": 8,
+			"y": 8,
+			"width": 16,
+			"height": 16,
 			"tile": {
 				"id": "grass_dirt_00"
 			}
@@ -27,19 +51,31 @@
 		},
 		{
 			"type": "furniture",
-			"x": 12,
-			"y": 12,
+			"x": 15,
+			"y": 16,
 			"z": 0,
-			"id": "Tree_00",
+			"id": "campfire_off",
 			"rotation": 0
 		},
 		{
 			"type": "furniture",
-			"x": 20,
-			"y": 12,
+			"x": 17,
+			"y": 16,
 			"z": 0,
-			"id": "PineTree_00",
-			"rotation": 270
+			"id": "plant_pot_00",
+			"rotation": 180
+		},
+		{
+			"type": "furniture_scatter",
+			"region": {
+				"x": 8,
+				"y": 8,
+				"width": 16,
+				"height": 16
+			},
+			"z": 0,
+			"count": 24,
+			"palette": "clearing_trees"
 		}
 	]
 }

--- a/Tools/map_generator.py
+++ b/Tools/map_generator.py
@@ -37,6 +37,7 @@ DEFAULT_CONNECTIONS = {
 VALID_ROTATIONS = (0, 90, 180, 270)
 TILE_FIELDS = {"id", "palette", "rotation"}
 PALETTE_FIELDS = {"id", "weight", "rotation"}
+FURNITURE_PALETTE_FIELDS = {"id", "weight", "rotation"}
 DEFINITION_NAME_PATTERN = re.compile(r"[A-Za-z0-9_-]+")
 REGION_FIELDS = {"x", "y", "z", "width", "height", "tile"}
 SET_FIELDS = {"type", "x", "y", "z", "tile"}
@@ -47,6 +48,7 @@ SCATTER_REGION_FIELDS = {"x", "y", "width", "height"}
 PATTERN_CELL_FIELDS = {"at", "tile"}
 PATTERN_OPERATION_FIELDS = {"type", "pattern", "at", "z", "rotation"}
 FURNITURE_OPERATION_FIELDS = {"type", "x", "y", "z", "id", "rotation"}
+FURNITURE_SCATTER_FIELDS = {"type", "region", "z", "palette", "count", "density"}
 TILE_OPERATION_TYPES = {"set", "rectangle", "rectangle_outline", "line", "scatter"}
 LEVEL_FIELDS = {"z", "base_tile", "regions", "operations"}
 RECIPE_FIELDS = {
@@ -56,6 +58,7 @@ RECIPE_FIELDS = {
     "seed",
     "base_tile",
     "palette",
+    "furniture_palette",
     "patterns",
     "regions",
     "operations",
@@ -167,6 +170,8 @@ def _furniture_ids(furnitures_path: Path) -> set[str]:
 
 
 def _contains_furniture_operations(recipe: dict[str, Any]) -> bool:
+    if "furniture_palette" in recipe:
+        return True
     operation_groups = [recipe.get("operations")]
     levels = recipe.get("levels")
     if isinstance(levels, list):
@@ -176,11 +181,65 @@ def _contains_furniture_operations(recipe: dict[str, Any]) -> bool:
             if isinstance(level, dict)
         )
     return any(
-        isinstance(operation, dict) and operation.get("type") == "furniture"
+        isinstance(operation, dict)
+        and operation.get("type") in {"furniture", "furniture_scatter"}
         for operations in operation_groups
         if isinstance(operations, list)
         for operation in operations
     )
+
+
+def _validate_furniture_palette_entry(
+    entry: Any,
+    known_furnitures: set[str],
+    context: str,
+) -> dict[str, Any]:
+    if not isinstance(entry, dict):
+        raise RecipeError(f"{context} must be an object")
+    unknown_fields = sorted(set(entry) - FURNITURE_PALETTE_FIELDS)
+    if unknown_fields:
+        raise RecipeError(f"unknown {context} field '{unknown_fields[0]}'")
+    furniture_id = entry.get("id")
+    if not isinstance(furniture_id, str) or not furniture_id.strip():
+        raise RecipeError(f"{context}.id must be a non-empty string")
+    _validate_unicode(furniture_id, f"{context}.id")
+    if furniture_id not in known_furnitures:
+        raise RecipeError(f"{context}.id references unknown furniture '{furniture_id}'")
+    weight = entry.get("weight", 1)
+    if type(weight) is not int or weight <= 0:
+        raise RecipeError(f"{context}.weight must be a positive integer")
+    rotation = entry.get("rotation", 0)
+    if rotation != "random" and (
+        type(rotation) is not int or rotation not in VALID_ROTATIONS
+    ):
+        raise RecipeError(f"{context}.rotation must be 0, 90, 180, 270, or 'random'")
+    return {"id": furniture_id, "weight": weight, "rotation": rotation}
+
+
+def _validate_furniture_palette(
+    furniture_palette: Any, known_furnitures: set[str]
+) -> dict[str, list[dict[str, Any]]]:
+    if not isinstance(furniture_palette, dict):
+        raise RecipeError("furniture_palette must be an object")
+    validated: dict[str, list[dict[str, Any]]] = {}
+    for name, entries in furniture_palette.items():
+        if not isinstance(name, str) or not name.strip():
+            raise RecipeError("furniture palette names must be non-empty strings")
+        _validate_unicode(name, f"furniture_palette.{name}")
+        if DEFINITION_NAME_PATTERN.fullmatch(name) is None:
+            raise RecipeError(
+                f"furniture palette name '{name}' may contain only letters, numbers, "
+                "underscores, and hyphens"
+            )
+        if not isinstance(entries, list) or not entries:
+            raise RecipeError(f"furniture_palette.{name} must be a non-empty array")
+        validated[name] = [
+            _validate_furniture_palette_entry(
+                entry, known_furnitures, f"furniture_palette.{name}[{index}]"
+            )
+            for index, entry in enumerate(entries)
+        ]
+    return validated
 
 
 def _validate_palette_entry(
@@ -698,6 +757,74 @@ def _apply_furniture(
     }
 
 
+def _apply_furniture_scatter(
+    level: list[dict[str, Any]],
+    operation: dict[str, Any],
+    rng: random.Random,
+    furniture_palette: dict[str, list[dict[str, Any]]],
+    context: str,
+) -> None:
+    unknown_fields = sorted(set(operation) - FURNITURE_SCATTER_FIELDS)
+    if unknown_fields:
+        raise RecipeError(f"unknown {context} field '{unknown_fields[0]}'")
+    region = operation.get("region")
+    if not isinstance(region, dict):
+        raise RecipeError(f"{context}.region must be an object")
+    unknown_region_fields = sorted(set(region) - SCATTER_REGION_FIELDS)
+    if unknown_region_fields:
+        raise RecipeError(
+            f"unknown {context}.region field '{unknown_region_fields[0]}'"
+        )
+    dimensions = _rectangle_dimensions(region, f"{context}.region")
+    palette_name = operation.get("palette")
+    if not isinstance(palette_name, str) or not palette_name.strip():
+        raise RecipeError(f"{context}.palette must be a non-empty string")
+    _validate_unicode(palette_name, f"{context}.palette")
+    if palette_name not in furniture_palette:
+        raise RecipeError(
+            f"{context}.palette references unknown furniture palette '{palette_name}'"
+        )
+    has_count = "count" in operation
+    has_density = "density" in operation
+    if has_count == has_density:
+        raise RecipeError(f"{context} must define exactly one of count or density")
+    area = dimensions["width"] * dimensions["height"]
+    if has_count:
+        count = operation["count"]
+        if type(count) is not int or not 0 <= count <= area:
+            raise RecipeError(
+                f"{context}.count must be an integer between 0 and {area}"
+            )
+    else:
+        density = operation["density"]
+        if type(density) not in (int, float) or not 0 <= density <= 1:
+            raise RecipeError(f"{context}.density must be a number between 0 and 1")
+        count = int(area * density)
+    candidates = [
+        y * MAP_WIDTH + x
+        for y in range(dimensions["y"], dimensions["y"] + dimensions["height"])
+        for x in range(dimensions["x"], dimensions["x"] + dimensions["width"])
+        if isinstance(level[y * MAP_WIDTH + x].get("id"), str)
+        and level[y * MAP_WIDTH + x]["id"]
+        and "feature" not in level[y * MAP_WIDTH + x]
+    ]
+    if count > len(candidates):
+        raise RecipeError(
+            f"{context} requests {count} placements but only {len(candidates)} eligible cells remain"
+        )
+    for level_index in rng.sample(candidates, count):
+        entry = _select_weighted_palette_entry(furniture_palette[palette_name], rng)
+        rotation = entry["rotation"]
+        if rotation == "random":
+            rotation = rng.choice(VALID_ROTATIONS)
+        level[level_index]["feature"] = {
+            "type": "furniture",
+            "id": entry["id"],
+            "rotation": rotation,
+            "itemgroups": [],
+        }
+
+
 def _target_z(
     spec: dict[str, Any], context: str, inherited_z: int | None
 ) -> int:
@@ -719,6 +846,7 @@ def _apply_layout(
     palette: dict[str, list[dict[str, Any]]],
     patterns: dict[str, list[dict[str, Any]]],
     known_furnitures: set[str],
+    furniture_palette: dict[str, list[dict[str, Any]]],
     context_prefix: str = "",
     inherited_z: int | None = None,
 ) -> None:
@@ -767,6 +895,10 @@ def _apply_layout(
             )
         elif operation_type == "furniture":
             _apply_furniture(level, operation, known_furnitures, context)
+        elif operation_type == "furniture_scatter":
+            _apply_furniture_scatter(
+                level, operation, rng, furniture_palette, context
+            )
         else:
             raise RecipeError(
                 f"{context}.type has unknown operation '{operation_type}'"
@@ -780,6 +912,7 @@ def _generate_levels(
     palette: dict[str, list[dict[str, Any]]],
     patterns: dict[str, list[dict[str, Any]]],
     known_furnitures: set[str],
+    furniture_palette: dict[str, list[dict[str, Any]]],
 ) -> list[list[dict[str, Any]]]:
     levels: list[list[dict[str, Any]]] = [[] for _ in range(LEVEL_COUNT)]
     if "levels" not in recipe:
@@ -801,6 +934,7 @@ def _generate_levels(
             palette,
             patterns,
             known_furnitures,
+            furniture_palette,
         )
         return levels
 
@@ -853,6 +987,7 @@ def _generate_levels(
             palette,
             patterns,
             known_furnitures,
+            furniture_palette,
             context_prefix=f"{context}.",
             inherited_z=logical_z,
         )
@@ -898,10 +1033,19 @@ def generate_map(
             )
         known_furnitures = _furniture_ids(Path(furnitures_path))
     palette = _validate_palette(recipe.get("palette", {}), known_tiles)
+    furniture_palette = _validate_furniture_palette(
+        recipe.get("furniture_palette", {}), known_furnitures
+    )
     patterns = _validate_patterns(recipe.get("patterns", {}), known_tiles, palette)
     rng = random.Random(seed)
     levels = _generate_levels(
-        recipe, rng, known_tiles, palette, patterns, known_furnitures
+        recipe,
+        rng,
+        known_tiles,
+        palette,
+        patterns,
+        known_furnitures,
+        furniture_palette,
     )
 
     return {

--- a/Tools/tests/test_map_generator.py
+++ b/Tools/tests/test_map_generator.py
@@ -407,6 +407,145 @@ class MapGeneratorTests(unittest.TestCase):
 
         self.assertEqual(tile, {"id": "dirt_light_00"})
 
+
+    def test_furniture_scatter_uses_weighted_palette_on_eligible_cells_only(self):
+        recipe = valid_recipe()
+        recipe["seed"] = 41
+        recipe["base_tile"] = {"id": "grass_plain_01"}
+        recipe["furniture_palette"] = {
+            "forest": [
+                {"id": "Tree_00", "weight": 3, "rotation": "random"},
+                {"id": "PineTree_00", "weight": 1, "rotation": 90},
+            ]
+        }
+        recipe["operations"] = [
+            {"type": "furniture", "x": 1, "y": 1, "id": "bench_garden"},
+            {"type": "set", "x": 2, "y": 1, "tile": None},
+            {
+                "type": "furniture_scatter",
+                "region": {"x": 0, "y": 0, "width": 4, "height": 2},
+                "count": 6,
+                "palette": "forest",
+            },
+        ]
+
+        first = generate_map(recipe, TILES_PATH)
+        second = generate_map(recipe, TILES_PATH)
+        level = first["levels"][10]
+        scattered = [
+            (index % 32, index // 32, tile["feature"])
+            for index, tile in enumerate(level)
+            if tile.get("feature", {}).get("id") in {"Tree_00", "PineTree_00"}
+        ]
+
+        self.assertEqual(first, second)
+        self.assertEqual(len(scattered), 6)
+        self.assertTrue(all(0 <= x < 4 and 0 <= y < 2 for x, y, _ in scattered))
+        self.assertFalse(level[1 * 32 + 1].get("feature", {}).get("id") in {"Tree_00", "PineTree_00"})
+        self.assertEqual(level[1 * 32 + 1]["feature"]["id"], "bench_garden")
+        self.assertEqual(level[1 * 32 + 2], {})
+        self.assertTrue(
+            all(feature["rotation"] in {0, 90, 180, 270} for _, _, feature in scattered)
+        )
+
+    def test_furniture_scatter_rejects_insufficient_eligible_cells(self):
+        recipe = valid_recipe()
+        recipe["base_tile"] = {"id": "grass_plain_01"}
+        recipe["furniture_palette"] = {"forest": [{"id": "Tree_00"}]}
+        recipe["operations"] = [
+            {"type": "furniture", "x": 0, "y": 0, "id": "bench_garden"},
+            {
+                "type": "furniture_scatter",
+                "region": {"x": 0, "y": 0, "width": 2, "height": 1},
+                "count": 2,
+                "palette": "forest",
+            },
+        ]
+
+        with self.assertRaisesRegex(RecipeError, "requests 2 placements but only 1 eligible"):
+            generate_map(recipe, TILES_PATH)
+
+    def test_grouped_furniture_scatter_inherits_logical_level_and_uses_density(self):
+        recipe = valid_recipe()
+        del recipe["base_tile"]
+        del recipe["regions"]
+        recipe["furniture_palette"] = {"forest": [{"id": "Tree_00"}]}
+        recipe["levels"] = [
+            {
+                "z": 1,
+                "base_tile": {"id": "grass_plain_01"},
+                "operations": [
+                    {
+                        "type": "furniture_scatter",
+                        "region": {"x": 0, "y": 0, "width": 3, "height": 3},
+                        "density": 0.5,
+                        "palette": "forest",
+                    }
+                ],
+            }
+        ]
+
+        levels = generate_map(recipe, TILES_PATH)["levels"]
+
+        self.assertEqual(
+            sum(
+                tile.get("feature", {}).get("id") == "Tree_00"
+                for tile in levels[11]
+            ),
+            4,
+        )
+        self.assertEqual(levels[10], [])
+
+    def test_furniture_palette_and_scatter_strictly_validate_schema(self):
+        cases = [
+            (
+                {"furniture_palette": {"forest": [{"id": "missing"}]}},
+                "unknown furniture 'missing'",
+            ),
+            (
+                {"furniture_palette": {"forest": [{"id": "Tree_00", "weight": 0}]}},
+                "weight must be a positive integer",
+            ),
+            (
+                {"furniture_palette": {"forest": [{"id": "Tree_00", "rotation": 45}]}},
+                "rotation must be 0, 90, 180, 270, or 'random'",
+            ),
+            (
+                {
+                    "operations": [
+                        {
+                            "type": "furniture_scatter",
+                            "region": {"x": 0, "y": 0, "width": 1, "height": 1},
+                            "count": 1,
+                            "palette": "missing",
+                        }
+                    ]
+                },
+                "unknown furniture palette 'missing'",
+            ),
+            (
+                {
+                    "furniture_palette": {"forest": [{"id": "Tree_00"}]},
+                    "operations": [
+                        {
+                            "type": "furniture_scatter",
+                            "region": {"x": 0, "y": 0, "width": 1, "height": 1},
+                            "count": 1,
+                            "palette": "forest",
+                            "extra": True,
+                        }
+                    ],
+                },
+                r"unknown operations\[0\] field 'extra'",
+            ),
+        ]
+        for changes, expected_message in cases:
+            with self.subTest(changes=changes):
+                recipe = valid_recipe()
+                recipe.update(changes)
+                with self.assertRaisesRegex(RecipeError, expected_message):
+                    generate_map(recipe, TILES_PATH)
+
     def test_furniture_operation_strictly_validates_schema_id_and_rotation(self):
         cases = [
             (
@@ -1109,8 +1248,38 @@ class MapGeneratorTests(unittest.TestCase):
             for tile in generated["levels"][10]
             if tile.get("feature", {}).get("type") == "furniture"
         }
+        furniture_tiles = [
+            tile
+            for tile in generated["levels"][10]
+            if tile.get("feature", {}).get("type") == "furniture"
+        ]
 
-        self.assertEqual(furniture_ids, {"bench_garden", "Tree_00", "PineTree_00"})
+        self.assertTrue(
+            {"bench_garden", "campfire_off", "plant_pot_00"}.issubset(furniture_ids)
+        )
+        self.assertTrue(
+            furniture_ids <= {
+                "Tree_00",
+                "PineTree_00",
+                "WillowTree_00",
+                "burned_tree_stump",
+                "bench_garden",
+                "campfire_off",
+                "plant_pot_00",
+            }
+        )
+        self.assertEqual(len(furniture_tiles), 27)
+        self.assertTrue(
+            any(
+                tile["feature"]["id"] in {
+                    "Tree_00",
+                    "PineTree_00",
+                    "WillowTree_00",
+                    "burned_tree_stump",
+                }
+                for tile in furniture_tiles
+            )
+        )
         self.assertTrue(
             all(
                 tile.get("id")


### PR DESCRIPTION
## Summary

Advance Phase 5 map generation with deterministic outdoor furniture
distribution.

- add root-level weighted `furniture_palette` definitions;
- add bounded `furniture_scatter` operations;
- restrict scatter candidates to terrain cells without a feature;
- preserve explicit furniture features already placed in the region;
- support explicit root logical `z` and grouped-level inheritance;
- validate furniture IDs, weights, rotations, palette references,
  regions, counts, densities, and unknown fields;
- fail clearly before placement when the requested count exceeds
  eligible cells;
- expand the maintained furnished clearing;
- update generator, example, and roadmap documentation.

## Determinism

Furniture scatter:

1. enumerates eligible target cells in row-major order;
2. samples unique cells with the recipe RNG;
3. selects weighted palette entries in sample order;
4. resolves `rotation: "random"` in that same order.

The same complete recipe and seed produce identical JSON. As with
existing tile palettes and scatter, changing an earlier RNG-consuming
operation can change later selections.

## Maintained example

`map_recipe_furniture_outdoor.json` now contains:

- garden bench at `[16, 16]`;
- unlit campfire at `[15, 16]`;
- movable potted plant at `[17, 16]`;
- 24 weighted tree, pine, willow, or burned-stump placements over a
  `16×16` ground-level clearing.

The generated map has 27 furniture features total.

## Content inventory finding

The core furniture database currently has no rock, grass, or
wild-vegetation furniture definitions. This PR does not create
invented IDs or claim to generate unavailable assets.

The roadmap now identifies the required follow-up: inspect the
furnished clearing at runtime and decide whether normal content work
should add real outdoor rock/vegetation assets, or whether the Phase 5
success criterion should use existing terrain detail instead.

## Validation

- Python suite: 65/65 passed;
- complete Godot GUT suite: 80/80 passed, 376 assertions;
- all four maintained recipes generated and validated;
- furnished clearing: 27 generated furniture features;
- batch furnished variants: 2 generated and cleanup-verified;
- full existing core map validation: 51 files, no errors;
- Python compilation passed;
- Godot 4.7 headless editor initialization passed;
- `git diff --check` passed.

## Scope exclusions

This PR intentionally does not add:

- itemgroup population;
- multi-tile or tall furniture;
- automatic support or adjacent-level inference;
- rooms, buildings, roads, towns, or semantic areas;
- nested feature templates;
- unbacked rock or vegetation IDs.