### PR TITLE
Add level-aware runtime area generation foundation

### DIFF
--- a/Documentation/Game_design/Map_generation_plan.md
+++ b/Documentation/Game_design/Map_generation_plan.md
@@ -535,7 +535,7 @@ This success criterion is met. The maintained recipes generate valid two-level m
 
 ## Phase 5 — Features and furniture
 
-**Status: in progress; dedicated outdoor art delivered, final inspection remains**
+**Status: complete**
 
 This is where generated maps start becoming playable rather than merely visual.
 
@@ -583,11 +583,11 @@ Delivered:
 * two new core static Nature furniture definitions: `rock_field_00` and `wild_vegetation_00`, using dedicated AI-generated 32×32 sprites `ai_rock_32_32.png` and `ai_vegetation_32_32.png` in the core furniture sprite directory;
 * maintained-example reference entries and a weighted groundcover scatter pass containing the new rock and vegetation IDs, giving the clearing trees, rocks, vegetation, and simple decorative/interactable objects without changing the feature schema.
 
-Still required before Phase 5 is complete:
+Final verification:
 
-* visual and gameplay inspection of `rock_field_00` and `wild_vegetation_00` with their dedicated AI-generated sprites;
-* decisions about furniture itemgroup authoring, multi-tile footprints, tall features, and adjacent-level conflicts, each introduced only when supported by runtime evidence;
-* documented editor and `save and test` results for the dedicated rock and vegetation assets.
+* the temporary art was replaced with dedicated AI-generated sprites `ai_rock_32_32.png` and `ai_vegetation_32_32.png`;
+* the maintainer regenerated `generated_furnished_clearing`, inspected it in the editor with `save and test`, and confirmed that both rock and wild-vegetation furniture spawn without issues;
+* the generated clearing therefore meets this phase's outdoor-composition success criterion with trees, rocks, vegetation, and simple decorative/interactable objects.
 
 ### Success criterion
 
@@ -595,9 +595,25 @@ Generate an outdoor map with trees, rocks, vegetation, and simple interactable o
 
 ## Phase 6 — Areas, rooms, and buildings
 
-**Status: planned**
+**Status: in progress; level-aware runtime area foundation complete**
 
 The generator needs semantic areas before it can create convincing buildings.
+
+### Completed foundation
+
+The established map contract was inspected before extending the generator:
+
+* `DMap` serializes area definitions in the map-level `areas` array;
+* the map editor stores spatial membership in each terrain tile as an `areas` array of `{ "id", "rotation" }` references;
+* `Helper.map_manager.process_areas_in_map()` selects a definition by `spawn_chance` and applies it to connected tile-membership clusters on every populated level;
+* distinct area IDs may overlap on one tile, matching editor/runtime behavior; a duplicate reference to the same area ID is rejected by the recipe generator;
+* memberships do not introduce a new parallel map representation and do not replace terrain or features.
+
+The recipe generator now supports strict root `areas` definitions plus an `area_rectangle` operation. The operation uses existing logical-level rules: root operations default to `z: 0`, can target `-10` through `10`, and grouped operations inherit their containing level. It requires supporting terrain, validates its named area, uses only editor-facing quarter-turn rotations, and serializes the existing runtime/editor tile membership object.
+
+`Tools/examples/map_recipe_area_meadow.json` is the maintained evidence: a deterministic `12×12` `meadow_clearing` membership rectangle from `[10, 10]` through `[21, 21]` at `z: 0`, with a 100-percent runtime rule that applies `grass_dirt_00`. Python coverage verifies level placement, malformed references, duplicate memberships, unsupported cells, maintained-example bounds, and validator shape/rotation checks.
+
+This foundation intentionally does **not** yet define polygons, room boundaries, indoor/outdoor semantics, entity-placement behavior beyond preserving the existing area definition structure, walls, doors, roofs, building footprints, anchors, or generalized templates.
 
 Capabilities:
 
@@ -832,11 +848,9 @@ An agent can create a new playable, potentially multi-level map from a concise d
 
 # Recommended immediate next task
 
-The next contribution should finish the remaining dedicated-asset inspection evidence needed for **Phase 5**, without widening the generator schema.
+**Phase 6 is in progress.** Its first, runtime-compatible area foundation is complete. The next contribution should add the smallest evidenced room-boundary or indoor/outdoor semantic extension, only after confirming how the existing editor and runtime distinguish those concepts.
 
-The furnished clearing has been inspected in the map editor and with `save and test`; the maintainer verified all its prior features. Regenerate it and inspect `rock_field_00` and `wild_vegetation_00`, which now use `ai_rock_32_32.png` and `ai_vegetation_32_32.png`.
-
-Record the new editor and gameplay result, including sprite appearance, static spawning, collision, and local navigation behavior. Do not add multi-tile footprints, itemgroup generation, automatic support inference, rooms, buildings, roads, towns, nested patterns, or generalized feature templates.
+Do not yet add walls, doors, roofs, multi-level building footprints, furniture anchors, roads, towns, or generalized building templates. Preserve the established map-level `areas` plus per-tile membership representation, and validate any new semantics in the editor and runtime.
 
 Run the complete Python suite, relevant Godot tests or smoke checks, all maintained example generations through `Tools/map_validator.py`, and `git diff --check`.
 
@@ -868,8 +882,10 @@ Do not commit or push unless explicitly requested.
 [Complete] Furnished-clearing editor and runtime verification
 [Complete] Outdoor rock and wild-vegetation content definitions
 [Complete] Dedicated AI-generated outdoor sprite replacement
-[Next]     Final Phase 5 outdoor-asset inspection
-[Planned]  Level-aware areas and buildings
+[Complete] Final Phase 5 outdoor-asset inspection
+[Complete] Level-aware runtime area schema and maintained example
+[Next]     Room-boundary or indoor/outdoor semantics investigation
+[Planned]  Rooms and buildings
 [Planned]  Roads and map connections
 [Planned]  Multi-level reusable templates and richer composition
 [Planned]  Semantic map planning

--- a/Documentation/Modding/map_example_generation.md
+++ b/Documentation/Modding/map_example_generation.md
@@ -24,6 +24,7 @@ The maintained recipe examples are:
 |---|---|---|
 | `Tools/examples/map_recipe.json` | `Mods/Dimensionfall/Maps/generated_meadow_prototype.json` | Ground-level palettes, placement operations, scatter, and reusable patterns. |
 | `Tools/examples/map_recipe_furniture_outdoor.json` | `Mods/Dimensionfall/Maps/generated_furnished_clearing.json` | Explicit decor plus weighted, conflict-aware tree, rock, and wild-vegetation scatter on supported terrain at logical `z: 0`. |
+| `Tools/examples/map_recipe_area_meadow.json` | `Mods/Dimensionfall/Maps/generated_area_meadow.json` | One runtime area definition and a `12×12` terrain-backed `area_rectangle` membership boundary at logical `z: 0`. |
 | `Tools/examples/map_recipe_two_level_hill.json` | `Mods/Dimensionfall/Maps/generated_two_level_hill.json` | Ground level `z: 0`, raised terrain at `z: 1`, and all four slope rotations. |
 | `Tools/examples/map_recipe_two_level_depression.json` | `Mods/Dimensionfall/Maps/generated_two_level_depression.json` | Ground level `z: 0`, lowered terrain at `z: -1`, and all four slope rotations. |
 
@@ -52,6 +53,11 @@ python3 Tools/map_generator.py \
   Tools/examples/map_recipe_furniture_outdoor.json \
   Mods/Dimensionfall/Maps/generated_furnished_clearing.json
 
+# Ground-level runtime area meadow
+python3 Tools/map_generator.py \
+  Tools/examples/map_recipe_area_meadow.json \
+  Mods/Dimensionfall/Maps/generated_area_meadow.json
+
 # Two-level hill
 python3 Tools/map_generator.py \
   Tools/examples/map_recipe_two_level_hill.json \
@@ -77,6 +83,7 @@ After generating a map, start or restart Godot and follow the content-editor ste
 ```bash
 rm Mods/Dimensionfall/Maps/generated_meadow_prototype.json
 rm Mods/Dimensionfall/Maps/generated_furnished_clearing.json
+rm Mods/Dimensionfall/Maps/generated_area_meadow.json
 rm Mods/Dimensionfall/Maps/generated_two_level_hill.json
 rm Mods/Dimensionfall/Maps/generated_two_level_depression.json
 ```
@@ -142,7 +149,9 @@ Content Manager
 
 If Godot was already running when files were generated, restart it so mod content is loaded again. The existing map-editor preview displays generated map JSON; the Python tool does not create a separate image or HTML preview.
 
-For the maintained furnished clearing, confirm that the editor shows a garden bench at `[16, 16]`, an unlit campfire at `[15, 16]`, and a potted plant at `[17, 16]`. It deterministically scatters 24 trees or burned stumps, then 16 rocks or wild-vegetation features, over the 16×16 clearing while leaving those three authored features untouched. The maintainer has inspected the prior tree/decor clearing in the editor with `save and test` and verified all its features. Re-run that inspection after generating this version and specifically check the new rock and vegetation entries. `rock_field_00` uses the dedicated AI-generated `ai_rock_32_32.png`, and `wild_vegetation_00` uses the dedicated AI-generated `ai_vegetation_32_32.png`. The recipe intentionally leaves `itemgroups` empty and does not exercise container contents, multi-cell occupancy, or cross-level support rules.
+For the maintained furnished clearing, confirm that the editor shows a garden bench at `[16, 16]`, an unlit campfire at `[15, 16]`, and a potted plant at `[17, 16]`. It deterministically scatters 24 trees or burned stumps, then 16 rocks or wild-vegetation features, over the 16×16 clearing while leaving those three authored features untouched. The maintainer inspected the clearing in the editor with `save and test` after the dedicated AI sprites were installed and confirmed that the rock and wild-vegetation furniture spawn without issues. `rock_field_00` uses `ai_rock_32_32.png`, and `wild_vegetation_00` uses `ai_vegetation_32_32.png`. The recipe intentionally leaves `itemgroups` empty and does not exercise container contents, multi-cell occupancy, or cross-level support rules.
+
+For the maintained area meadow, confirm that the area list contains `meadow_clearing` and the editor highlights exactly the `12×12` rectangle from `[10, 10]` through `[21, 21]` at logical `z: 0`. The definition has a `100` percent spawn chance and replaces that connected membership cluster with `grass_dirt_00`; use `save and test` to confirm the runtime applies the area without affecting outside terrain. The example deliberately contains no entities, rooms, walls, doors, or building semantics.
 
 Dimensionfall also looks for a same-named `.png` map sprite during startup. The runner intentionally generates map JSON only, so Godot currently logs a non-fatal missing-resource error for that sprite. This does not prevent the JSON map from loading or the map editor's tile-grid preview from rendering it.
 
@@ -276,6 +285,6 @@ PY
 ## Current limitations
 
 - Variants change the recipe seed; they do not synthesize new recipe operations.
-- Generated maps support terrain plus explicit known single-cell furniture and deterministic weighted furniture scatter over eligible terrain cells. The maintained clearing uses dedicated AI-generated rock and wild-vegetation sprites. Itemgroup contents, multi-tile or tall features, automatic support inference, areas, buildings, semantic roads, and multi-level templates are not supported yet.
+- Generated maps support terrain, explicit known single-cell furniture, deterministic weighted furniture scatter, and runtime-compatible rectangular area memberships at explicit logical levels. The maintained clearing uses dedicated AI-generated rock and wild-vegetation sprites. Itemgroup contents, multi-tile or tall features, automatic support inference, polygonal areas, rooms, buildings, semantic roads, and multi-level templates are not supported yet.
 - The maps can be inspected with the existing content-editor preview, but the runner does not launch Godot or inject maps into an already-running editor session.
 - Installing examples under `Mods/Dimensionfall/Maps` makes them available to the content editor, but does not automatically reference them from overmap-area generation.

--- a/Documentation/Modding/map_recipe_generator.md
+++ b/Documentation/Modding/map_recipe_generator.md
@@ -30,6 +30,7 @@ The root must be a JSON object with these fields:
 | `base_tile` | tile object | Legacy-mode tile initially placed in every cell at `z: 0`. Required unless `levels` is used. |
 | `palette` | object | Named weighted tile sets that tile objects can reference. Optional; defaults to `{}`. |
 | `furniture_palette` | object | Named weighted furniture sets used by `furniture_scatter`. Optional; defaults to `{}`. |
+| `areas` | array | Strict runtime area definitions referenced by `area_rectangle`. Optional; defaults to `[]`. |
 | `patterns` | object | Named arrays of relative tile placements used by `pattern` operations. Optional; defaults to `{}`. |
 | `regions` | array | Legacy filled rectangles. Optional; defaults to `[]`. |
 | `operations` | array | Ordered placement operations. Optional; defaults to `[]`. |
@@ -171,6 +172,51 @@ Definitions themselves consume no randomness. An invoked `furniture_scatter` fir
 
 Every operation requires a `type`. Unknown operation types and fields are errors. At the recipe root, every operation accepts optional logical `z` and defaults to `0`. Inside a grouped level, the operation inherits `z` and must omit the field.
 
+## Runtime areas and tile membership
+
+Dimensionfall's existing area system has two linked serialized forms:
+
+1. the map-level `areas` array defines a runtime spawn/transformation rule; and
+2. a terrain tile's `areas` array records membership as `{"id": "...", "rotation": 0}`.
+
+At runtime, `Helper.map_manager.process_areas_in_map()` selects definitions by `spawn_chance`, then applies each selected definition to connected clusters of matching tile memberships on every populated level. The editor displays these memberships and permits multiple *different* area IDs on one tile, so recipe generation preserves that supported overlay behavior. It rejects a duplicate membership of the same area ID on the same cell.
+
+Recipe area definitions require exactly `id`, `spawn_chance`, `rotate_random`, `pick_one`, `tiles`, and `entities`. Area IDs use letters, numbers, `_`, and `-`; `spawn_chance` is an integer from `0` through `100`; `rotate_random` and `pick_one` are booleans. `tiles` is a non-empty array of `{ "id", "count" }` entries whose IDs are known tiles or the runtime's `"null"` sentinel. `entities` is an array of `{ "id", "type", "count" }` entries. This slice preserves the established entity data contract rather than adding new entity placement semantics.
+
+```json
+{
+  "areas": [
+    {
+      "id": "meadow_clearing",
+      "spawn_chance": 100,
+      "rotate_random": false,
+      "pick_one": false,
+      "tiles": [{"id": "grass_dirt_00", "count": 1}],
+      "entities": []
+    }
+  ]
+}
+```
+
+### `area_rectangle`
+
+Adds one area membership to every terrain tile in a filled rectangle. Fields are `type`, `area`, `x`, `y`, positive `width`, positive `height`, optional root-level `z`, and optional editor-facing `rotation`. The rotation defaults to `0` and accepts `0`, `90`, `180`, or `270`.
+
+```json
+{
+  "type": "area_rectangle",
+  "area": "meadow_clearing",
+  "x": 10,
+  "y": 10,
+  "width": 12,
+  "height": 12,
+  "z": 0,
+  "rotation": 0
+}
+```
+
+The referenced top-level area must exist and every target cell must already contain terrain at the selected logical level. A membership operation does not replace terrain, features, or other distinct area memberships, and consumes no RNG. Coordinates are preflighted against the complete `32×32` map, so the operation cannot be clipped or partially applied.
+
 ### `set`
 
 Places one tile. Fields: `type`, `x`, `y`, `tile`, and optional root-level `z`.
@@ -292,13 +338,13 @@ Places a bounded number of single-cell furniture features selected from a named 
 
 ## Validation and limitations
 
-The generator rejects unknown fields at every recipe level, root-level dimension fields, malformed or out-of-bounds placements, logical levels outside `-10` through `10`, duplicate grouped levels, ambiguous root/grouped layouts, malformed tile or furniture databases, unknown tile and furniture IDs, malformed weights, unsupported furniture cells, feature conflicts, scatter requests that exceed eligible cells, invalid rotations, invalid Unicode, and non-object recipes. It validates generated data with `Tools/map_validator.py` before publishing the output. The validator independently requires exactly 21 level arrays and exactly 1024 entries in every populated level, and structurally validates embedded furniture fields, IDs, rotations, and itemgroup arrays.
+The generator rejects unknown fields at every recipe level, root-level dimension fields, malformed or out-of-bounds placements, logical levels outside `-10` through `10`, duplicate grouped levels, ambiguous root/grouped layouts, malformed tile or furniture databases, unknown tile and furniture IDs, malformed area definitions or memberships, duplicate area IDs or same-ID tile memberships, unsupported area cells, feature conflicts, scatter requests that exceed eligible cells, invalid rotations, invalid Unicode, and non-object recipes. It validates generated data with `Tools/map_validator.py` before publishing the output. The validator independently requires exactly 21 level arrays and exactly 1024 entries in every populated level, and structurally validates embedded furniture fields, IDs, rotations, itemgroup arrays, and area-reference arrays.
 
 The output uses 21 levels; logical `z: 0` is row-major grid index `10`. It sets `categories` to `[]`, `weight` to `1000`, and all four connections to `"ground"`. It omits `areas`, matching `DMap.get_data()` when the area list is empty.
 
-The generator currently creates explicit, known, single-cell furniture features and deterministic weighted furniture scatter over eligible terrain. The core mod defines `rock_field_00` and `wild_vegetation_00` for outdoor composition, using the dedicated AI-generated sprites `ai_rock_32_32.png` and `ai_vegetation_32_32.png`. It does not yet support furniture itemgroup contents, multiple features per cell, multi-tile or tall-object occupancy, automatic support inference, other feature types, areas, roads as semantic objects, buildings, towns, nested or multi-level patterns, or shape-based templates.
+The generator currently creates explicit, known, single-cell furniture features, deterministic weighted furniture scatter over eligible terrain, and strict runtime-compatible rectangular area memberships at explicit logical levels. The core mod defines `rock_field_00` and `wild_vegetation_00` for outdoor composition, using the dedicated AI-generated sprites `ai_rock_32_32.png` and `ai_vegetation_32_32.png`. It does not yet support furniture itemgroup contents, multiple features per cell, multi-tile or tall-object occupancy, automatic support inference, polygonal areas, rooms, walls, doors, buildings, roads as semantic objects, towns, nested or multi-level patterns, or shape-based templates.
 
-The maintained furniture example is `Tools/examples/map_recipe_furniture_outdoor.json`. Maintained structural examples are available at `Tools/examples/map_recipe_two_level_hill.json` and `Tools/examples/map_recipe_two_level_depression.json`. They use `grass_ramp_00`, whose tile definition has `shape: "slope"`.
+The maintained area example is `Tools/examples/map_recipe_area_meadow.json`. The maintained furniture example is `Tools/examples/map_recipe_furniture_outdoor.json`. Maintained structural examples are available at `Tools/examples/map_recipe_two_level_hill.json` and `Tools/examples/map_recipe_two_level_depression.json`. They use `grass_ramp_00`, whose tile definition has `shape: "slope"`.
 
 Slope rotations in recipes use the same values shown by the map editor:
 

--- a/Tools/examples/map_recipe_area_meadow.json
+++ b/Tools/examples/map_recipe_area_meadow.json
@@ -1,0 +1,46 @@
+{
+	"id": "generated_area_meadow",
+	"name": "Generated Area Meadow",
+	"description": "A deterministic meadow with one runtime area rule and a level-aware rectangular membership boundary.",
+	"seed": 20260805,
+	"base_tile": {
+		"id": "grass_plain_01"
+	},
+	"areas": [
+		{
+			"id": "meadow_clearing",
+			"spawn_chance": 100,
+			"rotate_random": false,
+			"pick_one": false,
+			"tiles": [
+				{
+					"id": "grass_dirt_00",
+					"count": 1
+				}
+			],
+			"entities": []
+		}
+	],
+	"operations": [
+		{
+			"type": "rectangle",
+			"x": 10,
+			"y": 10,
+			"width": 12,
+			"height": 12,
+			"tile": {
+				"id": "grass_dirt_00"
+			}
+		},
+		{
+			"type": "area_rectangle",
+			"area": "meadow_clearing",
+			"x": 10,
+			"y": 10,
+			"width": 12,
+			"height": 12,
+			"z": 0,
+			"rotation": 0
+		}
+	]
+}

--- a/Tools/map_generator.py
+++ b/Tools/map_generator.py
@@ -49,6 +49,17 @@ PATTERN_CELL_FIELDS = {"at", "tile"}
 PATTERN_OPERATION_FIELDS = {"type", "pattern", "at", "z", "rotation"}
 FURNITURE_OPERATION_FIELDS = {"type", "x", "y", "z", "id", "rotation"}
 FURNITURE_SCATTER_FIELDS = {"type", "region", "z", "palette", "count", "density"}
+AREA_RECTANGLE_FIELDS = {"type", "area", "x", "y", "z", "width", "height", "rotation"}
+AREA_DEFINITION_FIELDS = {
+    "id",
+    "spawn_chance",
+    "rotate_random",
+    "pick_one",
+    "tiles",
+    "entities",
+}
+AREA_TILE_FIELDS = {"id", "count"}
+AREA_ENTITY_FIELDS = {"id", "type", "count"}
 TILE_OPERATION_TYPES = {"set", "rectangle", "rectangle_outline", "line", "scatter"}
 LEVEL_FIELDS = {"z", "base_tile", "regions", "operations"}
 RECIPE_FIELDS = {
@@ -59,6 +70,7 @@ RECIPE_FIELDS = {
     "base_tile",
     "palette",
     "furniture_palette",
+    "areas",
     "patterns",
     "regions",
     "operations",
@@ -825,6 +837,126 @@ def _apply_furniture_scatter(
         }
 
 
+def _validate_recipe_areas(
+    areas: Any, known_tiles: set[str]
+) -> list[dict[str, Any]]:
+    if not isinstance(areas, list):
+        raise RecipeError("areas must be an array")
+    validated: list[dict[str, Any]] = []
+    seen_ids: set[str] = set()
+    for index, area in enumerate(areas):
+        context = f"areas[{index}]"
+        if not isinstance(area, dict):
+            raise RecipeError(f"{context} must be an object")
+        unknown_fields = sorted(set(area) - AREA_DEFINITION_FIELDS)
+        if unknown_fields:
+            raise RecipeError(f"unknown {context} field '{unknown_fields[0]}'")
+        missing_fields = sorted(AREA_DEFINITION_FIELDS - set(area))
+        if missing_fields:
+            raise RecipeError(f"{context} is missing required field '{missing_fields[0]}'")
+        area_id = area["id"]
+        if not isinstance(area_id, str) or not area_id.strip():
+            raise RecipeError(f"{context}.id must be a non-empty string")
+        _validate_unicode(area_id, f"{context}.id")
+        if DEFINITION_NAME_PATTERN.fullmatch(area_id) is None:
+            raise RecipeError(
+                f"{context}.id may contain only letters, numbers, underscores, and hyphens"
+            )
+        if area_id in seen_ids:
+            raise RecipeError(f"duplicate area ID '{area_id}'")
+        seen_ids.add(area_id)
+        if type(area["spawn_chance"]) is not int or not 0 <= area["spawn_chance"] <= 100:
+            raise RecipeError(f"{context}.spawn_chance must be an integer between 0 and 100")
+        for field in ("rotate_random", "pick_one"):
+            if type(area[field]) is not bool:
+                raise RecipeError(f"{context}.{field} must be a boolean")
+        if not isinstance(area["tiles"], list) or not area["tiles"]:
+            raise RecipeError(f"{context}.tiles must be a non-empty array")
+        validated_tiles: list[dict[str, Any]] = []
+        for tile_index, tile in enumerate(area["tiles"]):
+            tile_context = f"{context}.tiles[{tile_index}]"
+            if not isinstance(tile, dict):
+                raise RecipeError(f"{tile_context} must be an object")
+            unknown_tile_fields = sorted(set(tile) - AREA_TILE_FIELDS)
+            if unknown_tile_fields:
+                raise RecipeError(f"unknown {tile_context} field '{unknown_tile_fields[0]}'")
+            if set(tile) != AREA_TILE_FIELDS:
+                raise RecipeError(f"{tile_context} must define id and count")
+            tile_id = tile["id"]
+            if not isinstance(tile_id, str) or not tile_id.strip():
+                raise RecipeError(f"{tile_context}.id must be a non-empty string")
+            if tile_id != "null" and tile_id not in known_tiles:
+                raise RecipeError(f"{tile_context}.id references unknown tile '{tile_id}'")
+            if type(tile["count"]) is not int or tile["count"] <= 0:
+                raise RecipeError(f"{tile_context}.count must be a positive integer")
+            validated_tiles.append({"id": tile_id, "count": tile["count"]})
+        if not isinstance(area["entities"], list):
+            raise RecipeError(f"{context}.entities must be an array")
+        validated_entities: list[dict[str, Any]] = []
+        for entity_index, entity in enumerate(area["entities"]):
+            entity_context = f"{context}.entities[{entity_index}]"
+            if not isinstance(entity, dict):
+                raise RecipeError(f"{entity_context} must be an object")
+            unknown_entity_fields = sorted(set(entity) - AREA_ENTITY_FIELDS)
+            if unknown_entity_fields:
+                raise RecipeError(f"unknown {entity_context} field '{unknown_entity_fields[0]}'")
+            if set(entity) != AREA_ENTITY_FIELDS:
+                raise RecipeError(f"{entity_context} must define id, type, and count")
+            if not isinstance(entity["id"], str) or not entity["id"].strip():
+                raise RecipeError(f"{entity_context}.id must be a non-empty string")
+            if not isinstance(entity["type"], str) or not entity["type"].strip():
+                raise RecipeError(f"{entity_context}.type must be a non-empty string")
+            if type(entity["count"]) is not int or entity["count"] <= 0:
+                raise RecipeError(f"{entity_context}.count must be a positive integer")
+            validated_entities.append(
+                {"id": entity["id"], "type": entity["type"], "count": entity["count"]}
+            )
+        validated.append(
+            {
+                "id": area_id,
+                "spawn_chance": area["spawn_chance"],
+                "rotate_random": area["rotate_random"],
+                "pick_one": area["pick_one"],
+                "tiles": validated_tiles,
+                "entities": validated_entities,
+            }
+        )
+    return validated
+
+
+def _apply_area_rectangle(
+    level: list[dict[str, Any]],
+    operation: dict[str, Any],
+    known_area_ids: set[str],
+    context: str,
+) -> None:
+    unknown_fields = sorted(set(operation) - AREA_RECTANGLE_FIELDS)
+    if unknown_fields:
+        raise RecipeError(f"unknown {context} field '{unknown_fields[0]}'")
+    area_id = operation.get("area")
+    if not isinstance(area_id, str) or not area_id.strip():
+        raise RecipeError(f"{context}.area must be a non-empty string")
+    if area_id not in known_area_ids:
+        raise RecipeError(f"{context}.area references unknown area '{area_id}'")
+    dimensions = _rectangle_dimensions(operation, context)
+    rotation = operation.get("rotation", 0)
+    if type(rotation) is not int or rotation not in VALID_ROTATIONS:
+        raise RecipeError(f"{context}.rotation must be 0, 90, 180, or 270")
+    for y in range(dimensions["y"], dimensions["y"] + dimensions["height"]):
+        for x in range(dimensions["x"], dimensions["x"] + dimensions["width"]):
+            tile = level[y * MAP_WIDTH + x]
+            if not isinstance(tile.get("id"), str) or not tile["id"]:
+                raise RecipeError(f"{context} requires supporting terrain at [{x}, {y}]")
+            existing_areas = tile.get("areas", [])
+            if any(reference.get("id") == area_id for reference in existing_areas):
+                raise RecipeError(f"{context} duplicates area '{area_id}' at [{x}, {y}]")
+    for y in range(dimensions["y"], dimensions["y"] + dimensions["height"]):
+        for x in range(dimensions["x"], dimensions["x"] + dimensions["width"]):
+            level[y * MAP_WIDTH + x].setdefault("areas", []).append(
+                {"id": area_id, "rotation": rotation}
+            )
+
+
 def _target_z(
     spec: dict[str, Any], context: str, inherited_z: int | None
 ) -> int:
@@ -847,6 +979,7 @@ def _apply_layout(
     patterns: dict[str, list[dict[str, Any]]],
     known_furnitures: set[str],
     furniture_palette: dict[str, list[dict[str, Any]]],
+    known_area_ids: set[str],
     context_prefix: str = "",
     inherited_z: int | None = None,
 ) -> None:
@@ -899,6 +1032,8 @@ def _apply_layout(
             _apply_furniture_scatter(
                 level, operation, rng, furniture_palette, context
             )
+        elif operation_type == "area_rectangle":
+            _apply_area_rectangle(level, operation, known_area_ids, context)
         else:
             raise RecipeError(
                 f"{context}.type has unknown operation '{operation_type}'"
@@ -913,6 +1048,7 @@ def _generate_levels(
     patterns: dict[str, list[dict[str, Any]]],
     known_furnitures: set[str],
     furniture_palette: dict[str, list[dict[str, Any]]],
+    known_area_ids: set[str],
 ) -> list[list[dict[str, Any]]]:
     levels: list[list[dict[str, Any]]] = [[] for _ in range(LEVEL_COUNT)]
     if "levels" not in recipe:
@@ -935,6 +1071,7 @@ def _generate_levels(
             patterns,
             known_furnitures,
             furniture_palette,
+            known_area_ids,
         )
         return levels
 
@@ -988,6 +1125,7 @@ def _generate_levels(
             patterns,
             known_furnitures,
             furniture_palette,
+            known_area_ids,
             context_prefix=f"{context}.",
             inherited_z=logical_z,
         )
@@ -1037,6 +1175,8 @@ def generate_map(
         recipe.get("furniture_palette", {}), known_furnitures
     )
     patterns = _validate_patterns(recipe.get("patterns", {}), known_tiles, palette)
+    areas = _validate_recipe_areas(recipe.get("areas", []), known_tiles)
+    known_area_ids = {area["id"] for area in areas}
     rng = random.Random(seed)
     levels = _generate_levels(
         recipe,
@@ -1046,9 +1186,10 @@ def generate_map(
         patterns,
         known_furnitures,
         furniture_palette,
+        known_area_ids,
     )
 
-    return {
+    generated = {
         "id": recipe["id"],
         "name": recipe["name"],
         "description": recipe["description"],
@@ -1059,6 +1200,9 @@ def generate_map(
         "levels": levels,
         "connections": DEFAULT_CONNECTIONS.copy(),
     }
+    if areas:
+        generated["areas"] = areas
+    return generated
 
 
 def main(argv: list[str] | None = None) -> int:

--- a/Tools/map_validator.py
+++ b/Tools/map_validator.py
@@ -57,6 +57,9 @@ class MapValidator:
         map_id = data['id']
         levels = data['levels']
         areas = data.get('areas', [])
+        if not isinstance(areas, list):
+            self.add_error(file_path, "top-level areas must be an array.")
+            areas = []
 
         # 2. Check Optional Metadata Types
         metadata_checks = {
@@ -197,18 +200,41 @@ class MapValidator:
                                     f"Level {level_idx}, Furniture ID '{furniture_id}' itemgroups must be an array of strings"
                                 )
 
-                    # Area References Check
-                    if 'areas' in tile and isinstance(tile['areas'], list):
-                        for area_ref in tile['areas']:
+                    # Area references use the editor/runtime contract: an array of
+                    # {id, rotation?} dictionaries embedded in a terrain tile.
+                    if 'areas' in tile:
+                        area_references = tile['areas']
+                        if not isinstance(area_references, list):
+                            self.add_error(
+                                file_path,
+                                f"Level {level_idx}, Tile '{tile['id']}' areas must be an array."
+                            )
+                            continue
+                        for area_ref in area_references:
                             if not isinstance(area_ref, dict):
                                 self.add_error(file_path, f"Level {level_idx}, Tile '{tile['id']}' has malformed area reference.")
                                 continue
                             
                             ref_id = area_ref.get('id')
-                            if not ref_id:
+                            if not isinstance(ref_id, str) or not ref_id:
                                 self.add_error(file_path, f"Level {level_idx}, Tile '{tile['id']}' references an area without an ID.")
                             elif ref_id not in area_ids:
                                 self.add_error(file_path, f"Level {level_idx}, Tile '{tile['id']}' references non-existent area '{ref_id}'")
+                            if 'rotation' in area_ref:
+                                rotation = area_ref['rotation']
+                                valid_area_rotations = {0, 90, 180, 270}
+                                try:
+                                    float_rotation = float(rotation) % 360
+                                    if float_rotation not in valid_area_rotations:
+                                        self.add_error(
+                                            file_path,
+                                            f"Level {level_idx}, Tile '{tile['id']}' has invalid area rotation: {rotation}"
+                                        )
+                                except (ValueError, TypeError):
+                                    self.add_error(
+                                        file_path,
+                                        f"Level {level_idx}, Tile '{tile['id']}' has non-numeric area rotation: {rotation}"
+                                    )
 
     def run(self, path: str):
         if os.path.isdir(path):

--- a/Tools/tests/test_map_generator.py
+++ b/Tools/tests/test_map_generator.py
@@ -1314,6 +1314,123 @@ class MapGeneratorTests(unittest.TestCase):
         }
         self.assertEqual(palette_ids, {"rock_field_00", "wild_vegetation_00"})
 
+    def test_area_rectangle_serializes_runtime_area_definition_at_explicit_level(self):
+        recipe = valid_recipe()
+        recipe["areas"] = [
+            {
+                "id": "meadow_clearing",
+                "spawn_chance": 100,
+                "rotate_random": False,
+                "pick_one": False,
+                "tiles": [{"id": "grass_dirt_00", "count": 1}],
+                "entities": [],
+            }
+        ]
+        recipe["operations"] = [
+            {
+                "type": "rectangle",
+                "x": 0,
+                "y": 0,
+                "width": 32,
+                "height": 32,
+                "z": 1,
+                "tile": {"id": "grass_plain_01"},
+            },
+            {
+                "type": "area_rectangle",
+                "area": "meadow_clearing",
+                "x": 4,
+                "y": 5,
+                "width": 3,
+                "height": 2,
+                "z": 1,
+                "rotation": 90,
+            }
+        ]
+
+        generated = generate_map(recipe, TILES_PATH)
+
+        self.assertEqual(generated["areas"], recipe["areas"])
+        self.assertEqual(generated["levels"][10][5 * 32 + 4]["id"], "grass_plain_01")
+        self.assertNotIn("areas", generated["levels"][10][5 * 32 + 4])
+        for y in range(5, 7):
+            for x in range(4, 7):
+                self.assertEqual(
+                    generated["levels"][11][y * 32 + x]["areas"],
+                    [{"id": "meadow_clearing", "rotation": 90}],
+                )
+
+    def test_area_rectangle_rejects_unknown_area_duplicate_membership_and_empty_cells(self):
+        base_area = {
+            "id": "meadow_clearing",
+            "spawn_chance": 100,
+            "rotate_random": False,
+            "pick_one": False,
+            "tiles": [{"id": "grass_dirt_00", "count": 1}],
+            "entities": [],
+        }
+        cases = [
+            (
+                [{"type": "area_rectangle", "area": "unknown", "x": 0, "y": 0, "width": 1, "height": 1}],
+                "references unknown area 'unknown'",
+            ),
+            (
+                [
+                    {"type": "area_rectangle", "area": "meadow_clearing", "x": 0, "y": 0, "width": 1, "height": 1},
+                    {"type": "area_rectangle", "area": "meadow_clearing", "x": 0, "y": 0, "width": 1, "height": 1},
+                ],
+                r"duplicates area 'meadow_clearing' at \[0, 0\]",
+            ),
+        ]
+        for operations, expected_message in cases:
+            with self.subTest(operations=operations):
+                recipe = valid_recipe()
+                recipe["areas"] = [base_area]
+                recipe["operations"] = operations
+                with self.assertRaisesRegex(RecipeError, expected_message):
+                    generate_map(recipe, TILES_PATH)
+
+        recipe = valid_recipe()
+        recipe["areas"] = [base_area]
+        recipe["operations"] = [
+            {"type": "set", "x": 0, "y": 0, "tile": None},
+            {"type": "area_rectangle", "area": "meadow_clearing", "x": 0, "y": 0, "width": 1, "height": 1},
+        ]
+        with self.assertRaisesRegex(RecipeError, r"requires supporting terrain at \[0, 0\]"):
+            generate_map(recipe, TILES_PATH)
+
+    def test_area_meadow_example_matches_its_runtime_area_boundary(self):
+        recipe_path = ROOT / "Tools" / "examples" / "map_recipe_area_meadow.json"
+        generated = generate_map(
+            json.loads(recipe_path.read_text(encoding="utf-8")), TILES_PATH
+        )
+
+        self.assertEqual(generated["areas"], [
+            {
+                "id": "meadow_clearing",
+                "spawn_chance": 100,
+                "rotate_random": False,
+                "pick_one": False,
+                "tiles": [{"id": "grass_dirt_00", "count": 1}],
+                "entities": [],
+            }
+        ])
+        memberships = [
+            (index % 32, index // 32)
+            for index, tile in enumerate(generated["levels"][10])
+            if tile.get("areas") == [{"id": "meadow_clearing", "rotation": 0}]
+        ]
+        self.assertEqual(len(memberships), 144)
+        self.assertEqual(set(memberships), {
+            (x, y) for y in range(10, 22) for x in range(10, 22)
+        })
+        self.assertTrue(
+            all(
+                generated["levels"][10][y * 32 + x]["id"] == "grass_dirt_00"
+                for x, y in memberships
+            )
+        )
+
     def test_multi_level_examples_have_supported_slope_endpoints(self):
         high_direction = {
             0: (0, -1),
@@ -1503,6 +1620,26 @@ class MapValidatorDimensionTests(unittest.TestCase):
                 errors = self.validate(map_data)
 
                 self.assertTrue(any(expected_message in error for error in errors))
+
+    def test_validates_area_reference_structure(self):
+        map_data = generate_map(valid_recipe(), TILES_PATH)
+        map_data["areas"] = "not-an-array"
+        errors = self.validate(map_data)
+        self.assertTrue(any("top-level areas must be an array" in error for error in errors))
+
+        map_data = generate_map(valid_recipe(), TILES_PATH)
+        map_data["areas"] = [{"id": "meadow_clearing"}]
+        map_data["levels"][10][0]["areas"] = "not-an-array"
+
+        errors = self.validate(map_data)
+
+        self.assertTrue(any("areas must be an array" in error for error in errors))
+
+        map_data["levels"][10][0]["areas"] = [
+            {"id": "meadow_clearing", "rotation": 45}
+        ]
+        errors = self.validate(map_data)
+        self.assertTrue(any("invalid area rotation" in error for error in errors))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

Add the first Phase 6 map-area generation slice while preserving the
existing Dimensionfall map editor and runtime serialization contract.

- add strict root-level `areas` recipe definitions;
- add terrain-backed `area_rectangle` membership placement;
- preserve map-level area definitions plus per-tile `areas` references;
- support existing root and grouped logical-z placement rules;
- validate unknown areas, duplicate same-ID membership, bounds,
  rotations, and unsupported cells;
- harden map validation for malformed area arrays and references;
- add a maintained generated area meadow;
- update roadmap and modding documentation.

## Existing contract preserved

Areas are serialized in two linked forms:

1. top-level map `areas` definitions;
2. tile-local `areas` memberships such as:

   ```json
   {"id": "meadow_clearing", "rotation": 0}