### PR TITLE
Add catalog-validated runtime area entity variation

### DIFF
--- a/Documentation/Game_design/Map_generation_plan.md
+++ b/Documentation/Game_design/Map_generation_plan.md
@@ -613,6 +613,8 @@ The recipe generator now supports strict root `areas` definitions plus an `area_
 
 `Tools/examples/map_recipe_area_meadow.json` is the maintained evidence: a deterministic `12×12` `meadow_clearing` membership rectangle from `[10, 10]` through `[21, 21]` at `z: 0`, with a 100-percent runtime rule that applies `grass_dirt_00`. Python coverage verifies level placement, malformed references, duplicate memberships, unsupported cells, maintained-example bounds, and validator shape/rotation checks.
 
+The area entity contract is now strict and catalog-aware. Recipes may use the existing runtime entity types `furniture`, `mob`, `mobgroup`, and `itemgroup`; each record must have a known catalog ID and a positive integer weight. Entity selection deliberately remains runtime-owned: `map_manager` appends its implicit no-spawn weight and selects a new outcome for every membership tile when the map is instanced. This keeps area fields unique between runs, unlike deterministic `furniture_scatter`, which pre-writes the same seeded feature positions into generated JSON. `Tools/examples/map_recipe_area_entity_clearing.json` is the maintained evidence: its 12×12 `stump_clearing` boundary has no pre-baked features, then independently rolls `burned_tree_stump` features at runtime. Focused GUT coverage proves membership rotation is retained for the spawned furniture structure and runtime processing reaches serialized level `11` (logical `z: +1`).
+
 This foundation intentionally does **not** yet define polygons, room boundaries, indoor/outdoor semantics, entity-placement behavior beyond preserving the existing area definition structure, walls, doors, roofs, building footprints, anchors, or generalized templates.
 
 Capabilities:
@@ -848,7 +850,7 @@ An agent can create a new playable, potentially multi-level map from a concise d
 
 # Recommended immediate next task
 
-**Phase 6 is in progress.** Its first, runtime-compatible area foundation is complete. The next contribution should add the smallest evidenced room-boundary or indoor/outdoor semantic extension, only after confirming how the existing editor and runtime distinguish those concepts.
+**Phase 6 is in progress.** Its runtime-compatible area foundation—including catalog-validated, per-instance runtime entity variation—is complete. The next contribution should add the smallest evidenced room-boundary or indoor/outdoor semantic extension, only after confirming how the existing editor and runtime distinguish those concepts.
 
 Do not yet add walls, doors, roofs, multi-level building footprints, furniture anchors, roads, towns, or generalized building templates. Preserve the established map-level `areas` plus per-tile membership representation, and validate any new semantics in the editor and runtime.
 
@@ -884,6 +886,7 @@ Do not commit or push unless explicitly requested.
 [Complete] Dedicated AI-generated outdoor sprite replacement
 [Complete] Final Phase 5 outdoor-asset inspection
 [Complete] Level-aware runtime area schema and maintained example
+[Complete] Catalog-validated runtime area entity variation
 [Next]     Room-boundary or indoor/outdoor semantics investigation
 [Planned]  Rooms and buildings
 [Planned]  Roads and map connections

--- a/Documentation/Modding/map_example_generation.md
+++ b/Documentation/Modding/map_example_generation.md
@@ -25,6 +25,7 @@ The maintained recipe examples are:
 | `Tools/examples/map_recipe.json` | `Mods/Dimensionfall/Maps/generated_meadow_prototype.json` | Ground-level palettes, placement operations, scatter, and reusable patterns. |
 | `Tools/examples/map_recipe_furniture_outdoor.json` | `Mods/Dimensionfall/Maps/generated_furnished_clearing.json` | Explicit decor plus weighted, conflict-aware tree, rock, and wild-vegetation scatter on supported terrain at logical `z: 0`. |
 | `Tools/examples/map_recipe_area_meadow.json` | `Mods/Dimensionfall/Maps/generated_area_meadow.json` | One runtime area definition and a `12×12` terrain-backed `area_rectangle` membership boundary at logical `z: 0`. |
+| `Tools/examples/map_recipe_area_entity_clearing.json` | `Mods/Dimensionfall/Maps/generated_area_entity_clearing.json` | A `12×12` terrain-backed area whose weighted stump entity is selected anew by the runtime each time the map is instanced. |
 | `Tools/examples/map_recipe_two_level_hill.json` | `Mods/Dimensionfall/Maps/generated_two_level_hill.json` | Ground level `z: 0`, raised terrain at `z: 1`, and all four slope rotations. |
 | `Tools/examples/map_recipe_two_level_depression.json` | `Mods/Dimensionfall/Maps/generated_two_level_depression.json` | Ground level `z: 0`, lowered terrain at `z: -1`, and all four slope rotations. |
 
@@ -58,6 +59,11 @@ python3 Tools/map_generator.py \
   Tools/examples/map_recipe_area_meadow.json \
   Mods/Dimensionfall/Maps/generated_area_meadow.json
 
+# Ground-level runtime-random area entity clearing
+python3 Tools/map_generator.py \
+  Tools/examples/map_recipe_area_entity_clearing.json \
+  Mods/Dimensionfall/Maps/generated_area_entity_clearing.json
+
 # Two-level hill
 python3 Tools/map_generator.py \
   Tools/examples/map_recipe_two_level_hill.json \
@@ -84,6 +90,7 @@ After generating a map, start or restart Godot and follow the content-editor ste
 rm Mods/Dimensionfall/Maps/generated_meadow_prototype.json
 rm Mods/Dimensionfall/Maps/generated_furnished_clearing.json
 rm Mods/Dimensionfall/Maps/generated_area_meadow.json
+rm Mods/Dimensionfall/Maps/generated_area_entity_clearing.json
 rm Mods/Dimensionfall/Maps/generated_two_level_hill.json
 rm Mods/Dimensionfall/Maps/generated_two_level_depression.json
 ```
@@ -152,6 +159,8 @@ If Godot was already running when files were generated, restart it so mod conten
 For the maintained furnished clearing, confirm that the editor shows a garden bench at `[16, 16]`, an unlit campfire at `[15, 16]`, and a potted plant at `[17, 16]`. It deterministically scatters 24 trees or burned stumps, then 16 rocks or wild-vegetation features, over the 16×16 clearing while leaving those three authored features untouched. The maintainer inspected the clearing in the editor with `save and test` after the dedicated AI sprites were installed and confirmed that the rock and wild-vegetation furniture spawn without issues. `rock_field_00` uses `ai_rock_32_32.png`, and `wild_vegetation_00` uses `ai_vegetation_32_32.png`. The recipe intentionally leaves `itemgroups` empty and does not exercise container contents, multi-cell occupancy, or cross-level support rules.
 
 For the maintained area meadow, confirm that the area list contains `meadow_clearing` and the editor highlights exactly the `12×12` rectangle from `[10, 10]` through `[21, 21]` at logical `z: 0`. The definition has a `100` percent spawn chance and replaces that connected membership cluster with `grass_dirt_00`; use `save and test` to confirm the runtime applies the area without affecting outside terrain. The example deliberately contains no entities, rooms, walls, doors, or building semantics.
+
+For the maintained area entity clearing, confirm the same `[10, 10]` through `[21, 21]` membership boundary for `stump_clearing`. The JSON deliberately contains no pre-baked furniture features: every instancing uses the established area rule to make a fresh weighted selection between its `burned_tree_stump` entry and the implicit no-spawn weight. Restart and instance the map multiple times with **save and test**; confirm stump positions can vary between runs, remain inside the membership boundary, preserve the membership rotation when spawned, and never alter outside terrain. Do not commit the generated inspection map unless it is explicitly promoted to project content.
 
 Dimensionfall also looks for a same-named `.png` map sprite during startup. The runner intentionally generates map JSON only, so Godot currently logs a non-fatal missing-resource error for that sprite. This does not prevent the JSON map from loading or the map editor's tile-grid preview from rendering it.
 
@@ -285,6 +294,6 @@ PY
 ## Current limitations
 
 - Variants change the recipe seed; they do not synthesize new recipe operations.
-- Generated maps support terrain, explicit known single-cell furniture, deterministic weighted furniture scatter, and runtime-compatible rectangular area memberships at explicit logical levels. The maintained clearing uses dedicated AI-generated rock and wild-vegetation sprites. Itemgroup contents, multi-tile or tall features, automatic support inference, polygonal areas, rooms, buildings, semantic roads, and multi-level templates are not supported yet.
+- Generated maps support terrain, explicit known single-cell furniture, deterministic weighted furniture scatter, and runtime-compatible rectangular area memberships at explicit logical levels. Areas can also declare weighted runtime `furniture`, `mob`, `mobgroup`, or `itemgroup` entities, so an area field can vary each time its map is instanced. The maintained clearing uses dedicated AI-generated rock and wild-vegetation sprites. Itemgroup contents, multi-tile or tall features, automatic support inference, polygonal areas, rooms, buildings, semantic roads, and multi-level templates are not supported yet.
 - The maps can be inspected with the existing content-editor preview, but the runner does not launch Godot or inject maps into an already-running editor session.
 - Installing examples under `Mods/Dimensionfall/Maps` makes them available to the content editor, but does not automatically reference them from overmap-area generation.

--- a/Documentation/Modding/map_recipe_generator.md
+++ b/Documentation/Modding/map_recipe_generator.md
@@ -181,7 +181,7 @@ Dimensionfall's existing area system has two linked serialized forms:
 
 At runtime, `Helper.map_manager.process_areas_in_map()` selects definitions by `spawn_chance`, then applies each selected definition to connected clusters of matching tile memberships on every populated level. The editor displays these memberships and permits multiple *different* area IDs on one tile, so recipe generation preserves that supported overlay behavior. It rejects a duplicate membership of the same area ID on the same cell.
 
-Recipe area definitions require exactly `id`, `spawn_chance`, `rotate_random`, `pick_one`, `tiles`, and `entities`. Area IDs use letters, numbers, `_`, and `-`; `spawn_chance` is an integer from `0` through `100`; `rotate_random` and `pick_one` are booleans. `tiles` is a non-empty array of `{ "id", "count" }` entries whose IDs are known tiles or the runtime's `"null"` sentinel. `entities` is an array of `{ "id", "type", "count" }` entries. This slice preserves the established entity data contract rather than adding new entity placement semantics.
+Recipe area definitions require exactly `id`, `spawn_chance`, `rotate_random`, `pick_one`, `tiles`, and `entities`. Area IDs use letters, numbers, `_`, and `-`; `spawn_chance` is an integer from `0` through `100`; `rotate_random` and `pick_one` are booleans. `tiles` is a non-empty array of `{ "id", "count" }` entries whose IDs are known tiles or the runtime's `"null"` sentinel. `entities` is an array of `{ "id", "type", "count" }` entries. The generator accepts only the existing runtime entity types—`furniture`, `mob`, `mobgroup`, and `itemgroup`—and validates each ID against its core catalog before publishing a map.
 
 ```json
 {
@@ -195,6 +195,32 @@ Recipe area definitions require exactly `id`, `spawn_chance`, `rotate_random`, `
       "entities": []
     }
   ]
+}
+```
+
+### Runtime entity variation
+
+An area entity is a runtime rule, not a pre-generated feature. For every processed membership tile, `map_manager` adds an implicit no-spawn entry weighted by the total `tiles` weight, then selects one declared entity by `count`. As a result, the generated JSON boundary is deterministic, but an entity-bearing field can differ each time the map is instanced. Do not replace this with `furniture_scatter` when per-instance variation is desired: scatter intentionally writes the same seeded features into every generated map.
+
+Entity `count` values must be positive integers in recipes. The generator enforces that stricter authoring rule; the standalone validator accepts positive numeric legacy weights so existing authored maps continue to match the runtime's weighted-picker contract. The supported types and ID catalogs are:
+
+| Type | Catalog | Runtime feature result |
+|---|---|---|
+| `furniture` | `Furniture/Furniture.json` | `{ "type", "id", "rotation" }` |
+| `mob` | `Mobs/Mobs.json` | `{ "type", "id", "rotation" }` |
+| `mobgroup` | `Mobgroups/Mobgroups.json` | `{ "type", "id", "rotation" }` |
+| `itemgroup` | `Itemgroups/Itemgroups.json` | `{ "type": "itemgroup", "itemgroups": ["id"], "rotation" }` |
+
+When `rotate_random` is false, a selected entity uses the membership's editor-facing rotation. When it is true, runtime chooses a quarter turn. Entity selection remains runtime-owned and is never pre-baked by the Python generator.
+
+```json
+{
+  "id": "stump_clearing",
+  "spawn_chance": 100,
+  "rotate_random": false,
+  "pick_one": false,
+  "tiles": [{"id": "grass_dirt_00", "count": 100}],
+  "entities": [{"id": "burned_tree_stump", "type": "furniture", "count": 1}]
 }
 ```
 
@@ -342,9 +368,9 @@ The generator rejects unknown fields at every recipe level, root-level dimension
 
 The output uses 21 levels; logical `z: 0` is row-major grid index `10`. It sets `categories` to `[]`, `weight` to `1000`, and all four connections to `"ground"`. It omits `areas`, matching `DMap.get_data()` when the area list is empty.
 
-The generator currently creates explicit, known, single-cell furniture features, deterministic weighted furniture scatter over eligible terrain, and strict runtime-compatible rectangular area memberships at explicit logical levels. The core mod defines `rock_field_00` and `wild_vegetation_00` for outdoor composition, using the dedicated AI-generated sprites `ai_rock_32_32.png` and `ai_vegetation_32_32.png`. It does not yet support furniture itemgroup contents, multiple features per cell, multi-tile or tall-object occupancy, automatic support inference, polygonal areas, rooms, walls, doors, buildings, roads as semantic objects, towns, nested or multi-level patterns, or shape-based templates.
+The generator currently creates explicit, known, single-cell furniture features, deterministic weighted furniture scatter over eligible terrain, and strict runtime-compatible rectangular area memberships at explicit logical levels. Areas can additionally declare catalog-validated weighted runtime `furniture`, `mob`, `mobgroup`, and `itemgroup` entities; selection occurs when the map is instanced rather than during Python generation. The core mod defines `rock_field_00` and `wild_vegetation_00` for outdoor composition, using the dedicated AI-generated sprites `ai_rock_32_32.png` and `ai_vegetation_32_32.png`. It does not yet support furniture itemgroup contents, multiple features per cell, multi-tile or tall-object occupancy, automatic support inference, polygonal areas, rooms, walls, doors, buildings, roads as semantic objects, towns, nested or multi-level patterns, or shape-based templates.
 
-The maintained area example is `Tools/examples/map_recipe_area_meadow.json`. The maintained furniture example is `Tools/examples/map_recipe_furniture_outdoor.json`. Maintained structural examples are available at `Tools/examples/map_recipe_two_level_hill.json` and `Tools/examples/map_recipe_two_level_depression.json`. They use `grass_ramp_00`, whose tile definition has `shape: "slope"`.
+The maintained area examples are `Tools/examples/map_recipe_area_meadow.json` and `Tools/examples/map_recipe_area_entity_clearing.json`. The maintained furniture example is `Tools/examples/map_recipe_furniture_outdoor.json`. Maintained structural examples are available at `Tools/examples/map_recipe_two_level_hill.json` and `Tools/examples/map_recipe_two_level_depression.json`. They use `grass_ramp_00`, whose tile definition has `shape: "slope"`.
 
 Slope rotations in recipes use the same values shown by the map editor:
 

--- a/Tests/Unit/test_map_manager.gd
+++ b/Tests/Unit/test_map_manager.gd
@@ -153,3 +153,47 @@ func test_process_entities_data():
 		assert_does_not_have(result, "mob", "Unexpected mob key")
 		assert_does_not_have(result, "mobgroup", "Unexpected mobgroup key")
 		assert_does_not_have(result, "itemgroup", "Unexpected itemgroup key")
+
+
+func test_area_entity_uses_membership_rotation_and_processes_non_default_level():
+	var area_data: Dictionary = {
+		"id": "stump_clearing",
+		"spawn_chance": 100,
+		"rotate_random": false,
+		"pick_one": false,
+		"tiles": [{"id": "grass_dirt_00", "count": 1}],
+		"entities": [{"id": "burned_tree_stump", "type": "furniture", "count": 1}],
+	}
+	var membership_tile: Dictionary = {
+		"id": "grass_plain_01",
+		"areas": [{"id": "stump_clearing", "rotation": 90}],
+	}
+	var entity_result: Dictionary = {}
+	map_manager._process_entities_data(
+		{
+			"id": "stump_clearing",
+			"rotate_random": false,
+			"tiles": [],
+			"entities": area_data["entities"],
+		},
+		entity_result,
+		membership_tile
+	)
+	assert_eq(entity_result.feature, {
+		"type": "furniture",
+		"id": "burned_tree_stump",
+		"rotation": 90,
+	})
+
+	var levels: Array = []
+	for level_index in range(21):
+		levels.append([])
+	var upper_level: Array = []
+	for tile_index in range(32 * 32):
+		upper_level.append({"id": "grass_plain_01"})
+	upper_level[3 * 32 + 2] = membership_tile.duplicate(true)
+	levels[11] = upper_level
+	var map_data: Dictionary = {"areas": [area_data], "levels": levels}
+	map_manager.process_areas_in_map(map_data)
+	assert_eq(map_data["levels"][11][3 * 32 + 2]["id"], "grass_dirt_00")
+	assert_eq(map_data["levels"][11][3 * 32 + 2]["areas"], membership_tile["areas"])

--- a/Tools/examples/map_recipe_area_entity_clearing.json
+++ b/Tools/examples/map_recipe_area_entity_clearing.json
@@ -1,0 +1,52 @@
+{
+	"id": "generated_area_entity_clearing",
+	"name": "Generated Area Entity Clearing",
+	"description": "A deterministic area boundary whose stump feature selection occurs at runtime each time the map is instanced.",
+	"seed": 20260805,
+	"base_tile": {
+		"id": "grass_plain_01"
+	},
+	"areas": [
+		{
+			"id": "stump_clearing",
+			"spawn_chance": 100,
+			"rotate_random": false,
+			"pick_one": false,
+			"tiles": [
+				{
+					"id": "grass_dirt_00",
+					"count": 100
+				}
+			],
+			"entities": [
+				{
+					"id": "burned_tree_stump",
+					"type": "furniture",
+					"count": 1
+				}
+			]
+		}
+	],
+	"operations": [
+		{
+			"type": "rectangle",
+			"x": 10,
+			"y": 10,
+			"width": 12,
+			"height": 12,
+			"tile": {
+				"id": "grass_dirt_00"
+			}
+		},
+		{
+			"type": "area_rectangle",
+			"area": "stump_clearing",
+			"x": 10,
+			"y": 10,
+			"width": 12,
+			"height": 12,
+			"z": 0,
+			"rotation": 0
+		}
+	]
+}

--- a/Tools/map_generator.py
+++ b/Tools/map_generator.py
@@ -60,6 +60,7 @@ AREA_DEFINITION_FIELDS = {
 }
 AREA_TILE_FIELDS = {"id", "count"}
 AREA_ENTITY_FIELDS = {"id", "type", "count"}
+AREA_ENTITY_TYPES = {"furniture", "mob", "mobgroup", "itemgroup"}
 TILE_OPERATION_TYPES = {"set", "rectangle", "rectangle_outline", "line", "scatter"}
 LEVEL_FIELDS = {"z", "base_tile", "regions", "operations"}
 RECIPE_FIELDS = {
@@ -170,14 +171,18 @@ def _tile_ids(tiles_path: Path) -> set[str]:
 
 
 def _furniture_ids(furnitures_path: Path) -> set[str]:
-    with furnitures_path.open(encoding="utf-8") as handle:
-        furniture_data = json.load(handle)
-    if not isinstance(furniture_data, list):
-        raise RecipeError("furniture database must be a JSON array")
+    return _content_ids(furnitures_path, "furniture")
+
+
+def _content_ids(content_path: Path, content_name: str) -> set[str]:
+    with content_path.open(encoding="utf-8") as handle:
+        content_data = json.load(handle)
+    if not isinstance(content_data, list):
+        raise RecipeError(f"{content_name} database must be a JSON array")
     return {
-        furniture["id"]
-        for furniture in furniture_data
-        if isinstance(furniture, dict) and isinstance(furniture.get("id"), str)
+        entry["id"]
+        for entry in content_data
+        if isinstance(entry, dict) and isinstance(entry.get("id"), str)
     }
 
 
@@ -198,6 +203,14 @@ def _contains_furniture_operations(recipe: dict[str, Any]) -> bool:
         for operations in operation_groups
         if isinstance(operations, list)
         for operation in operations
+    )
+
+
+def _contains_area_entities(recipe: dict[str, Any]) -> bool:
+    areas = recipe.get("areas")
+    return isinstance(areas, list) and any(
+        isinstance(area, dict) and area.get("entities")
+        for area in areas
     )
 
 
@@ -838,7 +851,9 @@ def _apply_furniture_scatter(
 
 
 def _validate_recipe_areas(
-    areas: Any, known_tiles: set[str]
+    areas: Any,
+    known_tiles: set[str],
+    known_area_entity_ids: dict[str, set[str]],
 ) -> list[dict[str, Any]]:
     if not isinstance(areas, list):
         raise RecipeError("areas must be an array")
@@ -906,10 +921,18 @@ def _validate_recipe_areas(
                 raise RecipeError(f"{entity_context}.id must be a non-empty string")
             if not isinstance(entity["type"], str) or not entity["type"].strip():
                 raise RecipeError(f"{entity_context}.type must be a non-empty string")
+            entity_type = entity["type"]
+            if entity_type not in AREA_ENTITY_TYPES:
+                raise RecipeError(f"{entity_context}.type has unsupported type '{entity_type}'")
+            entity_id = entity["id"]
+            if entity_id not in known_area_entity_ids[entity_type]:
+                raise RecipeError(
+                    f"{entity_context}.id references unknown {entity_type} '{entity_id}'"
+                )
             if type(entity["count"]) is not int or entity["count"] <= 0:
                 raise RecipeError(f"{entity_context}.count must be a positive integer")
             validated_entities.append(
-                {"id": entity["id"], "type": entity["type"], "count": entity["count"]}
+                {"id": entity_id, "type": entity_type, "count": entity["count"]}
             )
         validated.append(
             {
@@ -1163,19 +1186,41 @@ def generate_map(
     if type(seed) is not int:
         raise RecipeError("seed must be an integer")
     known_tiles = _tile_ids(Path(tiles_path))
+    content_root = Path(tiles_path).parent.parent
     known_furnitures: set[str] = set()
-    if _contains_furniture_operations(recipe):
+    requires_furniture_catalog = (
+        _contains_furniture_operations(recipe) or _contains_area_entities(recipe)
+    )
+    if requires_furniture_catalog:
         if furnitures_path is None:
-            furnitures_path = (
-                Path(tiles_path).parent.parent / "Furniture" / "Furniture.json"
-            )
+            furnitures_path = content_root / "Furniture" / "Furniture.json"
         known_furnitures = _furniture_ids(Path(furnitures_path))
+    known_area_entity_ids: dict[str, set[str]] = {
+        "furniture": known_furnitures,
+        "mob": set(),
+        "mobgroup": set(),
+        "itemgroup": set(),
+    }
+    if _contains_area_entities(recipe):
+        known_area_entity_ids.update(
+            {
+                "mob": _content_ids(content_root / "Mobs" / "Mobs.json", "mob"),
+                "mobgroup": _content_ids(
+                    content_root / "Mobgroups" / "Mobgroups.json", "mobgroup"
+                ),
+                "itemgroup": _content_ids(
+                    content_root / "Itemgroups" / "Itemgroups.json", "itemgroup"
+                ),
+            }
+        )
     palette = _validate_palette(recipe.get("palette", {}), known_tiles)
     furniture_palette = _validate_furniture_palette(
         recipe.get("furniture_palette", {}), known_furnitures
     )
     patterns = _validate_patterns(recipe.get("patterns", {}), known_tiles, palette)
-    areas = _validate_recipe_areas(recipe.get("areas", []), known_tiles)
+    areas = _validate_recipe_areas(
+        recipe.get("areas", []), known_tiles, known_area_entity_ids
+    )
     known_area_ids = {area["id"] for area in areas}
     rng = random.Random(seed)
     levels = _generate_levels(

--- a/Tools/map_validator.py
+++ b/Tools/map_validator.py
@@ -107,6 +107,34 @@ class MapValidator:
             else:
                 area_ids.add(a_id)
 
+            if 'entities' not in area:
+                continue
+            entities = area['entities']
+            if not isinstance(entities, list):
+                self.add_error(file_path, f"Area at index {idx} entities must be an array.")
+                continue
+            for entity_idx, entity in enumerate(entities):
+                entity_context = f"Area at index {idx} entity at index {entity_idx}"
+                if not isinstance(entity, dict):
+                    self.add_error(file_path, f"{entity_context} is not an object.")
+                    continue
+                for field in ('id', 'type', 'count'):
+                    if field not in entity:
+                        self.add_error(file_path, f"{entity_context} is missing required field '{field}'.")
+                entity_type = entity.get('type')
+                if entity_type not in {'furniture', 'mob', 'mobgroup', 'itemgroup'}:
+                    self.add_error(file_path, f"{entity_context} has unsupported entity type '{entity_type}'.")
+                entity_id = entity.get('id')
+                if not isinstance(entity_id, str) or not entity_id:
+                    self.add_error(file_path, f"{entity_context} has invalid or missing ID.")
+                count = entity.get('count')
+                if (
+                    isinstance(count, bool)
+                    or not isinstance(count, (int, float))
+                    or count <= 0
+                ):
+                    self.add_error(file_path, f"{entity_context} count must be a positive number.")
+
         # 5. Validate Levels (Tiles)
         if not isinstance(levels, list):
              self.add_error(file_path, "'levels' must be an array.")

--- a/Tools/tests/test_map_generator.py
+++ b/Tools/tests/test_map_generator.py
@@ -9,6 +9,9 @@ from Tools.map_validator import MapValidator
 ROOT = Path(__file__).resolve().parents[2]
 TILES_PATH = ROOT / "Mods" / "Dimensionfall" / "Tiles" / "Tiles.json"
 FURNITURES_PATH = ROOT / "Mods" / "Dimensionfall" / "Furniture" / "Furniture.json"
+MOBS_PATH = ROOT / "Mods" / "Dimensionfall" / "Mobs" / "Mobs.json"
+MOBGROUPS_PATH = ROOT / "Mods" / "Dimensionfall" / "Mobgroups" / "Mobgroups.json"
+ITEMGROUPS_PATH = ROOT / "Mods" / "Dimensionfall" / "Itemgroups" / "Itemgroups.json"
 
 
 def valid_recipe():
@@ -1399,6 +1402,52 @@ class MapGeneratorTests(unittest.TestCase):
         with self.assertRaisesRegex(RecipeError, r"requires supporting terrain at \[0, 0\]"):
             generate_map(recipe, TILES_PATH)
 
+    def test_area_entities_require_known_runtime_type_catalog_ids_and_positive_counts(self):
+        known_entity_ids = {
+            "furniture": json.loads(FURNITURES_PATH.read_text(encoding="utf-8"))[0]["id"],
+            "mob": json.loads(MOBS_PATH.read_text(encoding="utf-8"))[0]["id"],
+            "mobgroup": json.loads(MOBGROUPS_PATH.read_text(encoding="utf-8"))[0]["id"],
+            "itemgroup": json.loads(ITEMGROUPS_PATH.read_text(encoding="utf-8"))[0]["id"],
+        }
+
+        for entity_type, entity_id in known_entity_ids.items():
+            with self.subTest(entity_type=entity_type):
+                recipe = valid_recipe()
+                recipe["areas"] = [{
+                    "id": "runtime_entities",
+                    "spawn_chance": 100,
+                    "rotate_random": False,
+                    "pick_one": False,
+                    "tiles": [{"id": "grass_dirt_00", "count": 1}],
+                    "entities": [{"id": entity_id, "type": entity_type, "count": 1}],
+                }]
+                generated = generate_map(recipe, TILES_PATH)
+                self.assertEqual(generated["areas"][0]["entities"], recipe["areas"][0]["entities"])
+
+        invalid_entities = [
+            ({"id": "table_round_wood", "type": "unsupported", "count": 1}, "unsupported type"),
+            ({"id": "missing", "type": "furniture", "count": 1}, "unknown furniture"),
+            ({"id": "missing", "type": "mob", "count": 1}, "unknown mob"),
+            ({"id": "missing", "type": "mobgroup", "count": 1}, "unknown mobgroup"),
+            ({"id": "missing", "type": "itemgroup", "count": 1}, "unknown itemgroup"),
+            ({"id": "table_round_wood", "type": "furniture", "count": 0}, "positive integer"),
+            ({"id": "table_round_wood", "type": "furniture", "count": True}, "positive integer"),
+            ({"id": "table_round_wood", "type": "furniture", "count": 1.5}, "positive integer"),
+        ]
+        for entity, expected_message in invalid_entities:
+            with self.subTest(entity=entity):
+                recipe = valid_recipe()
+                recipe["areas"] = [{
+                    "id": "runtime_entities",
+                    "spawn_chance": 100,
+                    "rotate_random": False,
+                    "pick_one": False,
+                    "tiles": [{"id": "grass_dirt_00", "count": 1}],
+                    "entities": [entity],
+                }]
+                with self.assertRaisesRegex(RecipeError, expected_message):
+                    generate_map(recipe, TILES_PATH)
+
     def test_area_meadow_example_matches_its_runtime_area_boundary(self):
         recipe_path = ROOT / "Tools" / "examples" / "map_recipe_area_meadow.json"
         generated = generate_map(
@@ -1430,6 +1479,37 @@ class MapGeneratorTests(unittest.TestCase):
                 for x, y in memberships
             )
         )
+
+    def test_area_entity_clearing_example_preserves_runtime_entity_selection(self):
+        recipe_path = ROOT / "Tools" / "examples" / "map_recipe_area_entity_clearing.json"
+        recipe = json.loads(recipe_path.read_text(encoding="utf-8"))
+        generated = generate_map(recipe, TILES_PATH)
+
+        self.assertEqual(generate_map(recipe, TILES_PATH), generated)
+        self.assertEqual(generated["areas"], [{
+            "id": "stump_clearing",
+            "spawn_chance": 100,
+            "rotate_random": False,
+            "pick_one": False,
+            "tiles": [{"id": "grass_dirt_00", "count": 100}],
+            "entities": [{
+                "id": "burned_tree_stump",
+                "type": "furniture",
+                "count": 1,
+            }],
+        }])
+        memberships = [
+            (index % 32, index // 32, tile)
+            for index, tile in enumerate(generated["levels"][10])
+            if tile.get("areas") == [{"id": "stump_clearing", "rotation": 0}]
+        ]
+        self.assertEqual(len(memberships), 144)
+        self.assertEqual(
+            {(x, y) for x, y, _ in memberships},
+            {(x, y) for y in range(10, 22) for x in range(10, 22)},
+        )
+        self.assertTrue(all(tile["id"] == "grass_dirt_00" for _, _, tile in memberships))
+        self.assertTrue(all("feature" not in tile for _, _, tile in memberships))
 
     def test_multi_level_examples_have_supported_slope_endpoints(self):
         high_direction = {
@@ -1640,6 +1720,27 @@ class MapValidatorDimensionTests(unittest.TestCase):
         ]
         errors = self.validate(map_data)
         self.assertTrue(any("invalid area rotation" in error for error in errors))
+
+    def test_validates_area_entity_definition_structure(self):
+        invalid_entities = [
+            ("not-an-array", "entities must be an array"),
+            (["not-an-object"], "entity at index 0 is not an object"),
+            ([{"id": "burned_tree_stump", "type": "furniture"}], "missing required field 'count'"),
+            ([{"id": "burned_tree_stump", "type": "unsupported", "count": 1}], "unsupported entity type"),
+            ([{"id": "burned_tree_stump", "type": "furniture", "count": 0}], "count must be a positive number"),
+            ([{"id": "burned_tree_stump", "type": "furniture", "count": "one"}], "count must be a positive number"),
+        ]
+        for entities, expected_message in invalid_entities:
+            with self.subTest(entities=entities):
+                map_data = generate_map(valid_recipe(), TILES_PATH)
+                map_data["areas"] = [{
+                    "id": "stump_clearing",
+                    "entities": entities,
+                }]
+
+                errors = self.validate(map_data)
+
+                self.assertTrue(any(expected_message in error for error in errors))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

Extend the Phase 6 area foundation so generated maps can define
runtime-random content fields that vary each time a map is instanced.

- validate area `entities` against existing runtime-supported catalogs;
- support `furniture`, `mob`, `mobgroup`, and `itemgroup`;
- reject unsupported types, unknown IDs, malformed records, and invalid
  recipe weights before map publication;
- preserve the existing map-level `areas` plus tile-local membership
  representation;
- keep weighted entity selection runtime-owned rather than pre-baking
  features into generated JSON;
- add a maintained runtime-random stump-clearing example;
- add generator, validator, and logical-z runtime regression coverage;
- document deterministic scatter versus per-instance area variation.

## Runtime behavior preserved

Area entity rules remain processed by `map_manager`:

1. the runtime adds an implicit no-spawn weight based on area tile
   weights;
2. it independently selects a weighted entity per member tile;
3. it writes the established tile `feature` structure;
4. it uses membership rotation unless `rotate_random` is enabled.

This allows a generated area boundary to remain deterministic while
trees, stumps, mobs, or loot can vary every time the map is instanced.

## Maintained example

`Tools/examples/map_recipe_area_entity_clearing.json` defines a 12×12
`stump_clearing` at logical `z: 0`.

It has:

- deterministic terrain and membership bounds;
- a 100-percent area rule;
- one weighted `burned_tree_stump` furniture entry;
- no pre-baked features in generated JSON.

## Compatibility

New recipe area-entity weights must be positive integers.

The standalone map validator accepts positive numeric legacy weights
because existing authored maps use floats and the current runtime
weighted picker supports them.

## Validation

- Python suite: 73/73 passed;
- Godot GUT suite: 81/81 passed, 379 assertions;
- all six maintained recipes generated and validated;
- existing core maps: 51 validated with no errors;
- headless Godot editor startup passed;
- Python compilation and `git diff --check` passed.

## Follow-up

Manually inspect `generated_area_entity_clearing` with repeated
`save and test` sessions to confirm per-instance variation in the
editor/runtime.

The next Phase 6 discovery remains room-boundary or indoor/outdoor
semantics. This change intentionally excludes walls, doors, roofs,
building footprints, anchors, roads, towns, and templates.