### PR TITLE
Add validated authored building footprints

### DIFF
--- a/Documentation/Game_design/Map_generation_plan.md
+++ b/Documentation/Game_design/Map_generation_plan.md
@@ -623,9 +623,9 @@ Authored room semantics use a separate map-level `rooms` array plus exclusive ti
 
 An `enclosed` room may add `boundary_validation: "complete"`. Only this opt-in mode requires directional evidence and validates every exposed cardinal edge of every room-membership tile: exactly one wall or connected-door boundary must map to each edge. Missing, incorrectly oriented, duplicate, and non-exposed declarations are rejected. `covered_open` and `ruin` cannot opt in, so their intentional openings and damage remain valid without blanket enclosure requirements.
 
-The generator, standalone map validator, and `DMap` save/load path validate or preserve definitions and references. No topology inference, wall/roof generation, indoor weather/lighting, or geometry generation is introduced yet.
+The generator, standalone map validator, and `DMap` save/load path validate or preserve definitions and references. A first `buildings` root field now groups existing room content under one explicit, data-only rectangular footprint at one logical z. Each record names a nonempty set of known rooms, requires every owned membership, boundary target, and named door-connection target to sit inside its bounds, disallows same-level overlap, and requires at least one owned `enclosed` room with complete boundary validation. `Tools/examples/map_recipe_single_level_building.json` provides a 4×4 `office_building` containing the already-proven office, its seven wall tiles, and exterior door. The footprint does not generate or modify geometry, furniture, roofs, collision, navigation, lighting, weather, or indoor state; it only gives authored validated evidence a first building-level grouping.
 
-This foundation intentionally does **not** yet define polygons, topology-derived room boundaries, indoor/outdoor runtime behavior, wall/roof generation, building footprints, anchors, or generalized templates.
+This foundation intentionally does **not** yet define polygons, topology-derived room boundaries, indoor/outdoor runtime behavior, wall/roof generation, roof/ceiling semantics, multi-level building records, furniture anchors, or generalized templates.
 
 Capabilities:
 
@@ -860,7 +860,7 @@ An agent can create a new playable, potentially multi-level map from a concise d
 
 # Recommended immediate next task
 
-**Phase 6 is in progress.** Its runtime-compatible area foundation, catalog-validated per-instance entity variation, authored room semantics, explicit door-link metadata, partial physical boundary references, and opt-in enclosed-room completeness validation are complete. The next contribution should use that validated authored input for one small single-level building footprint without introducing generalized templates.
+**Phase 6 is in progress.** Its runtime-compatible area foundation, catalog-validated per-instance entity variation, authored room semantics, explicit door-link metadata, partial physical boundary references, opt-in enclosed-room completeness validation, and first single-level authored footprint are complete. The next contribution should add one narrow authored roof/ceiling semantic contract for the validated footprint without introducing multi-level structures or generalized templates.
 
 Do not yet generate walls, doors, roofs, multi-level building footprints, furniture anchors, roads, towns, or generalized building templates. Preserve the established map-level `areas` plus per-tile area membership representation, keep room semantics independent from runtime areas, and validate any physical semantics in the editor and runtime.
 
@@ -901,7 +901,8 @@ Do not commit or push unless explicitly requested.
 [Complete] Explicit room-to-exterior and room-to-room door-link metadata
 [Complete] Authored existing-wall and connected-door boundary references
 [Complete] Opt-in directional completeness validation for `enclosed` rooms
-[Next]     Small single-level authored building footprint
+[Complete] Small single-level authored building footprint
+[Next]     Authored roof/ceiling semantics for validated footprints
 [Planned]  Rooms and buildings
 [Planned]  Roads and map connections
 [Planned]  Multi-level reusable templates and richer composition

--- a/Documentation/Modding/map_example_generation.md
+++ b/Documentation/Modding/map_example_generation.md
@@ -29,6 +29,7 @@ The maintained recipe examples are:
 | `Tools/examples/map_recipe_room_semantics.json` | `Mods/Dimensionfall/Maps/generated_room_semantics.json` | Authored `enclosed`, `covered_open`, and `ruin` room labels on terrain without generated walls, doors, roofs, or indoor runtime behavior. |
 | `Tools/examples/map_recipe_room_connections.json` | `Mods/Dimensionfall/Maps/generated_room_connections.json` | Existing `door_wood` features with explicit room-to-exterior and room-to-room semantic links, without inferred topology or new runtime door behavior. |
 | `Tools/examples/map_recipe_room_boundaries.json` | `Mods/Dimensionfall/Maps/generated_room_boundaries.json` | A complete opt-in `enclosed` office with directional existing `brick_wall_00`/`door_wood` evidence, plus deliberately partial `covered_open` and `ruin` room references. |
+| `Tools/examples/map_recipe_single_level_building.json` | `Mods/Dimensionfall/Maps/generated_single_level_building.json` | One data-only rectangular `office_building` footprint containing the complete authored office and its existing wall/door evidence at logical `z: 0`. |
 | `Tools/examples/map_recipe_two_level_hill.json` | `Mods/Dimensionfall/Maps/generated_two_level_hill.json` | Ground level `z: 0`, raised terrain at `z: 1`, and all four slope rotations. |
 | `Tools/examples/map_recipe_two_level_depression.json` | `Mods/Dimensionfall/Maps/generated_two_level_depression.json` | Ground level `z: 0`, lowered terrain at `z: -1`, and all four slope rotations. |
 
@@ -82,6 +83,11 @@ python3 Tools/map_generator.py \
   Tools/examples/map_recipe_room_boundaries.json \
   Mods/Dimensionfall/Maps/generated_room_boundaries.json
 
+# Ground-level single-level authored building footprint
+python3 Tools/map_generator.py \
+  Tools/examples/map_recipe_single_level_building.json \
+  Mods/Dimensionfall/Maps/generated_single_level_building.json
+
 # Two-level hill
 python3 Tools/map_generator.py \
   Tools/examples/map_recipe_two_level_hill.json \
@@ -112,6 +118,7 @@ rm Mods/Dimensionfall/Maps/generated_area_entity_clearing.json
 rm Mods/Dimensionfall/Maps/generated_room_semantics.json
 rm Mods/Dimensionfall/Maps/generated_room_connections.json
 rm Mods/Dimensionfall/Maps/generated_room_boundaries.json
+rm Mods/Dimensionfall/Maps/generated_single_level_building.json
 rm Mods/Dimensionfall/Maps/generated_two_level_hill.json
 rm Mods/Dimensionfall/Maps/generated_two_level_depression.json
 ```
@@ -188,6 +195,8 @@ For the maintained room-semantics map, inspect `generated_room_semantics` in the
 For the maintained room-connections map, open `generated_room_connections`, save it, close it, and re-open it. Confirm that `office_front_door` remains an `office`→`exterior` link and `office_to_garage` remains an `office`→`garage_bay` link. In map preview and **save and test**, verify both existing `door_wood` features load and retain normal open/close interaction. This metadata must not create walls, roofs, lighting, weather, automatic enclosure, or a different door runtime behavior.
 
 For the maintained room-boundaries map, open `generated_room_boundaries`, save it, close it, and re-open it. Confirm that `office` retains `boundary_validation: "complete"`, its eight directed boundary records retain their cardinal `side`, and the office’s seven existing `brick_wall_00` tiles plus one existing `door_wood` feature remain present. The partial garage and ruin records deliberately have no completeness requirement. **Save and test** should confirm normal loading and existing door interaction only: this validation adds no geometry, collision, navigation, lighting, weather, or indoor behavior.
+
+For the maintained single-level building map, open `generated_single_level_building`, save it, close it, and re-open it. Confirm the root `buildings` array retains `office_building` with its `office` room list, `[7, 7]` `4×4` footprint, and logical `z: 0`. Confirm the existing seven `brick_wall_00` tiles and one `door_wood` opening still load and retain normal interaction. The footprint is metadata only: **save and test** must not produce new terrain, walls, roofs, collision, navigation, lighting, weather, or indoor behavior.
 
 Dimensionfall also looks for a same-named `.png` map sprite during startup. The runner intentionally generates map JSON only, so Godot currently logs a non-fatal missing-resource error for that sprite. This does not prevent the JSON map from loading or the map editor's tile-grid preview from rendering it.
 

--- a/Documentation/Modding/map_recipe_generator.md
+++ b/Documentation/Modding/map_recipe_generator.md
@@ -362,6 +362,29 @@ An `enclosed` room may opt in to strict completeness by adding `"boundary_valida
 
 Boundary metadata preserves existing terrain, furniture, rotation, collision, and runtime door behavior. `DMap` preserves it through content-editor save/load and removes records naming deleted rooms. It does not create walls or openings, infer a door from rotation, change navigation, or add indoor/outdoor effects.
 
+### `buildings`
+
+`buildings` groups existing authored room evidence into one explicit, rectangular single-level building footprint. It does not generate terrain, walls, doors, roofs, furniture, tile-local memberships, or indoor runtime state:
+
+```json
+{
+  "buildings": [
+    {
+      "id": "office_building",
+      "rooms": ["office"],
+      "footprint": {"x": 7, "y": 7, "width": 4, "height": 4},
+      "z": 0
+    }
+  ]
+}
+```
+
+Each record has exactly `id`, `rooms`, `footprint`, and `z`. `id` is unique; `rooms` is a nonempty list of unique known room IDs; `footprint` has exactly non-negative integer `x`/`y` plus positive integer `width`/`height`, fully inside the 32×32 map; and `z` is a required logical level from `-10` through `10`. Footprints on the same logical z must not overlap, though they may touch.
+
+Every owned room must have membership only at the building level and wholly inside its footprint. At least one owned room must be an `enclosed` room with `"boundary_validation": "complete"`. Its same-level `room_boundaries` and any same-level `room_connections` naming it must also lie inside the footprint. This makes the record a strict ownership/containment contract for already-authored physical evidence, not a claim that every footprint cell is occupied, roofed, or indoors.
+
+`DMap` preserves building records through editor save/load and removes records whose room list becomes stale. The standalone validator performs strict shape, containment, same-level overlap, and complete-enclosed-room checks. No generalized templates, polygons, multi-level building records, roof/ceiling semantics, furniture anchors, or generation operations are introduced.
+
 ### `set`
 
 Places one tile. Fields: `type`, `x`, `y`, `tile`, and optional root-level `z`.

--- a/Scripts/Gamedata/DMap.gd
+++ b/Scripts/Gamedata/DMap.gd
@@ -96,6 +96,7 @@ var areas: Array = []
 var rooms: Array = []
 var room_connections: Array = []
 var room_boundaries: Array = []
+var buildings: Array = []
 var sprite: Texture = null
 # Variable to store connections. For example: {"south": "road","west": "ground"} default to ground
 var connections: Dictionary = {
@@ -151,6 +152,7 @@ func set_data(newdata: Dictionary) -> void:
 	rooms = newdata.get("rooms", [])
 	room_connections = newdata.get("room_connections", [])
 	room_boundaries = newdata.get("room_boundaries", [])
+	buildings = newdata.get("buildings", [])
 	connections = newdata.get("connections", {})  # Set connections from data if present
 
 
@@ -174,6 +176,8 @@ func get_data() -> Dictionary:
 		mydata["room_connections"] = room_connections
 	if not room_boundaries.is_empty():
 		mydata["room_boundaries"] = room_boundaries
+	if not buildings.is_empty():
+		mydata["buildings"] = buildings
 	if not connections.is_empty():  # Omit connections if empty
 		mydata["connections"] = connections
 	
@@ -182,6 +186,7 @@ func get_data() -> Dictionary:
 	_sanitize_room_references(mydata)
 	_sanitize_room_connections(mydata)
 	_sanitize_room_boundaries(mydata)
+	_sanitize_buildings(mydata)
 
 	# NEW: Implement sanitization for corrupt tiles (missing or empty ID when metadata exists)
 	_sanitize_tile_objects(mydata)
@@ -300,6 +305,38 @@ func _sanitize_room_boundaries(data: Dictionary) -> void:
 	)
 	if data["room_boundaries"].is_empty():
 		data.erase("room_boundaries")
+
+
+func _sanitize_buildings(data: Dictionary) -> void:
+	if not data.has("buildings") or not data["buildings"] is Array:
+		return
+
+	var valid_room_ids: Array[String] = []
+	if data.has("rooms") and data["rooms"] is Array:
+		for room in data["rooms"]:
+			if room is Dictionary and room.has("id") and room["id"] is String:
+				valid_room_ids.append(room["id"])
+
+	data["buildings"] = data["buildings"].filter(func(building):
+		if not building is Dictionary \
+			or not building.has("id") \
+			or not building["id"] is String \
+			or building["id"].is_empty() \
+			or not building.has("rooms") \
+			or not building["rooms"] is Array \
+			or building["rooms"].is_empty() \
+			or not building.has("footprint") \
+			or not building["footprint"] is Dictionary \
+			or not building.has("z") \
+			or not building["z"] is int:
+			return false
+		for room_id in building["rooms"]:
+			if not room_id is String or room_id not in valid_room_ids:
+				return false
+		return true
+	)
+	if data["buildings"].is_empty():
+		data.erase("buildings")
 
 
 func load_data_from_disk():

--- a/Tests/Unit/test_dmap_sanitization.gd
+++ b/Tests/Unit/test_dmap_sanitization.gd
@@ -183,3 +183,44 @@ func test_dmap_room_boundaries_roundtrip_and_sanitization():
 		"side": "south",
 	}])
 	assert_eq(data["rooms"], [{"id": "office", "kind": "enclosed", "boundary_validation": "complete"}])
+
+
+func test_dmap_buildings_roundtrip_and_sanitization():
+	var DMap = load("res://Scripts/Gamedata/DMap.gd")
+	var map = DMap.new("test_buildings", "/tmp/", null)
+	map.set_data({
+		"name": "Buildings",
+		"description": "Preserve authored building footprints.",
+		"rooms": [
+			{"id": "office", "kind": "enclosed", "boundary_validation": "complete"},
+		],
+		"buildings": [
+			{
+				"id": "office_building",
+				"rooms": ["office"],
+				"footprint": {"x": 7, "y": 7, "width": 4, "height": 4},
+				"z": 0,
+			},
+			{
+				"rooms": ["office"],
+			},
+			{
+				"id": "stale_building",
+				"rooms": ["missing_room"],
+				"footprint": {"x": 12, "y": 7, "width": 4, "height": 4},
+				"z": 0,
+			},
+		],
+		"levels": [[
+			{"id": "concrete_00"},
+		]],
+	})
+
+	var data = map.get_data()
+
+	assert_eq(data["buildings"], [{
+		"id": "office_building",
+		"rooms": ["office"],
+		"footprint": {"x": 7, "y": 7, "width": 4, "height": 4},
+		"z": 0,
+	}])

--- a/Tools/examples/map_recipe_single_level_building.json
+++ b/Tools/examples/map_recipe_single_level_building.json
@@ -1,0 +1,49 @@
+{
+	"id": "generated_single_level_building",
+	"name": "Generated Single-Level Building",
+	"description": "A data-only authored building footprint enclosing an existing complete office room and its physical boundary evidence.",
+	"seed": 20260810,
+	"base_tile": {"id": "grass_plain_01"},
+	"rooms": [
+		{"id": "office", "kind": "enclosed", "boundary_validation": "complete"}
+	],
+	"buildings": [
+		{
+			"id": "office_building",
+			"rooms": ["office"],
+			"footprint": {"x": 7, "y": 7, "width": 4, "height": 4},
+			"z": 0
+		}
+	],
+	"room_connections": [
+		{
+			"id": "office_front_door",
+			"at": [8, 9],
+			"z": 0,
+			"from": {"kind": "room", "id": "office"},
+			"to": {"kind": "exterior"}
+		}
+	],
+	"room_boundaries": [
+		{"id": "office_northwest_north", "room": "office", "at": [8, 7], "z": 0, "element": "wall_tile", "side": "south"},
+		{"id": "office_northeast_north", "room": "office", "at": [9, 7], "z": 0, "element": "wall_tile", "side": "south"},
+		{"id": "office_southwest_south", "room": "office", "at": [8, 10], "z": 0, "element": "wall_tile", "side": "north"},
+		{"id": "office_southeast_south", "room": "office", "at": [9, 10], "z": 0, "element": "wall_tile", "side": "north"},
+		{"id": "office_northwest_west", "room": "office", "at": [7, 8], "z": 0, "element": "wall_tile", "side": "east"},
+		{"id": "office_northeast_east", "room": "office", "at": [10, 8], "z": 0, "element": "wall_tile", "side": "west"},
+		{"id": "office_southeast_east", "room": "office", "at": [10, 9], "z": 0, "element": "wall_tile", "side": "west"},
+		{"id": "office_southwest_door", "room": "office", "at": [8, 9], "z": 0, "element": "door_furniture", "side": "west"}
+	],
+	"operations": [
+		{"type": "rectangle", "x": 8, "y": 8, "width": 2, "height": 2, "tile": {"id": "concrete_00"}},
+		{"type": "room_rectangle", "room": "office", "x": 8, "y": 8, "width": 2, "height": 2},
+		{"type": "set", "x": 8, "y": 7, "tile": {"id": "brick_wall_00"}},
+		{"type": "set", "x": 9, "y": 7, "tile": {"id": "brick_wall_00"}},
+		{"type": "set", "x": 8, "y": 10, "tile": {"id": "brick_wall_00"}},
+		{"type": "set", "x": 9, "y": 10, "tile": {"id": "brick_wall_00"}},
+		{"type": "set", "x": 7, "y": 8, "tile": {"id": "brick_wall_00"}},
+		{"type": "set", "x": 10, "y": 8, "tile": {"id": "brick_wall_00"}},
+		{"type": "set", "x": 10, "y": 9, "tile": {"id": "brick_wall_00"}},
+		{"type": "furniture", "id": "door_wood", "x": 8, "y": 9, "rotation": 0}
+	]
+}

--- a/Tools/map_generator.py
+++ b/Tools/map_generator.py
@@ -78,6 +78,8 @@ ROOM_CONNECTION_ENDPOINT_FIELDS = {"kind", "id"}
 ROOM_CONNECTION_ENDPOINT_KINDS = {"room", "exterior"}
 ROOM_BOUNDARY_FIELDS = {"id", "room", "at", "z", "element", "side"}
 ROOM_BOUNDARY_ELEMENTS = {"wall_tile", "door_furniture"}
+BUILDING_FIELDS = {"id", "rooms", "footprint", "z"}
+BUILDING_FOOTPRINT_FIELDS = {"x", "y", "width", "height"}
 TILE_OPERATION_TYPES = {"set", "rectangle", "rectangle_outline", "line", "scatter"}
 LEVEL_FIELDS = {"z", "base_tile", "regions", "operations"}
 RECIPE_FIELDS = {
@@ -92,6 +94,7 @@ RECIPE_FIELDS = {
     "rooms",
     "room_connections",
     "room_boundaries",
+    "buildings",
     "patterns",
     "regions",
     "operations",
@@ -1043,6 +1046,136 @@ def _validate_recipe_rooms(rooms: Any) -> list[dict[str, str]]:
     return validated
 
 
+def _validate_recipe_buildings(
+    buildings: Any, known_room_ids: set[str]
+) -> list[dict[str, Any]]:
+    if not isinstance(buildings, list):
+        raise RecipeError("buildings must be an array")
+    validated: list[dict[str, Any]] = []
+    seen_ids: set[str] = set()
+    for index, building in enumerate(buildings):
+        context = f"buildings[{index}]"
+        if not isinstance(building, dict):
+            raise RecipeError(f"{context} must be an object")
+        unknown_fields = sorted(set(building) - BUILDING_FIELDS)
+        if unknown_fields:
+            raise RecipeError(f"unknown {context} field '{unknown_fields[0]}'")
+        if set(building) != BUILDING_FIELDS:
+            raise RecipeError(f"{context} must define id, rooms, footprint, and z")
+        building_id = building["id"]
+        if not isinstance(building_id, str) or not building_id.strip():
+            raise RecipeError(f"{context}.id must be a non-empty string")
+        _validate_unicode(building_id, f"{context}.id")
+        if DEFINITION_NAME_PATTERN.fullmatch(building_id) is None:
+            raise RecipeError(f"{context}.id may contain only letters, numbers, underscores, and hyphens")
+        if building_id in seen_ids:
+            raise RecipeError(f"duplicate building ID '{building_id}'")
+        seen_ids.add(building_id)
+        room_ids = building["rooms"]
+        if not isinstance(room_ids, list) or not room_ids:
+            raise RecipeError(f"{context}.rooms must name at least one room")
+        if any(not isinstance(room_id, str) or room_id not in known_room_ids for room_id in room_ids):
+            unknown_room = next(room_id for room_id in room_ids if not isinstance(room_id, str) or room_id not in known_room_ids)
+            raise RecipeError(f"{context}.rooms references unknown room '{unknown_room}'")
+        if len(room_ids) != len(set(room_ids)):
+            raise RecipeError(f"{context}.rooms must not duplicate room IDs")
+        footprint = building["footprint"]
+        if not isinstance(footprint, dict) or set(footprint) != BUILDING_FOOTPRINT_FIELDS:
+            raise RecipeError(f"{context}.footprint must define x, y, width, and height")
+        x, y, width, height = (footprint[field] for field in ("x", "y", "width", "height"))
+        if any(type(value) is not int for value in (x, y, width, height)) or width <= 0 or height <= 0:
+            raise RecipeError(f"{context}.footprint must use positive integer width and height")
+        if x < 0 or y < 0 or x + width > MAP_WIDTH or y + height > MAP_HEIGHT:
+            raise RecipeError(f"{context}.footprint must fit within map bounds")
+        z = building["z"]
+        if type(z) is not int or not MIN_LOGICAL_Z <= z <= MAX_LOGICAL_Z:
+            raise RecipeError(f"{context}.z must be an integer from -10 through 10")
+        validated.append({
+            "id": building_id,
+            "rooms": room_ids,
+            "footprint": {"x": x, "y": y, "width": width, "height": height},
+            "z": z,
+        })
+    return validated
+
+
+def _point_in_building_footprint(x: int, y: int, footprint: dict[str, int]) -> bool:
+    return (
+        footprint["x"] <= x < footprint["x"] + footprint["width"]
+        and footprint["y"] <= y < footprint["y"] + footprint["height"]
+    )
+
+
+def _footprints_overlap(left: dict[str, int], right: dict[str, int]) -> bool:
+    return not (
+        left["x"] + left["width"] <= right["x"]
+        or right["x"] + right["width"] <= left["x"]
+        or left["y"] + left["height"] <= right["y"]
+        or right["y"] + right["height"] <= left["y"]
+    )
+
+
+def _validate_building_targets(
+    buildings: list[dict[str, Any]],
+    rooms: list[dict[str, Any]],
+    room_boundaries: list[dict[str, Any]],
+    room_connections: list[dict[str, Any]],
+    levels: list[list[dict[str, Any]]],
+) -> None:
+    room_definitions = {room["id"]: room for room in rooms}
+    for index, building in enumerate(buildings):
+        context = f"buildings[{index}]"
+        footprint = building["footprint"]
+        z = building["z"]
+        for other in buildings[:index]:
+            if other["z"] == z and _footprints_overlap(footprint, other["footprint"]):
+                raise RecipeError(f"{context} overlaps building '{other['id']}' at z {z}")
+        if not any(
+            room_definitions[room_id]["kind"] == "enclosed"
+            and room_definitions[room_id].get("boundary_validation") == "complete"
+            for room_id in building["rooms"]
+        ):
+            raise RecipeError(
+                f"{context} requires an enclosed room with boundary_validation 'complete'"
+            )
+        for room_id in building["rooms"]:
+            membership_count = 0
+            for level_index, level in enumerate(levels):
+                if not level:
+                    continue
+                logical_z = level_index - POPULATED_LEVEL_INDEX
+                for y in range(MAP_HEIGHT):
+                    for x in range(MAP_WIDTH):
+                        tile = level[y * MAP_WIDTH + x]
+                        if not isinstance(tile, dict) or tile.get("rooms") != [room_id]:
+                            continue
+                        if logical_z != z:
+                            raise RecipeError(
+                                f"{context} room '{room_id}' has membership outside building z {z}"
+                            )
+                        membership_count += 1
+                        if not _point_in_building_footprint(x, y, footprint):
+                            raise RecipeError(
+                                f"{context} room '{room_id}' membership at [{x}, {y}] is outside building footprint"
+                            )
+            if membership_count == 0:
+                raise RecipeError(f"{context} room '{room_id}' has no membership at z {z}")
+            for boundary in room_boundaries:
+                if boundary["room"] == room_id and boundary["z"] == z:
+                    x, y = boundary["at"]
+                    if not _point_in_building_footprint(x, y, footprint):
+                        raise RecipeError(
+                            f"{context} room boundary '{boundary['id']}' is outside building footprint"
+                        )
+            for connection in room_connections:
+                if connection["z"] == z and _room_connection_names_room(connection, room_id):
+                    x, y = connection["at"]
+                    if not _point_in_building_footprint(x, y, footprint):
+                        raise RecipeError(
+                            f"{context} room connection '{connection['id']}' is outside building footprint"
+                        )
+
+
 def _validate_room_connection_endpoint(
     endpoint: Any, context: str, known_room_ids: set[str]
 ) -> dict[str, str]:
@@ -1675,6 +1808,7 @@ def generate_map(
     known_area_ids = {area["id"] for area in areas}
     rooms = _validate_recipe_rooms(recipe.get("rooms", []))
     known_room_ids = {room["id"] for room in rooms}
+    buildings = _validate_recipe_buildings(recipe.get("buildings", []), known_room_ids)
     room_connections = _validate_recipe_room_connections(
         recipe.get("room_connections", []), known_room_ids
     )
@@ -1702,6 +1836,13 @@ def generate_map(
         room_connections,
         rooms,
     )
+    _validate_building_targets(
+        buildings,
+        rooms,
+        room_boundaries,
+        room_connections,
+        levels,
+    )
 
     generated = {
         "id": recipe["id"],
@@ -1722,6 +1863,8 @@ def generate_map(
         generated["room_connections"] = room_connections
     if room_boundaries:
         generated["room_boundaries"] = room_boundaries
+    if buildings:
+        generated["buildings"] = buildings
     return generated
 
 

--- a/Tools/map_validator.py
+++ b/Tools/map_validator.py
@@ -21,6 +21,8 @@ ROOM_CONNECTION_FIELDS = {'id', 'at', 'z', 'from', 'to'}
 ROOM_CONNECTION_ENDPOINT_KINDS = {'room', 'exterior'}
 ROOM_BOUNDARY_FIELDS = {'id', 'room', 'at', 'z', 'element', 'side'}
 ROOM_BOUNDARY_ELEMENTS = {'wall_tile', 'door_furniture'}
+BUILDING_FIELDS = {'id', 'rooms', 'footprint', 'z'}
+BUILDING_FOOTPRINT_FIELDS = {'x', 'y', 'width', 'height'}
 
 class MapValidationError(Exception):
     """Custom exception for map validation errors."""
@@ -132,6 +134,10 @@ class MapValidator:
         if not isinstance(room_boundaries, list):
             self.add_error(file_path, "top-level room_boundaries must be an array.")
             room_boundaries = []
+        buildings = data.get('buildings', [])
+        if not isinstance(buildings, list):
+            self.add_error(file_path, "top-level buildings must be an array.")
+            buildings = []
 
         # 2. Check Optional Metadata Types
         metadata_checks = {
@@ -668,6 +674,116 @@ class MapValidator:
                 if extra:
                     x, y, side = sorted(extra)[0]
                     self.add_error(file_path, f"Complete room '{room_id}' declares non-exposed {side} boundary edge at z {z} [{x}, {y}].")
+
+        validated_buildings = []
+        seen_building_ids: Set[str] = set()
+        for idx, building in enumerate(buildings):
+            context = f"Building at index {idx}"
+            if not isinstance(building, dict):
+                self.add_error(file_path, f"{context} is not an object.")
+                continue
+            unknown_fields = sorted(set(building) - BUILDING_FIELDS)
+            if unknown_fields:
+                self.add_error(file_path, f"{context} has unknown field '{unknown_fields[0]}'.")
+            for field in BUILDING_FIELDS:
+                if field not in building:
+                    self.add_error(file_path, f"{context} is missing required field '{field}'.")
+            building_id = building.get('id')
+            if not isinstance(building_id, str) or not building_id:
+                self.add_error(file_path, f"{context} has invalid or missing ID.")
+            elif building_id in seen_building_ids:
+                self.add_error(file_path, f"Duplicate building ID detected: '{building_id}'")
+            else:
+                seen_building_ids.add(building_id)
+            building_rooms = building.get('rooms')
+            rooms_valid = isinstance(building_rooms, list) and bool(building_rooms)
+            if not rooms_valid:
+                self.add_error(file_path, f"{context} rooms must name at least one room.")
+                building_rooms = []
+            elif len(building_rooms) != len(set(building_rooms)):
+                self.add_error(file_path, f"{context} rooms must not duplicate room IDs.")
+            for room_id in building_rooms:
+                if not isinstance(room_id, str) or room_id not in room_ids:
+                    self.add_error(file_path, f"{context} references non-existent room '{room_id}'.")
+                    rooms_valid = False
+            footprint = building.get('footprint')
+            footprint_valid = isinstance(footprint, dict) and set(footprint) == BUILDING_FOOTPRINT_FIELDS
+            if not footprint_valid:
+                self.add_error(file_path, f"{context} footprint must define x, y, width, and height.")
+                footprint = {}
+            x, y, width, height = (footprint.get(field) for field in ('x', 'y', 'width', 'height'))
+            if (
+                not all(type(value) is int for value in (x, y, width, height))
+                or width is None or height is None or width <= 0 or height <= 0
+            ):
+                self.add_error(file_path, f"{context} footprint must use positive integer width and height.")
+                footprint_valid = False
+            elif x < 0 or y < 0 or x + width > MAP_WIDTH or y + height > MAP_HEIGHT:
+                self.add_error(file_path, f"{context} footprint must fit within map bounds.")
+                footprint_valid = False
+            z = building.get('z')
+            z_valid = type(z) is int and -10 <= z <= 10
+            if not z_valid:
+                self.add_error(file_path, f"{context} z must be an integer from -10 through 10.")
+            if (
+                isinstance(building_id, str) and building_id
+                and rooms_valid and footprint_valid and z_valid
+            ):
+                validated_buildings.append(building)
+
+        room_definitions = {
+            room['id']: room for room in rooms
+            if isinstance(room, dict) and isinstance(room.get('id'), str)
+        }
+        for index, building in enumerate(validated_buildings):
+            context = f"Building at index {index}"
+            footprint = building['footprint']
+            z = building['z']
+            for other in validated_buildings[:index]:
+                if other['z'] != z:
+                    continue
+                left, right = footprint, other['footprint']
+                overlaps = not (
+                    left['x'] + left['width'] <= right['x']
+                    or right['x'] + right['width'] <= left['x']
+                    or left['y'] + left['height'] <= right['y']
+                    or right['y'] + right['height'] <= left['y']
+                )
+                if overlaps:
+                    self.add_error(file_path, f"{context} overlaps building '{other['id']}' at z {z}.")
+            if not any(
+                room_definitions[room_id].get('kind') == 'enclosed'
+                and room_definitions[room_id].get('boundary_validation') == 'complete'
+                for room_id in building['rooms']
+            ):
+                self.add_error(file_path, f"{context} requires an enclosed room with boundary_validation 'complete'.")
+            for room_id in building['rooms']:
+                memberships = []
+                for level_index, level in enumerate(levels if isinstance(levels, list) else []):
+                    if not isinstance(level, list) or len(level) != POPULATED_LEVEL_TILE_COUNT:
+                        continue
+                    for tile_index, tile in enumerate(level):
+                        if isinstance(tile, dict) and tile.get('rooms') == [room_id]:
+                            memberships.append((level_index - 10, tile_index % MAP_WIDTH, tile_index // MAP_WIDTH))
+                if not memberships:
+                    self.add_error(file_path, f"{context} room '{room_id}' has no membership at z {z}.")
+                    continue
+                for membership_z, x, y in memberships:
+                    if membership_z != z:
+                        self.add_error(file_path, f"{context} room '{room_id}' has membership outside building z {z}.")
+                    elif not (footprint['x'] <= x < footprint['x'] + footprint['width'] and footprint['y'] <= y < footprint['y'] + footprint['height']):
+                        self.add_error(file_path, f"{context} room '{room_id}' membership at [{x}, {y}] is outside building footprint.")
+                for boundary in validated_room_boundaries:
+                    if boundary['room'] == room_id and boundary['z'] == z:
+                        x, y = boundary['at']
+                        if not (footprint['x'] <= x < footprint['x'] + footprint['width'] and footprint['y'] <= y < footprint['y'] + footprint['height']):
+                            self.add_error(file_path, f"{context} room boundary '{boundary['id']}' is outside building footprint.")
+                for connection in validated_room_connections:
+                    names_room = any(endpoint.get('kind') == 'room' and endpoint.get('id') == room_id for endpoint in (connection['from'], connection['to']))
+                    if connection['z'] == z and names_room:
+                        x, y = connection['at']
+                        if not (footprint['x'] <= x < footprint['x'] + footprint['width'] and footprint['y'] <= y < footprint['y'] + footprint['height']):
+                            self.add_error(file_path, f"{context} room connection '{connection['id']}' is outside building footprint.")
 
     def run(self, path: str):
         if os.path.isdir(path):

--- a/Tools/tests/test_map_generator.py
+++ b/Tools/tests/test_map_generator.py
@@ -1606,6 +1606,76 @@ class MapGeneratorTests(unittest.TestCase):
         self.assertEqual(generated["rooms"], recipe["rooms"])
         self.assertEqual(generated["room_boundaries"], recipe["room_boundaries"])
 
+    def test_buildings_validate_strict_schema_and_preserve_authored_record(self):
+        recipe_path = ROOT / "Tools" / "examples" / "map_recipe_room_boundaries.json"
+        recipe = json.loads(recipe_path.read_text(encoding="utf-8"))
+        building = {
+            "id": "office_building",
+            "rooms": ["office"],
+            "footprint": {"x": 7, "y": 7, "width": 4, "height": 4},
+            "z": 0,
+        }
+        recipe["buildings"] = [building]
+
+        generated = generate_map(recipe, TILES_PATH)
+
+        self.assertEqual(generated["buildings"], [building])
+
+        invalid_cases = [
+            ("not-an-array", "buildings must be an array"),
+            ([{**building, "extra": True}], r"unknown buildings\[0\] field 'extra'"),
+            ([{**building, "rooms": []}], "must name at least one room"),
+            ([{**building, "rooms": ["missing"]}], "references unknown room 'missing'"),
+            ([{**building, "footprint": {"x": 30, "y": 30, "width": 4, "height": 4}}], "must fit within map bounds"),
+            ([{**building, "z": 11}], "must be an integer from -10 through 10"),
+        ]
+        for buildings, message in invalid_cases:
+            with self.subTest(buildings=buildings):
+                invalid_recipe = json.loads(recipe_path.read_text(encoding="utf-8"))
+                invalid_recipe["buildings"] = buildings
+                with self.assertRaisesRegex(RecipeError, message):
+                    generate_map(invalid_recipe, TILES_PATH)
+
+    def test_buildings_require_contained_complete_enclosed_room_content(self):
+        recipe_path = ROOT / "Tools" / "examples" / "map_recipe_room_boundaries.json"
+        recipe = json.loads(recipe_path.read_text(encoding="utf-8"))
+        building = {
+            "id": "office_building",
+            "rooms": ["office"],
+            "footprint": {"x": 7, "y": 7, "width": 4, "height": 4},
+            "z": 0,
+        }
+        recipe["buildings"] = [building]
+        self.assertEqual(generate_map(recipe, TILES_PATH)["buildings"], [building])
+
+        cases = [
+            ({**building, "footprint": {"x": 8, "y": 8, "width": 2, "height": 2}}, "outside building footprint"),
+            ({**building, "rooms": ["garage_bay"]}, "requires an enclosed room with boundary_validation 'complete'"),
+            ({**building, "z": 1}, "has membership outside building z 1"),
+            ([building, {**building, "id": "overlap", "footprint": {"x": 10, "y": 7, "width": 2, "height": 4}}], "overlaps building 'office_building'"),
+        ]
+        for buildings, message in cases:
+            with self.subTest(buildings=buildings):
+                invalid_recipe = json.loads(recipe_path.read_text(encoding="utf-8"))
+                invalid_recipe["buildings"] = buildings if isinstance(buildings, list) else [buildings]
+                with self.assertRaisesRegex(RecipeError, message):
+                    generate_map(invalid_recipe, TILES_PATH)
+
+    def test_single_level_building_example_preserves_contained_existing_content(self):
+        recipe_path = ROOT / "Tools" / "examples" / "map_recipe_single_level_building.json"
+        generated = generate_map(json.loads(recipe_path.read_text(encoding="utf-8")), TILES_PATH)
+
+        self.assertEqual(generated["id"], "generated_single_level_building")
+        self.assertEqual(generated["buildings"], [{
+            "id": "office_building",
+            "rooms": ["office"],
+            "footprint": {"x": 7, "y": 7, "width": 4, "height": 4},
+            "z": 0,
+        }])
+        level = generated["levels"][10]
+        self.assertEqual(level[7 * 32 + 8]["id"], "brick_wall_00")
+        self.assertEqual(level[9 * 32 + 8]["feature"]["id"], "door_wood")
+
     def test_complete_enclosed_room_rejects_missing_or_wrong_directional_boundaries(self):
         recipe_path = ROOT / "Tools" / "examples" / "map_recipe_room_boundaries.json"
 
@@ -2290,6 +2360,32 @@ class MapValidatorDimensionTests(unittest.TestCase):
         non_enclosed["rooms"][0]["kind"] = "covered_open"
         errors = self.validate(non_enclosed)
         self.assertTrue(any("only supported for enclosed rooms" in error for error in errors))
+    def test_validates_single_level_building_footprint_contract(self):
+        recipe_path = ROOT / "Tools" / "examples" / "map_recipe_room_boundaries.json"
+        recipe = json.loads(recipe_path.read_text(encoding="utf-8"))
+        recipe["buildings"] = [{
+            "id": "office_building",
+            "rooms": ["office"],
+            "footprint": {"x": 7, "y": 7, "width": 4, "height": 4},
+            "z": 0,
+        }]
+        valid_map = generate_map(recipe, TILES_PATH)
+        self.assertEqual(self.validate(valid_map), [])
+
+        malformed = json.loads(json.dumps(valid_map))
+        malformed["buildings"][0]["rooms"] = ["missing"]
+        errors = self.validate(malformed)
+        self.assertTrue(any("references non-existent room 'missing'" in error for error in errors))
+
+        incomplete = json.loads(json.dumps(valid_map))
+        incomplete["buildings"][0]["footprint"] = {"x": 8, "y": 8, "width": 2, "height": 2}
+        errors = self.validate(incomplete)
+        self.assertTrue(any("outside building footprint" in error for error in errors))
+
+        missing_complete_room = json.loads(json.dumps(valid_map))
+        missing_complete_room["buildings"][0]["rooms"] = ["garage_bay"]
+        errors = self.validate(missing_complete_room)
+        self.assertTrue(any("requires an enclosed room with boundary_validation 'complete'" in error for error in errors))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

Adds a strict, data-only `buildings` map contract for grouping existing authored room evidence into explicit single-level rectangular footprints.

- adds root-level building definitions with `id`, `rooms`, `footprint`, and logical `z`;
- requires known, unique owned rooms and map-bounded positive footprints;
- requires at least one owned complete `enclosed` room;
- validates owned room memberships, boundary records, and named door-connection targets stay inside the footprint;
- rejects same-level footprint overlap and cross-level owned-room memberships;
- preserves building metadata through `DMap` editor save/load;
- removes stale or structurally incomplete building records during DMap serialization;
- adds a maintained `generated_single_level_building` office example;
- updates roadmap and map-generation documentation.

## Scope

This is authored metadata and validation only.

It does not generate or modify terrain, walls, doors, roofs, furniture, collision, navigation, lighting, weather, indoor state, tile-local building membership, generalized templates, or multi-level buildings.

## Validation

- `python3 -m unittest discover -s Tools/tests` — 92 passed
- all 10 maintained recipes generated and validated
- `python3 Tools/map_validator.py Mods/Dimensionfall/Maps` — 51 maps, no errors
- full GUT suite — 85 passed, 386 assertions
- `godot --headless --path . --editor --quit`
- `git diff --check`