### PR TITLE
Add authored room boundary references

### DIFF
--- a/Documentation/Game_design/Map_generation_plan.md
+++ b/Documentation/Game_design/Map_generation_plan.md
@@ -617,11 +617,13 @@ The area entity contract is now strict and catalog-aware. Recipes may use the ex
 
 Authored room semantics use a separate map-level `rooms` array plus exclusive tile-local `rooms: ["id"]` membership. Each definition has a stable authored ID and exactly one semantic kind: `enclosed`, `covered_open`, or `ruin`. These labels are deliberately independent from floor material and runtime `areas`: one wood or concrete floor can span several rooms, a roofed garage can be `covered_open`, and a ruined room remains a room despite intended wall gaps. `Tools/examples/map_recipe_room_semantics.json` is the maintained evidence and puts adjacent `office` and `garage_bay` labels on the same `concrete_00` material.
 
-`room_connections` now adds explicit authored door intent without topology inference. Each root connection names a unique `id`, an `[x, y]` coordinate, required logical `z`, and two distinct endpoints: a known room or `exterior`. The target must be an existing terrain tile with catalog-recognized door-capable furniture; current evidence uses the runtime-native `door_wood` feature. This covers both room-to-exterior and room-to-room doors while preserving existing door opening, collision, and rotation behavior. `Tools/examples/map_recipe_room_connections.json` carries both cases. The generator and independent validator reject malformed endpoints, unknown rooms, duplicate door targets, or non-door targets; `DMap` preserves valid connections and removes links that name deleted rooms.
+`room_connections` adds explicit authored door intent without topology inference. Each root connection names a unique `id`, an `[x, y]` coordinate, required logical `z`, and two distinct endpoints: a known room or `exterior`. The target must be an existing terrain tile with catalog-recognized door-capable furniture; current evidence uses the runtime-native `door_wood` feature. This covers both room-to-exterior and room-to-room doors while preserving existing door opening, collision, and rotation behavior. `Tools/examples/map_recipe_room_connections.json` carries both cases. The generator and independent validator reject malformed endpoints, unknown rooms, duplicate door targets, or non-door targets; `DMap` preserves valid connections and removes links that name deleted rooms.
 
-The generator, standalone map validator, and `DMap` save/load path validate or preserve definitions and references. No topology inference, wall/roof checks, indoor weather/lighting, or geometry generation is introduced yet.
+`room_boundaries` now provides the first authored physical evidence without generating a building. Each record identifies one room, exact `[x, y, z]`, and either `wall_tile` or `door_furniture`. Wall records must point to an existing tile catalogued with the `Wall` category and be cardinally adjacent to that room’s semantic tiles. Door records must point to existing door-capable furniture and a same-location `room_connections` endpoint naming that room. A room cannot duplicate a target, but one wall tile can be declared for different rooms. `Tools/examples/map_recipe_room_boundaries.json` demonstrates four existing `brick_wall_00` tiles and three opening records across `enclosed`, `covered_open`, and `ruin` rooms. It is intentionally partial: no perimeter-completeness rule penalizes the garage or ruin.
 
-This foundation intentionally does **not** yet define polygons, topology-derived room boundaries, indoor/outdoor runtime behavior, wall/roof enclosure validation, building footprints, anchors, or generalized templates.
+The generator, standalone map validator, and `DMap` save/load path validate or preserve definitions and references. No topology inference, wall/roof generation, indoor weather/lighting, or geometry generation is introduced yet.
+
+This foundation intentionally does **not** yet define polygons, topology-derived room boundaries, indoor/outdoor runtime behavior, boundary completeness/enclosure validation, wall/roof generation, building footprints, anchors, or generalized templates.
 
 Capabilities:
 
@@ -856,7 +858,7 @@ An agent can create a new playable, potentially multi-level map from a concise d
 
 # Recommended immediate next task
 
-**Phase 6 is in progress.** Its runtime-compatible area foundation, catalog-validated per-instance entity variation, authored room semantics, and explicit door-link metadata are complete. The next contribution should add the smallest evidenced physical boundary representation or validation without inferring it from floor materials.
+**Phase 6 is in progress.** Its runtime-compatible area foundation, catalog-validated per-instance entity variation, authored room semantics, explicit door-link metadata, and partial physical boundary references are complete. The next contribution should selectively validate declared boundary completeness for `enclosed` rooms without inferring it from floor materials.
 
 Do not yet generate walls, doors, roofs, multi-level building footprints, furniture anchors, roads, towns, or generalized building templates. Preserve the established map-level `areas` plus per-tile area membership representation, keep room semantics independent from runtime areas, and validate any physical semantics in the editor and runtime.
 
@@ -895,7 +897,8 @@ Do not commit or push unless explicitly requested.
 [Complete] Catalog-validated runtime area entity variation
 [Complete] Authored room semantics (`enclosed`, `covered_open`, `ruin`)
 [Complete] Explicit room-to-exterior and room-to-room door-link metadata
-[Next]     Physical room boundary representation or validation
+[Complete] Authored existing-wall and connected-door boundary references
+[Next]     Selective declared-boundary completeness validation
 [Planned]  Rooms and buildings
 [Planned]  Roads and map connections
 [Planned]  Multi-level reusable templates and richer composition

--- a/Documentation/Modding/map_example_generation.md
+++ b/Documentation/Modding/map_example_generation.md
@@ -28,6 +28,7 @@ The maintained recipe examples are:
 | `Tools/examples/map_recipe_area_entity_clearing.json` | `Mods/Dimensionfall/Maps/generated_area_entity_clearing.json` | A `12×12` terrain-backed area whose weighted stump entity is selected anew by the runtime each time the map is instanced. |
 | `Tools/examples/map_recipe_room_semantics.json` | `Mods/Dimensionfall/Maps/generated_room_semantics.json` | Authored `enclosed`, `covered_open`, and `ruin` room labels on terrain without generated walls, doors, roofs, or indoor runtime behavior. |
 | `Tools/examples/map_recipe_room_connections.json` | `Mods/Dimensionfall/Maps/generated_room_connections.json` | Existing `door_wood` features with explicit room-to-exterior and room-to-room semantic links, without inferred topology or new runtime door behavior. |
+| `Tools/examples/map_recipe_room_boundaries.json` | `Mods/Dimensionfall/Maps/generated_room_boundaries.json` | Existing `brick_wall_00` tiles and connected `door_wood` features explicitly attached to rooms without generated geometry or enclosure-completeness rules. |
 | `Tools/examples/map_recipe_two_level_hill.json` | `Mods/Dimensionfall/Maps/generated_two_level_hill.json` | Ground level `z: 0`, raised terrain at `z: 1`, and all four slope rotations. |
 | `Tools/examples/map_recipe_two_level_depression.json` | `Mods/Dimensionfall/Maps/generated_two_level_depression.json` | Ground level `z: 0`, lowered terrain at `z: -1`, and all four slope rotations. |
 
@@ -76,6 +77,11 @@ python3 Tools/map_generator.py \
   Tools/examples/map_recipe_room_connections.json \
   Mods/Dimensionfall/Maps/generated_room_connections.json
 
+# Ground-level authored room boundaries
+python3 Tools/map_generator.py \
+  Tools/examples/map_recipe_room_boundaries.json \
+  Mods/Dimensionfall/Maps/generated_room_boundaries.json
+
 # Two-level hill
 python3 Tools/map_generator.py \
   Tools/examples/map_recipe_two_level_hill.json \
@@ -105,6 +111,7 @@ rm Mods/Dimensionfall/Maps/generated_area_meadow.json
 rm Mods/Dimensionfall/Maps/generated_area_entity_clearing.json
 rm Mods/Dimensionfall/Maps/generated_room_semantics.json
 rm Mods/Dimensionfall/Maps/generated_room_connections.json
+rm Mods/Dimensionfall/Maps/generated_room_boundaries.json
 rm Mods/Dimensionfall/Maps/generated_two_level_hill.json
 rm Mods/Dimensionfall/Maps/generated_two_level_depression.json
 ```
@@ -179,6 +186,8 @@ For the maintained area entity clearing, confirm the same `[10, 10]` through `[2
 For the maintained room-semantics map, inspect `generated_room_semantics` in the content editor, save it, close it, and re-open it. Confirm that `office` (`enclosed`), `garage_bay` (`covered_open`), and `ruined_store` (`ruin`) labels persist without load errors. The office and garage intentionally share adjacent `concrete_00` terrain, so do not infer room boundaries from floor material. Map preview and **save and test** should only be used to confirm persistence and normal loading in this slice: it does not yet create walls, roofs, doors, lighting, weather, or indoor gameplay behavior.
 
 For the maintained room-connections map, open `generated_room_connections`, save it, close it, and re-open it. Confirm that `office_front_door` remains an `office`→`exterior` link and `office_to_garage` remains an `office`→`garage_bay` link. In map preview and **save and test**, verify both existing `door_wood` features load and retain normal open/close interaction. This metadata must not create walls, roofs, lighting, weather, automatic enclosure, or a different door runtime behavior.
+
+For the maintained room-boundaries map, open `generated_room_boundaries`, save it, close it, and re-open it. Confirm the four existing `brick_wall_00` cells and both existing `door_wood` features remain present, and that the root `room_boundaries` list persists with four `wall_tile` and three `door_furniture` records. The garage and ruin deliberately do not declare full perimeters; **save and test** should confirm normal loading and existing door interaction only, not new enclosure, collision, navigation, lighting, weather, or indoor behavior.
 
 Dimensionfall also looks for a same-named `.png` map sprite during startup. The runner intentionally generates map JSON only, so Godot currently logs a non-fatal missing-resource error for that sprite. This does not prevent the JSON map from loading or the map editor's tile-grid preview from rendering it.
 

--- a/Documentation/Modding/map_recipe_generator.md
+++ b/Documentation/Modding/map_recipe_generator.md
@@ -323,6 +323,42 @@ Room IDs must exist in root `rooms`; the two endpoints must be distinct; and one
 
 Connections are semantic metadata only. They preserve their authored `from`/`to` order but do not create a new door feature, alter existing door behavior, infer enclosure, generate geometry, or introduce an indoor/outdoor runtime state. `DMap` preserves valid links through content-editor save/load and removes links that name deleted rooms.
 
+### `room_boundaries`
+
+`room_boundaries` explicitly attaches an existing physical wall tile or connected door opening to one authored room. It does not derive a perimeter from rooms, floor material, wall rotation, or neighboring geometry. Each root record contains exactly `id`, `room`, `at`, `z`, and `element`:
+
+```json
+{
+  "room_boundaries": [
+    {
+      "id": "office_north_wall",
+      "room": "office",
+      "at": [8, 7],
+      "z": 0,
+      "element": "wall_tile"
+    },
+    {
+      "id": "office_front_opening",
+      "room": "office",
+      "at": [11, 10],
+      "z": 0,
+      "element": "door_furniture"
+    }
+  ]
+}
+```
+
+`id` is unique and uses normal definition-name characters. `room` must name a root room, `at` is an in-bounds `[x, y]`, and `z` is a required logical level from `-10` through `10`. `element` is exactly one of:
+
+| Element | Existing target requirement |
+|---|---|
+| `wall_tile` | The target terrain ID is in the tile catalog and has the `Wall` category; it must be cardinally adjacent to a tile labelled with the named room. |
+| `door_furniture` | The target terrain tile contains catalog-recognized door-capable furniture and a `room_connections` entry at the same `[x, y, z]` names the room. |
+
+A room cannot name the same target coordinate twice, but one wall tile may deliberately bound different rooms through separate records. This remains partial authored evidence: `enclosed`, `covered_open`, and `ruin` rooms may declare only the segments that matter to the current recipe. No perimeter-completeness or enclosure rule exists yet.
+
+Boundary metadata preserves existing terrain, furniture, rotation, collision, and runtime door behavior. `DMap` preserves it through content-editor save/load and removes records naming deleted rooms. It does not create walls or openings, infer a door from rotation, change navigation, or add indoor/outdoor effects.
+
 ### `set`
 
 Places one tile. Fields: `type`, `x`, `y`, `tile`, and optional root-level `z`.

--- a/Scripts/Gamedata/DMap.gd
+++ b/Scripts/Gamedata/DMap.gd
@@ -95,6 +95,7 @@ var levels: Array = [
 var areas: Array = []
 var rooms: Array = []
 var room_connections: Array = []
+var room_boundaries: Array = []
 var sprite: Texture = null
 # Variable to store connections. For example: {"south": "road","west": "ground"} default to ground
 var connections: Dictionary = {
@@ -149,6 +150,7 @@ func set_data(newdata: Dictionary) -> void:
 	areas = newdata.get("areas", [])
 	rooms = newdata.get("rooms", [])
 	room_connections = newdata.get("room_connections", [])
+	room_boundaries = newdata.get("room_boundaries", [])
 	connections = newdata.get("connections", {})  # Set connections from data if present
 
 
@@ -170,6 +172,8 @@ func get_data() -> Dictionary:
 		mydata["rooms"] = rooms
 	if not room_connections.is_empty():
 		mydata["room_connections"] = room_connections
+	if not room_boundaries.is_empty():
+		mydata["room_boundaries"] = room_boundaries
 	if not connections.is_empty():  # Omit connections if empty
 		mydata["connections"] = connections
 	
@@ -177,6 +181,7 @@ func get_data() -> Dictionary:
 	_sanitize_area_references(mydata)
 	_sanitize_room_references(mydata)
 	_sanitize_room_connections(mydata)
+	_sanitize_room_boundaries(mydata)
 
 	# NEW: Implement sanitization for corrupt tiles (missing or empty ID when metadata exists)
 	_sanitize_tile_objects(mydata)
@@ -275,6 +280,26 @@ func _sanitize_room_connections(data: Dictionary) -> void:
 	)
 	if data["room_connections"].is_empty():
 		data.erase("room_connections")
+
+
+func _sanitize_room_boundaries(data: Dictionary) -> void:
+	if not data.has("room_boundaries") or not data["room_boundaries"] is Array:
+		return
+
+	var valid_room_ids: Array[String] = []
+	if data.has("rooms") and data["rooms"] is Array:
+		for room in data["rooms"]:
+			if room is Dictionary and room.has("id") and room["id"] is String:
+				valid_room_ids.append(room["id"])
+
+	data["room_boundaries"] = data["room_boundaries"].filter(func(boundary):
+		return boundary is Dictionary \
+			and boundary.has("room") \
+			and boundary["room"] is String \
+			and boundary["room"] in valid_room_ids
+	)
+	if data["room_boundaries"].is_empty():
+		data.erase("room_boundaries")
 
 
 func load_data_from_disk():

--- a/Tests/Unit/test_dmap_sanitization.gd
+++ b/Tests/Unit/test_dmap_sanitization.gd
@@ -139,3 +139,44 @@ func test_dmap_room_connections_roundtrip_and_sanitization():
 		"from": {"kind": "room", "id": "office"},
 		"to": {"kind": "exterior"},
 	}])
+
+
+func test_dmap_room_boundaries_roundtrip_and_sanitization():
+	var DMap = load("res://Scripts/Gamedata/DMap.gd")
+	var map = DMap.new("test_room_boundaries", "/tmp/", null)
+	map.set_data({
+		"name": "Room boundaries",
+		"description": "Preserve authored physical references.",
+		"rooms": [
+			{"id": "office", "kind": "enclosed"},
+		],
+		"room_boundaries": [
+			{
+				"id": "office_north_wall",
+				"room": "office",
+				"at": [8, 7],
+				"z": 0,
+				"element": "wall_tile",
+			},
+			{
+				"id": "stale_boundary",
+				"room": "missing_room",
+				"at": [12, 10],
+				"z": 0,
+				"element": "door_furniture",
+			},
+		],
+		"levels": [[
+			{"id": "concrete_00"},
+		]],
+	})
+
+	var data = map.get_data()
+
+	assert_eq(data["room_boundaries"], [{
+		"id": "office_north_wall",
+		"room": "office",
+		"at": [8, 7],
+		"z": 0,
+		"element": "wall_tile",
+	}])

--- a/Tools/examples/map_recipe_room_boundaries.json
+++ b/Tools/examples/map_recipe_room_boundaries.json
@@ -1,0 +1,193 @@
+{
+	"id": "generated_room_boundaries",
+	"name": "Generated Room Boundaries",
+	"description": "Authored room boundary references to existing wall tiles and connected door furniture without generated building geometry.",
+	"seed": 20260808,
+	"base_tile": {
+		"id": "grass_plain_01"
+	},
+	"rooms": [
+		{
+			"id": "office",
+			"kind": "enclosed"
+		},
+		{
+			"id": "garage_bay",
+			"kind": "covered_open"
+		},
+		{
+			"id": "ruined_store",
+			"kind": "ruin"
+		}
+	],
+	"room_connections": [
+		{
+			"id": "office_front_door",
+			"at": [11, 10],
+			"z": 0,
+			"from": {
+				"kind": "room",
+				"id": "office"
+			},
+			"to": {
+				"kind": "exterior"
+			}
+		},
+		{
+			"id": "office_to_garage",
+			"at": [12, 10],
+			"z": 0,
+			"from": {
+				"kind": "room",
+				"id": "office"
+			},
+			"to": {
+				"kind": "room",
+				"id": "garage_bay"
+			}
+		}
+	],
+	"room_boundaries": [
+		{
+			"id": "office_north_wall",
+			"room": "office",
+			"at": [8, 7],
+			"z": 0,
+			"element": "wall_tile"
+		},
+		{
+			"id": "office_west_wall",
+			"room": "office",
+			"at": [7, 8],
+			"z": 0,
+			"element": "wall_tile"
+		},
+		{
+			"id": "garage_east_wall",
+			"room": "garage_bay",
+			"at": [16, 8],
+			"z": 0,
+			"element": "wall_tile"
+		},
+		{
+			"id": "ruin_north_wall",
+			"room": "ruined_store",
+			"at": [8, 16],
+			"z": 0,
+			"element": "wall_tile"
+		},
+		{
+			"id": "office_front_opening",
+			"room": "office",
+			"at": [11, 10],
+			"z": 0,
+			"element": "door_furniture"
+		},
+		{
+			"id": "office_garage_opening",
+			"room": "office",
+			"at": [12, 10],
+			"z": 0,
+			"element": "door_furniture"
+		},
+		{
+			"id": "garage_office_opening",
+			"room": "garage_bay",
+			"at": [12, 10],
+			"z": 0,
+			"element": "door_furniture"
+		}
+	],
+	"operations": [
+		{
+			"type": "rectangle",
+			"x": 8,
+			"y": 8,
+			"width": 8,
+			"height": 4,
+			"tile": {
+				"id": "concrete_00"
+			}
+		},
+		{
+			"type": "rectangle",
+			"x": 8,
+			"y": 17,
+			"width": 8,
+			"height": 4,
+			"tile": {
+				"id": "concrete__cracked_01"
+			}
+		},
+		{
+			"type": "room_rectangle",
+			"room": "office",
+			"x": 8,
+			"y": 8,
+			"width": 4,
+			"height": 4
+		},
+		{
+			"type": "room_rectangle",
+			"room": "garage_bay",
+			"x": 12,
+			"y": 8,
+			"width": 4,
+			"height": 4
+		},
+		{
+			"type": "room_rectangle",
+			"room": "ruined_store",
+			"x": 8,
+			"y": 17,
+			"width": 8,
+			"height": 4
+		},
+		{
+			"type": "set",
+			"x": 8,
+			"y": 7,
+			"tile": {
+				"id": "brick_wall_00"
+			}
+		},
+		{
+			"type": "set",
+			"x": 7,
+			"y": 8,
+			"tile": {
+				"id": "brick_wall_00"
+			}
+		},
+		{
+			"type": "set",
+			"x": 16,
+			"y": 8,
+			"tile": {
+				"id": "brick_wall_00"
+			}
+		},
+		{
+			"type": "set",
+			"x": 8,
+			"y": 16,
+			"tile": {
+				"id": "brick_wall_00"
+			}
+		},
+		{
+			"type": "furniture",
+			"id": "door_wood",
+			"x": 11,
+			"y": 10,
+			"rotation": 0
+		},
+		{
+			"type": "furniture",
+			"id": "door_wood",
+			"x": 12,
+			"y": 10,
+			"rotation": 90
+		}
+	]
+}

--- a/Tools/map_generator.py
+++ b/Tools/map_generator.py
@@ -67,6 +67,8 @@ ROOM_RECTANGLE_FIELDS = {"type", "room", "x", "y", "z", "width", "height"}
 ROOM_CONNECTION_FIELDS = {"id", "at", "z", "from", "to"}
 ROOM_CONNECTION_ENDPOINT_FIELDS = {"kind", "id"}
 ROOM_CONNECTION_ENDPOINT_KINDS = {"room", "exterior"}
+ROOM_BOUNDARY_FIELDS = {"id", "room", "at", "z", "element"}
+ROOM_BOUNDARY_ELEMENTS = {"wall_tile", "door_furniture"}
 TILE_OPERATION_TYPES = {"set", "rectangle", "rectangle_outline", "line", "scatter"}
 LEVEL_FIELDS = {"z", "base_tile", "regions", "operations"}
 RECIPE_FIELDS = {
@@ -80,6 +82,7 @@ RECIPE_FIELDS = {
     "areas",
     "rooms",
     "room_connections",
+    "room_boundaries",
     "patterns",
     "regions",
     "operations",
@@ -175,6 +178,23 @@ def _tile_ids(tiles_path: Path) -> set[str]:
         tile["id"]
         for tile in tile_data
         if isinstance(tile, dict) and isinstance(tile.get("id"), str)
+    }
+
+
+def _wall_tile_ids(tiles_path: Path) -> set[str]:
+    with tiles_path.open(encoding="utf-8") as handle:
+        tile_data = json.load(handle)
+    if not isinstance(tile_data, list):
+        raise RecipeError("tile database must be a JSON array")
+    return {
+        entry["id"]
+        for entry in tile_data
+        if (
+            isinstance(entry, dict)
+            and isinstance(entry.get("id"), str)
+            and isinstance(entry.get("categories"), list)
+            and "Wall" in entry["categories"]
+        )
     }
 
 
@@ -1111,6 +1131,123 @@ def _validate_room_connection_targets(
             raise RecipeError(f"{context} must reference door-capable furniture at z {z} [{x}, {y}]")
 
 
+def _validate_recipe_room_boundaries(
+    boundaries: Any, known_room_ids: set[str]
+) -> list[dict[str, Any]]:
+    if not isinstance(boundaries, list):
+        raise RecipeError("room_boundaries must be an array")
+    validated: list[dict[str, Any]] = []
+    seen_ids: set[str] = set()
+    for index, boundary in enumerate(boundaries):
+        context = f"room_boundaries[{index}]"
+        if not isinstance(boundary, dict):
+            raise RecipeError(f"{context} must be an object")
+        unknown_fields = sorted(set(boundary) - ROOM_BOUNDARY_FIELDS)
+        if unknown_fields:
+            raise RecipeError(f"unknown {context} field '{unknown_fields[0]}'")
+        if set(boundary) != ROOM_BOUNDARY_FIELDS:
+            raise RecipeError(f"{context} must define id, room, at, z, and element")
+        boundary_id = boundary["id"]
+        if not isinstance(boundary_id, str) or not boundary_id.strip():
+            raise RecipeError(f"{context}.id must be a non-empty string")
+        _validate_unicode(boundary_id, f"{context}.id")
+        if DEFINITION_NAME_PATTERN.fullmatch(boundary_id) is None:
+            raise RecipeError(f"{context}.id may contain only letters, numbers, underscores, and hyphens")
+        if boundary_id in seen_ids:
+            raise RecipeError(f"duplicate room boundary ID '{boundary_id}'")
+        seen_ids.add(boundary_id)
+        room_id = boundary["room"]
+        if not isinstance(room_id, str) or not room_id.strip():
+            raise RecipeError(f"{context}.room must be a non-empty string")
+        if room_id not in known_room_ids:
+            raise RecipeError(f"{context}.room references unknown room '{room_id}'")
+        at = boundary["at"]
+        if (
+            not isinstance(at, list)
+            or len(at) != 2
+            or any(type(value) is not int for value in at)
+            or not 0 <= at[0] < MAP_WIDTH
+            or not 0 <= at[1] < MAP_HEIGHT
+        ):
+            raise RecipeError(f"{context}.at must be within map bounds as a two-integer array")
+        z = boundary["z"]
+        if type(z) is not int or not MIN_LOGICAL_Z <= z <= MAX_LOGICAL_Z:
+            raise RecipeError(f"{context}.z must be an integer from -10 through 10")
+        element = boundary["element"]
+        if element not in ROOM_BOUNDARY_ELEMENTS:
+            raise RecipeError(f"{context}.element has unsupported element '{element}'")
+        validated.append({
+            "id": boundary_id,
+            "room": room_id,
+            "at": at,
+            "z": z,
+            "element": element,
+        })
+    return validated
+
+
+def _room_connection_names_room(connection: dict[str, Any], room_id: str) -> bool:
+    return any(
+        endpoint.get("kind") == "room" and endpoint.get("id") == room_id
+        for endpoint in (connection["from"], connection["to"])
+    )
+
+
+def _wall_tile_bounds_room(x: int, y: int, room_id: str, level: list[dict[str, Any]]) -> bool:
+    for delta_x, delta_y in ((0, -1), (1, 0), (0, 1), (-1, 0)):
+        neighbor_x = x + delta_x
+        neighbor_y = y + delta_y
+        if not 0 <= neighbor_x < MAP_WIDTH or not 0 <= neighbor_y < MAP_HEIGHT:
+            continue
+        neighbor = level[neighbor_y * MAP_WIDTH + neighbor_x]
+        if isinstance(neighbor, dict) and neighbor.get("rooms") == [room_id]:
+            return True
+    return False
+
+
+def _validate_room_boundary_targets(
+    boundaries: list[dict[str, Any]],
+    levels: list[list[dict[str, Any]]],
+    wall_tile_ids: set[str],
+    door_furniture_ids: set[str],
+    room_connections: list[dict[str, Any]],
+) -> None:
+    seen_room_targets: set[tuple[str, int, int, int]] = set()
+    for index, boundary in enumerate(boundaries):
+        context = f"room_boundaries[{index}]"
+        room_id = boundary["room"]
+        x, y = boundary["at"]
+        z = boundary["z"]
+        target = (room_id, z, x, y)
+        if target in seen_room_targets:
+            raise RecipeError(f"{context} duplicates boundary target for room '{room_id}' at z {z} [{x}, {y}]")
+        seen_room_targets.add(target)
+        level = levels[_level_index(z)]
+        tile = level[y * MAP_WIDTH + x] if level else {}
+        if not isinstance(tile, dict) or not isinstance(tile.get("id"), str) or not tile["id"]:
+            raise RecipeError(f"{context} requires existing terrain at z {z} [{x}, {y}]")
+        if boundary["element"] == "wall_tile":
+            if tile["id"] not in wall_tile_ids:
+                raise RecipeError(f"{context} must reference a Wall-category tile at z {z} [{x}, {y}]")
+            if not _wall_tile_bounds_room(x, y, room_id, level):
+                raise RecipeError(f"{context} wall tile must be cardinally adjacent to room '{room_id}'")
+            continue
+        feature = tile.get("feature")
+        if (
+            not isinstance(feature, dict)
+            or feature.get("type") != "furniture"
+            or feature.get("id") not in door_furniture_ids
+        ):
+            raise RecipeError(f"{context} must reference door-capable furniture at z {z} [{x}, {y}]")
+        if not any(
+            connection["at"] == [x, y]
+            and connection["z"] == z
+            and _room_connection_names_room(connection, room_id)
+            for connection in room_connections
+        ):
+            raise RecipeError(f"{context} must match a room connection for room '{room_id}'")
+
+
 def _apply_area_rectangle(
     level: list[dict[str, Any]],
     operation: dict[str, Any],
@@ -1389,16 +1526,18 @@ def generate_map(
         _contains_furniture_operations(recipe)
         or _contains_area_entities(recipe)
         or "room_connections" in recipe
+        or "room_boundaries" in recipe
     )
     if requires_furniture_catalog:
         if furnitures_path is None:
             furnitures_path = content_root / "Furniture" / "Furniture.json"
         known_furnitures = _furniture_ids(Path(furnitures_path))
     door_furniture_ids: set[str] = set()
-    if "room_connections" in recipe:
+    if "room_connections" in recipe or "room_boundaries" in recipe:
         if furnitures_path is None:
-            raise RecipeError("room_connections requires a furniture database")
+            raise RecipeError("room connections or boundaries require a furniture database")
         door_furniture_ids = _door_furniture_ids(Path(furnitures_path))
+    wall_tile_ids = _wall_tile_ids(Path(tiles_path)) if "room_boundaries" in recipe else set()
     known_area_entity_ids: dict[str, set[str]] = {
         "furniture": known_furnitures,
         "mob": set(),
@@ -1431,6 +1570,9 @@ def generate_map(
     room_connections = _validate_recipe_room_connections(
         recipe.get("room_connections", []), known_room_ids
     )
+    room_boundaries = _validate_recipe_room_boundaries(
+        recipe.get("room_boundaries", []), known_room_ids
+    )
     rng = random.Random(seed)
     levels = _generate_levels(
         recipe,
@@ -1444,6 +1586,13 @@ def generate_map(
         known_room_ids,
     )
     _validate_room_connection_targets(room_connections, levels, door_furniture_ids)
+    _validate_room_boundary_targets(
+        room_boundaries,
+        levels,
+        wall_tile_ids,
+        door_furniture_ids,
+        room_connections,
+    )
 
     generated = {
         "id": recipe["id"],
@@ -1462,6 +1611,8 @@ def generate_map(
         generated["rooms"] = rooms
     if room_connections:
         generated["room_connections"] = room_connections
+    if room_boundaries:
+        generated["room_boundaries"] = room_boundaries
     return generated
 
 

--- a/Tools/map_validator.py
+++ b/Tools/map_validator.py
@@ -11,6 +11,8 @@ POPULATED_LEVEL_TILE_COUNT = MAP_WIDTH * MAP_HEIGHT
 ROOM_KINDS = {'enclosed', 'covered_open', 'ruin'}
 ROOM_CONNECTION_FIELDS = {'id', 'at', 'z', 'from', 'to'}
 ROOM_CONNECTION_ENDPOINT_KINDS = {'room', 'exterior'}
+ROOM_BOUNDARY_FIELDS = {'id', 'room', 'at', 'z', 'element'}
+ROOM_BOUNDARY_ELEMENTS = {'wall_tile', 'door_furniture'}
 
 class MapValidationError(Exception):
     """Custom exception for map validation errors."""
@@ -49,6 +51,29 @@ class MapValidator:
                 and isinstance(entry.get('Function'), dict)
                 and isinstance(entry['Function'].get('door'), str)
                 and entry['Function']['door'] != 'None'
+            )
+        }
+
+    def _wall_tile_ids(self):
+        tile_path = os.path.join(
+            os.path.dirname(os.path.dirname(__file__)),
+            'Mods', 'Dimensionfall', 'Tiles', 'Tiles.json'
+        )
+        try:
+            with open(tile_path, 'r', encoding='utf-8') as handle:
+                tile_data = json.load(handle)
+        except (OSError, json.JSONDecodeError):
+            return set()
+        if not isinstance(tile_data, list):
+            return set()
+        return {
+            entry['id']
+            for entry in tile_data
+            if (
+                isinstance(entry, dict)
+                and isinstance(entry.get('id'), str)
+                and isinstance(entry.get('categories'), list)
+                and 'Wall' in entry['categories']
             )
         }
 
@@ -95,6 +120,10 @@ class MapValidator:
         if not isinstance(room_connections, list):
             self.add_error(file_path, "top-level room_connections must be an array.")
             room_connections = []
+        room_boundaries = data.get('room_boundaries', [])
+        if not isinstance(room_boundaries, list):
+            self.add_error(file_path, "top-level room_boundaries must be an array.")
+            room_boundaries = []
 
         # 2. Check Optional Metadata Types
         metadata_checks = {
@@ -263,6 +292,55 @@ class MapValidator:
             ):
                 validated_room_connections.append(connection)
 
+        validated_room_boundaries = []
+        seen_boundary_ids: Set[str] = set()
+        for idx, boundary in enumerate(room_boundaries):
+            context = f"Room boundary at index {idx}"
+            if not isinstance(boundary, dict):
+                self.add_error(file_path, f"{context} is not an object.")
+                continue
+            unknown_fields = sorted(set(boundary) - ROOM_BOUNDARY_FIELDS)
+            if unknown_fields:
+                self.add_error(file_path, f"{context} has unknown field '{unknown_fields[0]}'.")
+            for field in ROOM_BOUNDARY_FIELDS:
+                if field not in boundary:
+                    self.add_error(file_path, f"{context} is missing required field '{field}'.")
+            boundary_id = boundary.get('id')
+            if not isinstance(boundary_id, str) or not boundary_id:
+                self.add_error(file_path, f"{context} has invalid or missing ID.")
+            elif boundary_id in seen_boundary_ids:
+                self.add_error(file_path, f"Duplicate room boundary ID detected: '{boundary_id}'")
+            else:
+                seen_boundary_ids.add(boundary_id)
+            room_id = boundary.get('room')
+            if not isinstance(room_id, str) or not room_id:
+                self.add_error(file_path, f"{context} has invalid or missing room ID.")
+            elif room_id not in room_ids:
+                self.add_error(file_path, f"{context} references non-existent room '{room_id}'.")
+            at = boundary.get('at')
+            valid_at = (
+                isinstance(at, list)
+                and len(at) == 2
+                and all(type(value) is int for value in at)
+                and 0 <= at[0] < MAP_WIDTH
+                and 0 <= at[1] < MAP_HEIGHT
+            )
+            if not valid_at:
+                self.add_error(file_path, f"{context} at must be a two-integer coordinate within map bounds.")
+            z = boundary.get('z')
+            valid_z = type(z) is int and -10 <= z <= 10
+            if not valid_z:
+                self.add_error(file_path, f"{context} z must be an integer from -10 through 10.")
+            element = boundary.get('element')
+            if element not in ROOM_BOUNDARY_ELEMENTS:
+                self.add_error(file_path, f"{context} has unsupported element '{element}'.")
+            if (
+                isinstance(boundary_id, str) and boundary_id
+                and isinstance(room_id, str) and room_id in room_ids
+                and valid_at and valid_z and element in ROOM_BOUNDARY_ELEMENTS
+            ):
+                validated_room_boundaries.append(boundary)
+
         # 5. Validate Levels (Tiles)
         if not isinstance(levels, list):
              self.add_error(file_path, "'levels' must be an array.")
@@ -419,7 +497,7 @@ class MapValidator:
                                         f"Level {level_idx}, Tile '{tile['id']}' has non-numeric area rotation: {rotation}"
                                     )
 
-        door_furniture_ids = self._door_furniture_ids() if validated_room_connections else set()
+        door_furniture_ids = self._door_furniture_ids() if (validated_room_connections or validated_room_boundaries) else set()
         seen_door_targets: Set[tuple] = set()
         for connection in validated_room_connections:
             x, y = connection['at']
@@ -442,6 +520,60 @@ class MapValidator:
                 or feature.get('id') not in door_furniture_ids
             ):
                 self.add_error(file_path, f"Room connection '{connection['id']}' must reference door-capable furniture at z {z} [{x}, {y}].")
+
+        wall_tile_ids = self._wall_tile_ids() if validated_room_boundaries else set()
+        seen_boundary_targets: Set[tuple] = set()
+        for boundary in validated_room_boundaries:
+            room_id = boundary['room']
+            x, y = boundary['at']
+            z = boundary['z']
+            target = (room_id, z, x, y)
+            if target in seen_boundary_targets:
+                self.add_error(file_path, f"Room boundary '{boundary['id']}' duplicates boundary target for room '{room_id}' at z {z} [{x}, {y}].")
+                continue
+            seen_boundary_targets.add(target)
+            level_index = z + 10
+            level = levels[level_index] if isinstance(levels, list) and level_index < len(levels) else []
+            tile = level[y * MAP_WIDTH + x] if isinstance(level, list) and len(level) == POPULATED_LEVEL_TILE_COUNT else {}
+            if not isinstance(tile, dict) or not isinstance(tile.get('id'), str) or not tile['id']:
+                self.add_error(file_path, f"Room boundary '{boundary['id']}' requires existing terrain at z {z} [{x}, {y}].")
+                continue
+            if boundary['element'] == 'wall_tile':
+                if tile['id'] not in wall_tile_ids:
+                    self.add_error(file_path, f"Room boundary '{boundary['id']}' must reference a Wall-category tile at z {z} [{x}, {y}].")
+                    continue
+                adjacent_to_room = False
+                for delta_x, delta_y in ((0, -1), (1, 0), (0, 1), (-1, 0)):
+                    neighbor_x = x + delta_x
+                    neighbor_y = y + delta_y
+                    if not 0 <= neighbor_x < MAP_WIDTH or not 0 <= neighbor_y < MAP_HEIGHT:
+                        continue
+                    neighbor = level[neighbor_y * MAP_WIDTH + neighbor_x]
+                    if isinstance(neighbor, dict) and neighbor.get('rooms') == [room_id]:
+                        adjacent_to_room = True
+                        break
+                if not adjacent_to_room:
+                    self.add_error(file_path, f"Room boundary '{boundary['id']}' wall tile must be cardinally adjacent to room '{room_id}'.")
+                continue
+            feature = tile.get('feature')
+            if (
+                not isinstance(feature, dict)
+                or feature.get('type') != 'furniture'
+                or feature.get('id') not in door_furniture_ids
+            ):
+                self.add_error(file_path, f"Room boundary '{boundary['id']}' must reference door-capable furniture at z {z} [{x}, {y}].")
+                continue
+            matches_connection = any(
+                connection['at'] == [x, y]
+                and connection['z'] == z
+                and any(
+                    endpoint.get('kind') == 'room' and endpoint.get('id') == room_id
+                    for endpoint in (connection['from'], connection['to'])
+                )
+                for connection in validated_room_connections
+            )
+            if not matches_connection:
+                self.add_error(file_path, f"Room boundary '{boundary['id']}' must match a room connection for room '{room_id}'.")
 
     def run(self, path: str):
         if os.path.isdir(path):

--- a/Tools/tests/test_map_generator.py
+++ b/Tools/tests/test_map_generator.py
@@ -1524,6 +1524,92 @@ class MapGeneratorTests(unittest.TestCase):
             "itemgroups": [],
         })
 
+    def test_room_boundaries_preserve_existing_wall_tiles_and_connected_doors(self):
+        recipe = valid_recipe()
+        recipe["base_tile"] = {"id": "concrete_00"}
+        recipe["rooms"] = [{"id": "office", "kind": "enclosed"}]
+        recipe["operations"] = [
+            {"type": "room_rectangle", "room": "office", "x": 8, "y": 8, "width": 4, "height": 4},
+            {"type": "set", "x": 8, "y": 7, "tile": {"id": "brick_wall_00"}},
+            {"type": "furniture", "id": "door_wood", "x": 11, "y": 10, "rotation": 0},
+        ]
+        recipe["room_connections"] = [{
+            "id": "office_front_door",
+            "at": [11, 10],
+            "z": 0,
+            "from": {"kind": "room", "id": "office"},
+            "to": {"kind": "exterior"},
+        }]
+        recipe["room_boundaries"] = [
+            {
+                "id": "office_north_wall",
+                "room": "office",
+                "at": [8, 7],
+                "z": 0,
+                "element": "wall_tile",
+            },
+            {
+                "id": "office_front_opening",
+                "room": "office",
+                "at": [11, 10],
+                "z": 0,
+                "element": "door_furniture",
+            },
+        ]
+
+        generated = generate_map(recipe, TILES_PATH)
+
+        self.assertEqual(generated["room_boundaries"], recipe["room_boundaries"])
+        level = generated["levels"][10]
+        self.assertEqual(level[7 * 32 + 8]["id"], "brick_wall_00")
+        self.assertEqual(level[10 * 32 + 11]["feature"]["id"], "door_wood")
+
+    def test_room_boundaries_reject_invalid_schema_and_physical_targets(self):
+        valid_boundary = {
+            "id": "office_north_wall",
+            "room": "office",
+            "at": [8, 7],
+            "z": 0,
+            "element": "wall_tile",
+        }
+        valid_connection = {
+            "id": "office_front_door",
+            "at": [11, 10],
+            "z": 0,
+            "from": {"kind": "room", "id": "office"},
+            "to": {"kind": "exterior"},
+        }
+        cases = [
+            ("not-an-array", "room_boundaries must be an array"),
+            ([{**valid_boundary, "extra": True}], "unknown room_boundaries\\[0\\] field 'extra'"),
+            ([{**valid_boundary, "room": "missing"}], "references unknown room 'missing'"),
+            ([{**valid_boundary, "at": [32, 7]}], "must be within map bounds"),
+            ([{**valid_boundary, "z": -11}], "must be an integer from -10 through 10"),
+            ([{**valid_boundary, "element": "wall_furniture"}], "unsupported element 'wall_furniture'"),
+            ([{**valid_boundary, "at": [0, 0]}], "Wall-category tile"),
+            ([{**valid_boundary, "at": [8, 6]}], "must be cardinally adjacent"),
+            ([{**valid_boundary, "element": "door_furniture", "at": [11, 10]}], "must match a room connection"),
+            ([valid_boundary, {**valid_boundary, "id": "duplicate_target"}], r"duplicates boundary target for room 'office' at z 0 \[8, 7\]"),
+        ]
+        for boundaries, expected_message in cases:
+            with self.subTest(boundaries=boundaries):
+                recipe = valid_recipe()
+                recipe["base_tile"] = {"id": "concrete_00"}
+                recipe["rooms"] = [{"id": "office", "kind": "enclosed"}]
+                recipe["operations"] = [
+                    {"type": "room_rectangle", "room": "office", "x": 8, "y": 8, "width": 4, "height": 4},
+                    {"type": "set", "x": 8, "y": 7, "tile": {"id": "brick_wall_00"}},
+                    {"type": "set", "x": 8, "y": 6, "tile": {"id": "brick_wall_00"}},
+                    {"type": "furniture", "id": "door_wood", "x": 11, "y": 10, "rotation": 0},
+                ]
+                recipe["room_boundaries"] = boundaries
+                if boundaries == [{**valid_boundary, "element": "door_furniture", "at": [11, 10]}]:
+                    recipe["room_connections"] = []
+                else:
+                    recipe["room_connections"] = [valid_connection]
+                with self.assertRaisesRegex(RecipeError, expected_message):
+                    generate_map(recipe, TILES_PATH)
+
     def test_room_connections_reject_invalid_schema_and_targets(self):
         base_connection = {
             "id": "office_front_door",
@@ -2042,6 +2128,81 @@ class MapValidatorDimensionTests(unittest.TestCase):
             with self.subTest(expected_message=expected_message):
                 errors = self.validate(map_data)
                 self.assertTrue(any(expected_message in error for error in errors))
+    def test_validates_room_boundary_structure_and_existing_sources(self):
+        recipe = valid_recipe()
+        recipe["base_tile"] = {"id": "concrete_00"}
+        recipe["rooms"] = [{"id": "office", "kind": "enclosed"}]
+        recipe["operations"] = [
+            {"type": "room_rectangle", "room": "office", "x": 8, "y": 8, "width": 4, "height": 4},
+            {"type": "set", "x": 8, "y": 7, "tile": {"id": "brick_wall_00"}},
+            {"type": "set", "x": 8, "y": 6, "tile": {"id": "brick_wall_00"}},
+            {"type": "furniture", "id": "door_wood", "x": 11, "y": 10, "rotation": 0},
+        ]
+        recipe["room_connections"] = [{
+            "id": "office_front_door",
+            "at": [11, 10],
+            "z": 0,
+            "from": {"kind": "room", "id": "office"},
+            "to": {"kind": "exterior"},
+        }]
+        recipe["room_boundaries"] = [
+            {"id": "office_north_wall", "room": "office", "at": [8, 7], "z": 0, "element": "wall_tile"},
+            {"id": "office_front_opening", "room": "office", "at": [11, 10], "z": 0, "element": "door_furniture"},
+        ]
+        valid_map = generate_map(recipe, TILES_PATH)
+        self.assertEqual(self.validate(valid_map), [])
+
+        invalid_maps = []
+        malformed_root = json.loads(json.dumps(valid_map))
+        malformed_root["room_boundaries"] = "not-an-array"
+        invalid_maps.append((malformed_root, "top-level room_boundaries must be an array"))
+
+        missing_room = json.loads(json.dumps(valid_map))
+        missing_room["room_boundaries"][0]["room"] = "missing"
+        invalid_maps.append((missing_room, "references non-existent room 'missing'"))
+
+        non_wall = json.loads(json.dumps(valid_map))
+        non_wall["room_boundaries"][0]["at"] = [0, 0]
+        invalid_maps.append((non_wall, "must reference a Wall-category tile"))
+
+        non_adjacent_wall = json.loads(json.dumps(valid_map))
+        non_adjacent_wall["room_boundaries"][0]["at"] = [8, 6]
+        invalid_maps.append((non_adjacent_wall, "must be cardinally adjacent"))
+
+        unmatched_door = json.loads(json.dumps(valid_map))
+        unmatched_door["room_connections"] = []
+        invalid_maps.append((unmatched_door, "must match a room connection"))
+
+        duplicate_target = json.loads(json.dumps(valid_map))
+        duplicate_target["room_boundaries"].append({
+            **duplicate_target["room_boundaries"][0], "id": "duplicate_target"
+        })
+        invalid_maps.append((duplicate_target, "duplicates boundary target"))
+
+        for map_data, expected_message in invalid_maps:
+            with self.subTest(expected_message=expected_message):
+                errors = self.validate(map_data)
+                self.assertTrue(any(expected_message in error for error in errors))
+    def test_room_boundaries_example_preserves_existing_physical_sources(self):
+        recipe_path = ROOT / "Tools" / "examples" / "map_recipe_room_boundaries.json"
+        generated = generate_map(
+            json.loads(recipe_path.read_text(encoding="utf-8")), TILES_PATH
+        )
+
+        self.assertEqual([boundary["id"] for boundary in generated["room_boundaries"]], [
+            "office_north_wall",
+            "office_west_wall",
+            "garage_east_wall",
+            "ruin_north_wall",
+            "office_front_opening",
+            "office_garage_opening",
+            "garage_office_opening",
+        ])
+        level = generated["levels"][10]
+        for x, y in ((8, 7), (7, 8), (16, 8), (8, 16)):
+            self.assertEqual(level[y * 32 + x]["id"], "brick_wall_00")
+        self.assertEqual(level[10 * 32 + 11]["feature"]["id"], "door_wood")
+        self.assertEqual(level[10 * 32 + 12]["feature"]["id"], "door_wood")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

Adds a narrow `room_boundaries` contract that explicitly attaches existing physical content to authored semantic rooms.

- supports existing `Wall`-category terrain tiles through `wall_tile`;
- supports existing door-capable furniture through `door_furniture`;
- requires door boundary records to match same-location `room_connections` endpoints;
- validates schema, IDs, rooms, coordinates, logical z, physical source type, wall adjacency, and duplicate room targets;
- preserves records through `DMap` content-editor save/load;
- removes records naming deleted rooms during serialization;
- adds a maintained `generated_room_boundaries` recipe;
- updates the roadmap and map-generation documentation.

## Scope

This is authored metadata only.

It does not generate or infer walls, doors, roofs, room perimeters, enclosure, indoor/outdoor state, navigation, collision, lighting, weather, or building geometry. It intentionally permits partial evidence for `covered_open` and `ruin` rooms.

## Validation

- `python3 -m unittest discover -s Tools/tests` — 85 passed
- all 9 maintained recipes generated and validated
- `python3 Tools/map_validator.py Mods/Dimensionfall/Maps` — 51 maps, no errors
- full GUT suite — 84 passed, 384 assertions
- `godot --headless --path . --editor --quit`
- `git diff --check`