### PR TITLE
Add explicit authored room connection metadata

### DIFF
--- a/Documentation/Game_design/Map_generation_plan.md
+++ b/Documentation/Game_design/Map_generation_plan.md
@@ -615,9 +615,13 @@ The recipe generator now supports strict root `areas` definitions plus an `area_
 
 The area entity contract is now strict and catalog-aware. Recipes may use the existing runtime entity types `furniture`, `mob`, `mobgroup`, and `itemgroup`; each record must have a known catalog ID and a positive integer weight. Entity selection deliberately remains runtime-owned: `map_manager` appends its implicit no-spawn weight and selects a new outcome for every membership tile when the map is instanced. This keeps area fields unique between runs, unlike deterministic `furniture_scatter`, which pre-writes the same seeded feature positions into generated JSON. `Tools/examples/map_recipe_area_entity_clearing.json` is the maintained evidence: its 12×12 `stump_clearing` boundary has no pre-baked features, then independently rolls `burned_tree_stump` features at runtime. Focused GUT coverage proves membership rotation is retained for the spawned furniture structure and runtime processing reaches serialized level `11` (logical `z: +1`).
 
-Authored room semantics now use a separate map-level `rooms` array plus exclusive tile-local `rooms: ["id"]` membership. Each definition has a stable authored ID and exactly one semantic kind: `enclosed`, `covered_open`, or `ruin`. These labels are deliberately independent from floor material and runtime `areas`: one wood or concrete floor can span several rooms, a roofed garage can be `covered_open`, and a ruined room remains a room despite intended wall gaps. `Tools/examples/map_recipe_room_semantics.json` is the maintained evidence and puts adjacent `office` and `garage_bay` labels on the same `concrete_00` material. The generator, standalone map validator, and `DMap` save/load path validate or preserve definitions and references; no topology inference, door links, wall/roof checks, indoor weather/lighting, or geometry generation is introduced yet.
+Authored room semantics use a separate map-level `rooms` array plus exclusive tile-local `rooms: ["id"]` membership. Each definition has a stable authored ID and exactly one semantic kind: `enclosed`, `covered_open`, or `ruin`. These labels are deliberately independent from floor material and runtime `areas`: one wood or concrete floor can span several rooms, a roofed garage can be `covered_open`, and a ruined room remains a room despite intended wall gaps. `Tools/examples/map_recipe_room_semantics.json` is the maintained evidence and puts adjacent `office` and `garage_bay` labels on the same `concrete_00` material.
 
-This foundation intentionally does **not** yet define polygons, topology-derived room boundaries, indoor/outdoor runtime behavior, wall/roof enclosure validation, door links, building footprints, anchors, or generalized templates.
+`room_connections` now adds explicit authored door intent without topology inference. Each root connection names a unique `id`, an `[x, y]` coordinate, required logical `z`, and two distinct endpoints: a known room or `exterior`. The target must be an existing terrain tile with catalog-recognized door-capable furniture; current evidence uses the runtime-native `door_wood` feature. This covers both room-to-exterior and room-to-room doors while preserving existing door opening, collision, and rotation behavior. `Tools/examples/map_recipe_room_connections.json` carries both cases. The generator and independent validator reject malformed endpoints, unknown rooms, duplicate door targets, or non-door targets; `DMap` preserves valid connections and removes links that name deleted rooms.
+
+The generator, standalone map validator, and `DMap` save/load path validate or preserve definitions and references. No topology inference, wall/roof checks, indoor weather/lighting, or geometry generation is introduced yet.
+
+This foundation intentionally does **not** yet define polygons, topology-derived room boundaries, indoor/outdoor runtime behavior, wall/roof enclosure validation, building footprints, anchors, or generalized templates.
 
 Capabilities:
 
@@ -852,9 +856,9 @@ An agent can create a new playable, potentially multi-level map from a concise d
 
 # Recommended immediate next task
 
-**Phase 6 is in progress.** Its runtime-compatible area foundation, catalog-validated per-instance entity variation, and authored room semantics are complete. The next contribution should add the smallest evidenced physical room contract—likely explicit boundary/door-link data or validation—without inferring topology from floor materials.
+**Phase 6 is in progress.** Its runtime-compatible area foundation, catalog-validated per-instance entity variation, authored room semantics, and explicit door-link metadata are complete. The next contribution should add the smallest evidenced physical boundary representation or validation without inferring it from floor materials.
 
-Do not yet generate walls, doors, roofs, multi-level building footprints, furniture anchors, roads, towns, or generalized building templates. Preserve the established map-level `areas` plus per-tile area membership representation, keep room semantics independent from those runtime areas, and validate any new physical semantics in the editor and runtime.
+Do not yet generate walls, doors, roofs, multi-level building footprints, furniture anchors, roads, towns, or generalized building templates. Preserve the established map-level `areas` plus per-tile area membership representation, keep room semantics independent from runtime areas, and validate any physical semantics in the editor and runtime.
 
 Run the complete Python suite, relevant Godot tests or smoke checks, all maintained example generations through `Tools/map_validator.py`, and `git diff --check`.
 
@@ -890,7 +894,8 @@ Do not commit or push unless explicitly requested.
 [Complete] Level-aware runtime area schema and maintained example
 [Complete] Catalog-validated runtime area entity variation
 [Complete] Authored room semantics (`enclosed`, `covered_open`, `ruin`)
-[Next]     Physical room boundary or door-link contract
+[Complete] Explicit room-to-exterior and room-to-room door-link metadata
+[Next]     Physical room boundary representation or validation
 [Planned]  Rooms and buildings
 [Planned]  Roads and map connections
 [Planned]  Multi-level reusable templates and richer composition

--- a/Documentation/Modding/map_example_generation.md
+++ b/Documentation/Modding/map_example_generation.md
@@ -27,6 +27,7 @@ The maintained recipe examples are:
 | `Tools/examples/map_recipe_area_meadow.json` | `Mods/Dimensionfall/Maps/generated_area_meadow.json` | One runtime area definition and a `12×12` terrain-backed `area_rectangle` membership boundary at logical `z: 0`. |
 | `Tools/examples/map_recipe_area_entity_clearing.json` | `Mods/Dimensionfall/Maps/generated_area_entity_clearing.json` | A `12×12` terrain-backed area whose weighted stump entity is selected anew by the runtime each time the map is instanced. |
 | `Tools/examples/map_recipe_room_semantics.json` | `Mods/Dimensionfall/Maps/generated_room_semantics.json` | Authored `enclosed`, `covered_open`, and `ruin` room labels on terrain without generated walls, doors, roofs, or indoor runtime behavior. |
+| `Tools/examples/map_recipe_room_connections.json` | `Mods/Dimensionfall/Maps/generated_room_connections.json` | Existing `door_wood` features with explicit room-to-exterior and room-to-room semantic links, without inferred topology or new runtime door behavior. |
 | `Tools/examples/map_recipe_two_level_hill.json` | `Mods/Dimensionfall/Maps/generated_two_level_hill.json` | Ground level `z: 0`, raised terrain at `z: 1`, and all four slope rotations. |
 | `Tools/examples/map_recipe_two_level_depression.json` | `Mods/Dimensionfall/Maps/generated_two_level_depression.json` | Ground level `z: 0`, lowered terrain at `z: -1`, and all four slope rotations. |
 
@@ -70,6 +71,11 @@ python3 Tools/map_generator.py \
   Tools/examples/map_recipe_room_semantics.json \
   Mods/Dimensionfall/Maps/generated_room_semantics.json
 
+# Ground-level authored room connections
+python3 Tools/map_generator.py \
+  Tools/examples/map_recipe_room_connections.json \
+  Mods/Dimensionfall/Maps/generated_room_connections.json
+
 # Two-level hill
 python3 Tools/map_generator.py \
   Tools/examples/map_recipe_two_level_hill.json \
@@ -98,6 +104,7 @@ rm Mods/Dimensionfall/Maps/generated_furnished_clearing.json
 rm Mods/Dimensionfall/Maps/generated_area_meadow.json
 rm Mods/Dimensionfall/Maps/generated_area_entity_clearing.json
 rm Mods/Dimensionfall/Maps/generated_room_semantics.json
+rm Mods/Dimensionfall/Maps/generated_room_connections.json
 rm Mods/Dimensionfall/Maps/generated_two_level_hill.json
 rm Mods/Dimensionfall/Maps/generated_two_level_depression.json
 ```
@@ -170,6 +177,8 @@ For the maintained area meadow, confirm that the area list contains `meadow_clea
 For the maintained area entity clearing, confirm the same `[10, 10]` through `[21, 21]` membership boundary for `stump_clearing`. The JSON deliberately contains no pre-baked furniture features: every instancing uses the established area rule to make a fresh weighted selection between its `burned_tree_stump` entry and the implicit no-spawn weight. Restart and instance the map multiple times with **save and test**; confirm stump positions can vary between runs, remain inside the membership boundary, preserve the membership rotation when spawned, and never alter outside terrain. Do not commit the generated inspection map unless it is explicitly promoted to project content.
 
 For the maintained room-semantics map, inspect `generated_room_semantics` in the content editor, save it, close it, and re-open it. Confirm that `office` (`enclosed`), `garage_bay` (`covered_open`), and `ruined_store` (`ruin`) labels persist without load errors. The office and garage intentionally share adjacent `concrete_00` terrain, so do not infer room boundaries from floor material. Map preview and **save and test** should only be used to confirm persistence and normal loading in this slice: it does not yet create walls, roofs, doors, lighting, weather, or indoor gameplay behavior.
+
+For the maintained room-connections map, open `generated_room_connections`, save it, close it, and re-open it. Confirm that `office_front_door` remains an `office`→`exterior` link and `office_to_garage` remains an `office`→`garage_bay` link. In map preview and **save and test**, verify both existing `door_wood` features load and retain normal open/close interaction. This metadata must not create walls, roofs, lighting, weather, automatic enclosure, or a different door runtime behavior.
 
 Dimensionfall also looks for a same-named `.png` map sprite during startup. The runner intentionally generates map JSON only, so Godot currently logs a non-fatal missing-resource error for that sprite. This does not prevent the JSON map from loading or the map editor's tile-grid preview from rendering it.
 

--- a/Documentation/Modding/map_recipe_generator.md
+++ b/Documentation/Modding/map_recipe_generator.md
@@ -285,7 +285,43 @@ Adds one authored room label to every terrain tile in a filled rectangle. Fields
 
 The referenced root room must exist. Every target cell must already contain terrain, and room membership is exclusive: an operation cannot overlap another room label or partially apply. Room definitions and membership consume no RNG.
 
-This slice preserves `rooms` through `DMap`/content-editor save-load paths and validates them independently, but does **not** yet infer or validate walls, roofs, door adjacency, enclosure, weather, lighting, or indoor gameplay. A door feature may eventually connect indoor-to-outdoor or indoor-to-indoor spaces; this semantic slice intentionally does not encode those links yet.
+This slice preserves `rooms` through `DMap`/content-editor save-load paths and validates them independently. It does **not** infer walls, roofs, enclosure, weather, lighting, or indoor gameplay.
+
+### `room_connections`
+
+`room_connections` explicitly records what existing door furniture connects; the generator never infers it from adjacent floor material, area membership, walls, roofs, or door rotation. Each root entry contains exactly `id`, `at`, `z`, `from`, and `to`:
+
+```json
+{
+  "room_connections": [
+    {
+      "id": "office_front_door",
+      "at": [11, 10],
+      "z": 0,
+      "from": {"kind": "room", "id": "office"},
+      "to": {"kind": "exterior"}
+    },
+    {
+      "id": "office_to_garage",
+      "at": [12, 10],
+      "z": 0,
+      "from": {"kind": "room", "id": "office"},
+      "to": {"kind": "room", "id": "garage_bay"}
+    }
+  ]
+}
+```
+
+`id` must be unique and use the normal definition-name characters. `at` is exactly `[x, y]` within the `32×32` map and `z` is a required logical level from `-10` through `10`. Endpoints use one of two exact forms:
+
+```json
+{"kind": "room", "id": "office"}
+{"kind": "exterior"}
+```
+
+Room IDs must exist in root `rooms`; the two endpoints must be distinct; and one door coordinate may have only one connection. The target tile must already exist at the declared level and contain a catalog-recognized door-capable furniture feature—for example, `door_wood`, whose existing runtime implementation owns open/closed state and collision behavior.
+
+Connections are semantic metadata only. They preserve their authored `from`/`to` order but do not create a new door feature, alter existing door behavior, infer enclosure, generate geometry, or introduce an indoor/outdoor runtime state. `DMap` preserves valid links through content-editor save/load and removes links that name deleted rooms.
 
 ### `set`
 

--- a/Scripts/Gamedata/DMap.gd
+++ b/Scripts/Gamedata/DMap.gd
@@ -94,6 +94,7 @@ var levels: Array = [
 ]
 var areas: Array = []
 var rooms: Array = []
+var room_connections: Array = []
 var sprite: Texture = null
 # Variable to store connections. For example: {"south": "road","west": "ground"} default to ground
 var connections: Dictionary = {
@@ -147,6 +148,7 @@ func set_data(newdata: Dictionary) -> void:
 	)
 	areas = newdata.get("areas", [])
 	rooms = newdata.get("rooms", [])
+	room_connections = newdata.get("room_connections", [])
 	connections = newdata.get("connections", {})  # Set connections from data if present
 
 
@@ -166,12 +168,15 @@ func get_data() -> Dictionary:
 		mydata["areas"] = areas
 	if not rooms.is_empty():
 		mydata["rooms"] = rooms
+	if not room_connections.is_empty():
+		mydata["room_connections"] = room_connections
 	if not connections.is_empty():  # Omit connections if empty
 		mydata["connections"] = connections
 	
 	# Sanitize tile-level area references to remove stale editor artifacts
 	_sanitize_area_references(mydata)
 	_sanitize_room_references(mydata)
+	_sanitize_room_connections(mydata)
 
 	# NEW: Implement sanitization for corrupt tiles (missing or empty ID when metadata exists)
 	_sanitize_tile_objects(mydata)
@@ -243,6 +248,33 @@ func _sanitize_room_references(data: Dictionary) -> void:
 				)
 				if tile["rooms"].is_empty():
 					tile.erase("rooms")
+
+
+func _sanitize_room_connections(data: Dictionary) -> void:
+	if not data.has("room_connections") or not data["room_connections"] is Array:
+		return
+
+	var valid_room_ids: Array[String] = []
+	if data.has("rooms") and data["rooms"] is Array:
+		for room in data["rooms"]:
+			if room is Dictionary and room.has("id") and room["id"] is String:
+				valid_room_ids.append(room["id"])
+
+	data["room_connections"] = data["room_connections"].filter(func(connection):
+		if not connection is Dictionary or not connection.has("from") or not connection.has("to"):
+			return false
+		for endpoint in [connection["from"], connection["to"]]:
+			if not endpoint is Dictionary or not endpoint.has("kind"):
+				return false
+			if endpoint["kind"] == "room":
+				if not endpoint.has("id") or not endpoint["id"] is String or endpoint["id"] not in valid_room_ids:
+					return false
+			elif endpoint["kind"] != "exterior":
+				return false
+		return true
+	)
+	if data["room_connections"].is_empty():
+		data.erase("room_connections")
 
 
 func load_data_from_disk():

--- a/Tests/Unit/test_dmap_sanitization.gd
+++ b/Tests/Unit/test_dmap_sanitization.gd
@@ -97,3 +97,45 @@ func test_dmap_room_semantics_roundtrip_and_sanitization():
 	])
 	assert_eq(data["levels"][0][0]["rooms"], ["garage_bay"])
 	assert_false(data["levels"][0][1].has("rooms"), "Stale room references should be removed")
+
+
+func test_dmap_room_connections_roundtrip_and_sanitization():
+	var DMap = load("res://Scripts/Gamedata/DMap.gd")
+	var map = DMap.new("test_room_connections", "/tmp/", null)
+	map.set_data({
+		"name": "Room connections",
+		"description": "Preserve authored door links.",
+		"rooms": [
+			{"id": "office", "kind": "enclosed"},
+			{"id": "garage_bay", "kind": "covered_open"},
+		],
+		"room_connections": [
+			{
+				"id": "office_front_door",
+				"at": [11, 10],
+				"z": 0,
+				"from": {"kind": "room", "id": "office"},
+				"to": {"kind": "exterior"},
+			},
+			{
+				"id": "stale_link",
+				"at": [12, 10],
+				"z": 0,
+				"from": {"kind": "room", "id": "missing_room"},
+				"to": {"kind": "exterior"},
+			},
+		],
+		"levels": [[
+			{"id": "concrete_00"},
+		]],
+	})
+
+	var data = map.get_data()
+
+	assert_eq(data["room_connections"], [{
+		"id": "office_front_door",
+		"at": [11, 10],
+		"z": 0,
+		"from": {"kind": "room", "id": "office"},
+		"to": {"kind": "exterior"},
+	}])

--- a/Tools/examples/map_recipe_room_connections.json
+++ b/Tools/examples/map_recipe_room_connections.json
@@ -1,0 +1,110 @@
+{
+	"id": "generated_room_connections",
+	"name": "Generated Room Connections",
+	"description": "Authored semantic door links for exterior and adjacent-room access without generated building geometry.",
+	"seed": 20260808,
+	"base_tile": {
+		"id": "grass_plain_01"
+	},
+	"rooms": [
+		{
+			"id": "office",
+			"kind": "enclosed"
+		},
+		{
+			"id": "garage_bay",
+			"kind": "covered_open"
+		},
+		{
+			"id": "ruined_store",
+			"kind": "ruin"
+		}
+	],
+	"room_connections": [
+		{
+			"id": "office_front_door",
+			"at": [11, 10],
+			"z": 0,
+			"from": {
+				"kind": "room",
+				"id": "office"
+			},
+			"to": {
+				"kind": "exterior"
+			}
+		},
+		{
+			"id": "office_to_garage",
+			"at": [12, 10],
+			"z": 0,
+			"from": {
+				"kind": "room",
+				"id": "office"
+			},
+			"to": {
+				"kind": "room",
+				"id": "garage_bay"
+			}
+		}
+	],
+	"operations": [
+		{
+			"type": "rectangle",
+			"x": 8,
+			"y": 8,
+			"width": 8,
+			"height": 4,
+			"tile": {
+				"id": "concrete_00"
+			}
+		},
+		{
+			"type": "rectangle",
+			"x": 8,
+			"y": 17,
+			"width": 8,
+			"height": 4,
+			"tile": {
+				"id": "concrete__cracked_01"
+			}
+		},
+		{
+			"type": "room_rectangle",
+			"room": "office",
+			"x": 8,
+			"y": 8,
+			"width": 4,
+			"height": 4
+		},
+		{
+			"type": "room_rectangle",
+			"room": "garage_bay",
+			"x": 12,
+			"y": 8,
+			"width": 4,
+			"height": 4
+		},
+		{
+			"type": "room_rectangle",
+			"room": "ruined_store",
+			"x": 8,
+			"y": 17,
+			"width": 8,
+			"height": 4
+		},
+		{
+			"type": "furniture",
+			"id": "door_wood",
+			"x": 11,
+			"y": 10,
+			"rotation": 0
+		},
+		{
+			"type": "furniture",
+			"id": "door_wood",
+			"x": 12,
+			"y": 10,
+			"rotation": 90
+		}
+	]
+}

--- a/Tools/map_generator.py
+++ b/Tools/map_generator.py
@@ -64,6 +64,9 @@ AREA_ENTITY_TYPES = {"furniture", "mob", "mobgroup", "itemgroup"}
 ROOM_DEFINITION_FIELDS = {"id", "kind"}
 ROOM_KINDS = {"enclosed", "covered_open", "ruin"}
 ROOM_RECTANGLE_FIELDS = {"type", "room", "x", "y", "z", "width", "height"}
+ROOM_CONNECTION_FIELDS = {"id", "at", "z", "from", "to"}
+ROOM_CONNECTION_ENDPOINT_FIELDS = {"kind", "id"}
+ROOM_CONNECTION_ENDPOINT_KINDS = {"room", "exterior"}
 TILE_OPERATION_TYPES = {"set", "rectangle", "rectangle_outline", "line", "scatter"}
 LEVEL_FIELDS = {"z", "base_tile", "regions", "operations"}
 RECIPE_FIELDS = {
@@ -76,6 +79,7 @@ RECIPE_FIELDS = {
     "furniture_palette",
     "areas",
     "rooms",
+    "room_connections",
     "patterns",
     "regions",
     "operations",
@@ -176,6 +180,24 @@ def _tile_ids(tiles_path: Path) -> set[str]:
 
 def _furniture_ids(furnitures_path: Path) -> set[str]:
     return _content_ids(furnitures_path, "furniture")
+
+
+def _door_furniture_ids(furnitures_path: Path) -> set[str]:
+    with furnitures_path.open(encoding="utf-8") as handle:
+        furniture_data = json.load(handle)
+    if not isinstance(furniture_data, list):
+        raise RecipeError("furniture database must be a JSON array")
+    return {
+        entry["id"]
+        for entry in furniture_data
+        if (
+            isinstance(entry, dict)
+            and isinstance(entry.get("id"), str)
+            and isinstance(entry.get("Function"), dict)
+            and isinstance(entry["Function"].get("door"), str)
+            and entry["Function"]["door"] != "None"
+        )
+    }
 
 
 def _content_ids(content_path: Path, content_name: str) -> set[str]:
@@ -983,6 +1005,112 @@ def _validate_recipe_rooms(rooms: Any) -> list[dict[str, str]]:
     return validated
 
 
+def _validate_room_connection_endpoint(
+    endpoint: Any, context: str, known_room_ids: set[str]
+) -> dict[str, str]:
+    if not isinstance(endpoint, dict):
+        raise RecipeError(f"{context} must be an object")
+    kind = endpoint.get("kind")
+    if kind not in ROOM_CONNECTION_ENDPOINT_KINDS:
+        raise RecipeError(f"{context}.kind has unsupported kind '{kind}'")
+    expected_fields = {"kind", "id"} if kind == "room" else {"kind"}
+    unknown_fields = sorted(set(endpoint) - expected_fields)
+    if unknown_fields:
+        raise RecipeError(f"{context} must define only kind")
+    if set(endpoint) != expected_fields:
+        raise RecipeError(f"{context} must define {'kind and id' if kind == 'room' else 'only kind'}")
+    if kind == "exterior":
+        return {"kind": "exterior"}
+    room_id = endpoint["id"]
+    if not isinstance(room_id, str) or not room_id.strip():
+        raise RecipeError(f"{context}.id must be a non-empty string")
+    if room_id not in known_room_ids:
+        raise RecipeError(f"{context}.id references unknown room '{room_id}'")
+    return {"kind": "room", "id": room_id}
+
+
+def _validate_recipe_room_connections(
+    connections: Any, known_room_ids: set[str]
+) -> list[dict[str, Any]]:
+    if not isinstance(connections, list):
+        raise RecipeError("room_connections must be an array")
+    validated: list[dict[str, Any]] = []
+    seen_ids: set[str] = set()
+    for index, connection in enumerate(connections):
+        context = f"room_connections[{index}]"
+        if not isinstance(connection, dict):
+            raise RecipeError(f"{context} must be an object")
+        unknown_fields = sorted(set(connection) - ROOM_CONNECTION_FIELDS)
+        if unknown_fields:
+            raise RecipeError(f"unknown {context} field '{unknown_fields[0]}'")
+        if set(connection) != ROOM_CONNECTION_FIELDS:
+            raise RecipeError(f"{context} must define id, at, z, from, and to")
+        connection_id = connection["id"]
+        if not isinstance(connection_id, str) or not connection_id.strip():
+            raise RecipeError(f"{context}.id must be a non-empty string")
+        _validate_unicode(connection_id, f"{context}.id")
+        if DEFINITION_NAME_PATTERN.fullmatch(connection_id) is None:
+            raise RecipeError(f"{context}.id may contain only letters, numbers, underscores, and hyphens")
+        if connection_id in seen_ids:
+            raise RecipeError(f"duplicate room connection ID '{connection_id}'")
+        seen_ids.add(connection_id)
+        at = connection["at"]
+        if (
+            not isinstance(at, list)
+            or len(at) != 2
+            or any(type(value) is not int for value in at)
+            or not 0 <= at[0] < MAP_WIDTH
+            or not 0 <= at[1] < MAP_HEIGHT
+        ):
+            raise RecipeError(f"{context}.at must be within map bounds as a two-integer array")
+        z = connection["z"]
+        if type(z) is not int or not MIN_LOGICAL_Z <= z <= MAX_LOGICAL_Z:
+            raise RecipeError(f"{context}.z must be an integer from -10 through 10")
+        from_endpoint = _validate_room_connection_endpoint(
+            connection["from"], f"{context}.from", known_room_ids
+        )
+        to_endpoint = _validate_room_connection_endpoint(
+            connection["to"], f"{context}.to", known_room_ids
+        )
+        if from_endpoint == to_endpoint:
+            raise RecipeError(f"{context} must connect distinct endpoints")
+        validated.append({
+            "id": connection_id,
+            "at": at,
+            "z": z,
+            "from": from_endpoint,
+            "to": to_endpoint,
+        })
+    return validated
+
+
+def _validate_room_connection_targets(
+    connections: list[dict[str, Any]],
+    levels: list[list[dict[str, Any]]],
+    door_furniture_ids: set[str],
+) -> None:
+    seen_targets: set[tuple[int, int, int]] = set()
+    for index, connection in enumerate(connections):
+        context = f"room_connections[{index}]"
+        x, y = connection["at"]
+        z = connection["z"]
+        target = (z, x, y)
+        if target in seen_targets:
+            raise RecipeError(f"{context} duplicates door target at z {z} [{x}, {y}]")
+        seen_targets.add(target)
+        level = levels[_level_index(z)]
+        tile = level[y * MAP_WIDTH + x] if level else {}
+        feature = tile.get("feature") if isinstance(tile, dict) else None
+        if (
+            not isinstance(tile.get("id"), str)
+            or not tile["id"]
+            or not isinstance(feature, dict)
+            or feature.get("type") != "furniture"
+            or feature.get("id") not in door_furniture_ids
+        ):
+            raise RecipeError(f"{context} must reference door-capable furniture at z {z} [{x}, {y}]")
+
+
 def _apply_area_rectangle(
     level: list[dict[str, Any]],
     operation: dict[str, Any],
@@ -1258,12 +1386,19 @@ def generate_map(
     content_root = Path(tiles_path).parent.parent
     known_furnitures: set[str] = set()
     requires_furniture_catalog = (
-        _contains_furniture_operations(recipe) or _contains_area_entities(recipe)
+        _contains_furniture_operations(recipe)
+        or _contains_area_entities(recipe)
+        or "room_connections" in recipe
     )
     if requires_furniture_catalog:
         if furnitures_path is None:
             furnitures_path = content_root / "Furniture" / "Furniture.json"
         known_furnitures = _furniture_ids(Path(furnitures_path))
+    door_furniture_ids: set[str] = set()
+    if "room_connections" in recipe:
+        if furnitures_path is None:
+            raise RecipeError("room_connections requires a furniture database")
+        door_furniture_ids = _door_furniture_ids(Path(furnitures_path))
     known_area_entity_ids: dict[str, set[str]] = {
         "furniture": known_furnitures,
         "mob": set(),
@@ -1293,6 +1428,9 @@ def generate_map(
     known_area_ids = {area["id"] for area in areas}
     rooms = _validate_recipe_rooms(recipe.get("rooms", []))
     known_room_ids = {room["id"] for room in rooms}
+    room_connections = _validate_recipe_room_connections(
+        recipe.get("room_connections", []), known_room_ids
+    )
     rng = random.Random(seed)
     levels = _generate_levels(
         recipe,
@@ -1305,6 +1443,7 @@ def generate_map(
         known_area_ids,
         known_room_ids,
     )
+    _validate_room_connection_targets(room_connections, levels, door_furniture_ids)
 
     generated = {
         "id": recipe["id"],
@@ -1321,6 +1460,8 @@ def generate_map(
         generated["areas"] = areas
     if rooms:
         generated["rooms"] = rooms
+    if room_connections:
+        generated["room_connections"] = room_connections
     return generated
 
 

--- a/Tools/map_validator.py
+++ b/Tools/map_validator.py
@@ -9,6 +9,8 @@ MAP_HEIGHT = 32
 LEVEL_COUNT = 21
 POPULATED_LEVEL_TILE_COUNT = MAP_WIDTH * MAP_HEIGHT
 ROOM_KINDS = {'enclosed', 'covered_open', 'ruin'}
+ROOM_CONNECTION_FIELDS = {'id', 'at', 'z', 'from', 'to'}
+ROOM_CONNECTION_ENDPOINT_KINDS = {'room', 'exterior'}
 
 class MapValidationError(Exception):
     """Custom exception for map validation errors."""
@@ -25,6 +27,30 @@ class MapValidator:
 
     def add_warning(self, file_path: str, message: str):
         self.warnings.append(f"[{file_path}] WARNING: {message}")
+
+    def _door_furniture_ids(self):
+        furniture_path = os.path.join(
+            os.path.dirname(os.path.dirname(__file__)),
+            'Mods', 'Dimensionfall', 'Furniture', 'Furniture.json'
+        )
+        try:
+            with open(furniture_path, 'r', encoding='utf-8') as handle:
+                furniture_data = json.load(handle)
+        except (OSError, json.JSONDecodeError):
+            return set()
+        if not isinstance(furniture_data, list):
+            return set()
+        return {
+            entry['id']
+            for entry in furniture_data
+            if (
+                isinstance(entry, dict)
+                and isinstance(entry.get('id'), str)
+                and isinstance(entry.get('Function'), dict)
+                and isinstance(entry['Function'].get('door'), str)
+                and entry['Function']['door'] != 'None'
+            )
+        }
 
     def validate_map(self, file_path: str):
         """Validates a single map JSON file."""
@@ -65,6 +91,10 @@ class MapValidator:
         if not isinstance(rooms, list):
             self.add_error(file_path, "top-level rooms must be an array.")
             rooms = []
+        room_connections = data.get('room_connections', [])
+        if not isinstance(room_connections, list):
+            self.add_error(file_path, "top-level room_connections must be an array.")
+            room_connections = []
 
         # 2. Check Optional Metadata Types
         metadata_checks = {
@@ -161,6 +191,77 @@ class MapValidator:
             kind = room.get('kind')
             if kind not in ROOM_KINDS:
                 self.add_error(file_path, f"Room at index {idx} has unsupported room kind '{kind}'.")
+
+        validated_room_connections = []
+        seen_connection_ids: Set[str] = set()
+        for idx, connection in enumerate(room_connections):
+            context = f"Room connection at index {idx}"
+            if not isinstance(connection, dict):
+                self.add_error(file_path, f"{context} is not an object.")
+                continue
+            unknown_fields = sorted(set(connection) - ROOM_CONNECTION_FIELDS)
+            if unknown_fields:
+                self.add_error(file_path, f"{context} has unknown field '{unknown_fields[0]}'.")
+            for field in ROOM_CONNECTION_FIELDS:
+                if field not in connection:
+                    self.add_error(file_path, f"{context} is missing required field '{field}'.")
+            connection_id = connection.get('id')
+            if not isinstance(connection_id, str) or not connection_id:
+                self.add_error(file_path, f"{context} has invalid or missing ID.")
+            elif connection_id in seen_connection_ids:
+                self.add_error(file_path, f"Duplicate room connection ID detected: '{connection_id}'")
+            else:
+                seen_connection_ids.add(connection_id)
+            at = connection.get('at')
+            if (
+                not isinstance(at, list)
+                or len(at) != 2
+                or any(type(value) is not int for value in at)
+                or not 0 <= at[0] < MAP_WIDTH
+                or not 0 <= at[1] < MAP_HEIGHT
+            ):
+                self.add_error(file_path, f"{context} at must be a two-integer coordinate within map bounds.")
+            z = connection.get('z')
+            if type(z) is not int or not -10 <= z <= 10:
+                self.add_error(file_path, f"{context} z must be an integer from -10 through 10.")
+            endpoints = []
+            endpoints_valid = True
+            for field in ('from', 'to'):
+                endpoint = connection.get(field)
+                endpoint_context = f"{context} {field} endpoint"
+                if not isinstance(endpoint, dict):
+                    self.add_error(file_path, f"{endpoint_context} is not an object.")
+                    endpoints_valid = False
+                    continue
+                kind = endpoint.get('kind')
+                if kind not in ROOM_CONNECTION_ENDPOINT_KINDS:
+                    self.add_error(file_path, f"{endpoint_context} has unsupported kind '{kind}'.")
+                    endpoints_valid = False
+                    continue
+                expected_fields = {'kind', 'id'} if kind == 'room' else {'kind'}
+                if set(endpoint) != expected_fields:
+                    self.add_error(file_path, f"{endpoint_context} has invalid fields.")
+                    endpoints_valid = False
+                    continue
+                if kind == 'room':
+                    room_id = endpoint.get('id')
+                    if not isinstance(room_id, str) or not room_id:
+                        self.add_error(file_path, f"{endpoint_context} has invalid or missing room ID.")
+                        endpoints_valid = False
+                    elif room_id not in room_ids:
+                        self.add_error(file_path, f"{endpoint_context} references non-existent room '{room_id}'.")
+                        endpoints_valid = False
+                endpoints.append(endpoint)
+            if endpoints_valid and len(endpoints) == 2 and endpoints[0] == endpoints[1]:
+                self.add_error(file_path, f"{context} must connect distinct endpoints.")
+            if (
+                isinstance(connection_id, str) and connection_id
+                and isinstance(at, list) and len(at) == 2
+                and all(type(value) is int for value in at)
+                and 0 <= at[0] < MAP_WIDTH and 0 <= at[1] < MAP_HEIGHT
+                and type(z) is int and -10 <= z <= 10
+            ):
+                validated_room_connections.append(connection)
 
         # 5. Validate Levels (Tiles)
         if not isinstance(levels, list):
@@ -317,6 +418,30 @@ class MapValidator:
                                         file_path,
                                         f"Level {level_idx}, Tile '{tile['id']}' has non-numeric area rotation: {rotation}"
                                     )
+
+        door_furniture_ids = self._door_furniture_ids() if validated_room_connections else set()
+        seen_door_targets: Set[tuple] = set()
+        for connection in validated_room_connections:
+            x, y = connection['at']
+            z = connection['z']
+            target = (z, x, y)
+            if target in seen_door_targets:
+                self.add_error(file_path, f"Room connection '{connection['id']}' duplicates door target at z {z} [{x}, {y}].")
+                continue
+            seen_door_targets.add(target)
+            level_index = z + 10
+            level = levels[level_index] if isinstance(levels, list) and level_index < len(levels) else []
+            tile = level[y * MAP_WIDTH + x] if isinstance(level, list) and len(level) == POPULATED_LEVEL_TILE_COUNT else {}
+            feature = tile.get('feature') if isinstance(tile, dict) else None
+            if (
+                not isinstance(tile, dict)
+                or not isinstance(tile.get('id'), str)
+                or not tile['id']
+                or not isinstance(feature, dict)
+                or feature.get('type') != 'furniture'
+                or feature.get('id') not in door_furniture_ids
+            ):
+                self.add_error(file_path, f"Room connection '{connection['id']}' must reference door-capable furniture at z {z} [{x}, {y}].")
 
     def run(self, path: str):
         if os.path.isdir(path):

--- a/Tools/tests/test_map_generator.py
+++ b/Tools/tests/test_map_generator.py
@@ -1477,6 +1477,84 @@ class MapGeneratorTests(unittest.TestCase):
         with self.assertRaisesRegex(RecipeError, r"requires supporting terrain at \[0, 0\]"):
             generate_map(recipe, TILES_PATH)
 
+    def test_room_connections_preserve_existing_door_features(self):
+        recipe = valid_recipe()
+        recipe["base_tile"] = {"id": "concrete_00"}
+        recipe["rooms"] = [
+            {"id": "office", "kind": "enclosed"},
+            {"id": "garage_bay", "kind": "covered_open"},
+        ]
+        recipe["operations"] = [
+            {"type": "room_rectangle", "room": "office", "x": 8, "y": 8, "width": 4, "height": 4},
+            {"type": "room_rectangle", "room": "garage_bay", "x": 12, "y": 8, "width": 4, "height": 4},
+            {"type": "furniture", "id": "door_wood", "x": 11, "y": 10, "rotation": 0},
+            {"type": "furniture", "id": "door_wood", "x": 12, "y": 10, "rotation": 90},
+        ]
+        recipe["room_connections"] = [
+            {
+                "id": "office_front_door",
+                "at": [11, 10],
+                "z": 0,
+                "from": {"kind": "room", "id": "office"},
+                "to": {"kind": "exterior"},
+            },
+            {
+                "id": "office_to_garage",
+                "at": [12, 10],
+                "z": 0,
+                "from": {"kind": "room", "id": "office"},
+                "to": {"kind": "room", "id": "garage_bay"},
+            },
+        ]
+
+        generated = generate_map(recipe, TILES_PATH)
+
+        self.assertEqual(generated["room_connections"], recipe["room_connections"])
+        level = generated["levels"][10]
+        self.assertEqual(level[10 * 32 + 11]["feature"], {
+            "type": "furniture",
+            "id": "door_wood",
+            "rotation": 0,
+            "itemgroups": [],
+        })
+        self.assertEqual(level[10 * 32 + 12]["feature"], {
+            "type": "furniture",
+            "id": "door_wood",
+            "rotation": 90,
+            "itemgroups": [],
+        })
+
+    def test_room_connections_reject_invalid_schema_and_targets(self):
+        base_connection = {
+            "id": "office_front_door",
+            "at": [11, 10],
+            "z": 0,
+            "from": {"kind": "room", "id": "office"},
+            "to": {"kind": "exterior"},
+        }
+        invalid_connections = [
+            ("not-an-array", "room_connections must be an array"),
+            ([{"id": "office_front_door", "at": [11, 10], "z": 0, "from": {"kind": "room", "id": "office"}, "to": {"kind": "exterior"}, "extra": True}], "unknown room_connections\\[0\\] field 'extra'"),
+            ([{**base_connection, "from": {"kind": "room", "id": "missing"}}], "references unknown room 'missing'"),
+            ([{**base_connection, "to": {"kind": "exterior", "id": "forbidden"}}], "must define only kind"),
+            ([{**base_connection, "to": {"kind": "room", "id": "office"}}], "must connect distinct endpoints"),
+            ([{**base_connection, "at": [32, 10]}], "must be within map bounds"),
+            ([{**base_connection, "z": 11}], "must be an integer from -10 through 10"),
+            ([{**base_connection, "at": [0, 0]}], "must reference door-capable furniture"),
+            ([base_connection, {**base_connection, "id": "another_door"}], r"duplicates door target at z 0 \[11, 10\]"),
+        ]
+        for connections, expected_message in invalid_connections:
+            with self.subTest(connections=connections):
+                recipe = valid_recipe()
+                recipe["base_tile"] = {"id": "concrete_00"}
+                recipe["rooms"] = [{"id": "office", "kind": "enclosed"}]
+                recipe["operations"] = [
+                    {"type": "furniture", "id": "door_wood", "x": 11, "y": 10, "rotation": 0},
+                ]
+                recipe["room_connections"] = connections
+                with self.assertRaisesRegex(RecipeError, expected_message):
+                    generate_map(recipe, TILES_PATH)
+
     def test_area_entities_require_known_runtime_type_catalog_ids_and_positive_counts(self):
         known_entity_ids = {
             "furniture": json.loads(FURNITURES_PATH.read_text(encoding="utf-8"))[0]["id"],
@@ -1550,6 +1628,44 @@ class MapGeneratorTests(unittest.TestCase):
         self.assertEqual(level[7 * 32 + 11]["id"], "concrete_00")
         self.assertEqual(level[7 * 32 + 12]["id"], "concrete_00")
         self.assertNotIn("rooms", level[0])
+
+    def test_room_connections_example_preserves_semantic_door_links(self):
+        recipe_path = ROOT / "Tools" / "examples" / "map_recipe_room_connections.json"
+        generated = generate_map(
+            json.loads(recipe_path.read_text(encoding="utf-8")), TILES_PATH
+        )
+
+        self.assertEqual([room["id"] for room in generated["rooms"]], [
+            "office", "garage_bay", "ruined_store"
+        ])
+        self.assertEqual(generated["room_connections"], [
+            {
+                "id": "office_front_door",
+                "at": [11, 10],
+                "z": 0,
+                "from": {"kind": "room", "id": "office"},
+                "to": {"kind": "exterior"},
+            },
+            {
+                "id": "office_to_garage",
+                "at": [12, 10],
+                "z": 0,
+                "from": {"kind": "room", "id": "office"},
+                "to": {"kind": "room", "id": "garage_bay"},
+            },
+        ])
+        level = generated["levels"][10]
+        for x, rotation in ((11, 0), (12, 90)):
+            self.assertEqual(level[10 * 32 + x]["feature"], {
+                "type": "furniture",
+                "id": "door_wood",
+                "rotation": rotation,
+                "itemgroups": [],
+            })
+        self.assertEqual(
+            generated,
+            generate_map(json.loads(recipe_path.read_text(encoding="utf-8")), TILES_PATH),
+        )
 
     def test_area_meadow_example_matches_its_runtime_area_boundary(self):
         recipe_path = ROOT / "Tools" / "examples" / "map_recipe_area_meadow.json"
@@ -1885,6 +2001,47 @@ class MapValidatorDimensionTests(unittest.TestCase):
         map_data["levels"][10][0] = {"id": "", "rooms": ["office"]}
         errors = self.validate(map_data)
         self.assertTrue(any("room membership requires terrain" in error for error in errors))
+
+    def test_validates_room_connection_structure_and_door_targets(self):
+        recipe = valid_recipe()
+        recipe["base_tile"] = {"id": "concrete_00"}
+        recipe["rooms"] = [{"id": "office", "kind": "enclosed"}]
+        recipe["operations"] = [
+            {"type": "furniture", "id": "door_wood", "x": 11, "y": 10, "rotation": 0},
+        ]
+        recipe["room_connections"] = [{
+            "id": "office_front_door",
+            "at": [11, 10],
+            "z": 0,
+            "from": {"kind": "room", "id": "office"},
+            "to": {"kind": "exterior"},
+        }]
+        valid_map = generate_map(recipe, TILES_PATH)
+        self.assertEqual(self.validate(valid_map), [])
+
+        invalid_maps = []
+        malformed_root = valid_map.copy()
+        malformed_root["room_connections"] = "not-an-array"
+        invalid_maps.append((malformed_root, "top-level room_connections must be an array"))
+
+        missing_room = json.loads(json.dumps(valid_map))
+        missing_room["room_connections"][0]["from"]["id"] = "missing"
+        invalid_maps.append((missing_room, "references non-existent room 'missing'"))
+
+        missing_feature = json.loads(json.dumps(valid_map))
+        missing_feature["levels"][10][10 * 32 + 11].pop("feature")
+        invalid_maps.append((missing_feature, "must reference door-capable furniture"))
+
+        duplicate_target = json.loads(json.dumps(valid_map))
+        duplicate_target["room_connections"].append({
+            **duplicate_target["room_connections"][0], "id": "another_door"
+        })
+        invalid_maps.append((duplicate_target, "duplicates door target"))
+
+        for map_data, expected_message in invalid_maps:
+            with self.subTest(expected_message=expected_message):
+                errors = self.validate(map_data)
+                self.assertTrue(any(expected_message in error for error in errors))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

Adds a narrow `room_connections` map contract for explicitly documenting what existing door furniture connects.

- supports room-to-exterior and room-to-room links;
- references existing door-capable furniture at explicit `[x, y, z]`;
- validates room IDs, endpoint shape, unique IDs, unique door targets, bounds, logical z, terrain, and door-capable features;
- preserves valid links through `DMap` content-editor save/load;
- removes saved links that reference deleted rooms;
- adds a maintained `generated_room_connections` recipe using existing `door_wood` features;
- synchronizes map-generation and roadmap documentation.

## Scope

This is semantic metadata only. It does not infer topology, create walls/roofs/doors, alter runtime door behavior, add indoor/outdoor gameplay state, or introduce enclosure validation.

## Validation

- `python3 -m unittest discover -s Tools/tests` — 81 passed
- all 8 maintained recipes generated and validated
- `python3 Tools/map_validator.py Mods/Dimensionfall/Maps` — 51 maps, no errors
- full GUT suite — 83 passed, 383 assertions
- `godot --headless --path . --editor --quit`
- `git diff --check`