### PR TITLE
Add authored roof and ceiling building semantics

### DIFF
--- a/Documentation/Game_design/Map_generation_plan.md
+++ b/Documentation/Game_design/Map_generation_plan.md
@@ -623,9 +623,11 @@ Authored room semantics use a separate map-level `rooms` array plus exclusive ti
 
 An `enclosed` room may add `boundary_validation: "complete"`. Only this opt-in mode requires directional evidence and validates every exposed cardinal edge of every room-membership tile: exactly one wall or connected-door boundary must map to each edge. Missing, incorrectly oriented, duplicate, and non-exposed declarations are rejected. `covered_open` and `ruin` cannot opt in, so their intentional openings and damage remain valid without blanket enclosure requirements.
 
-The generator, standalone map validator, and `DMap` save/load path validate or preserve definitions and references. A first `buildings` root field now groups existing room content under one explicit, data-only rectangular footprint at one logical z. Each record names a nonempty set of known rooms, requires every owned membership, boundary target, and named door-connection target to sit inside its bounds, disallows same-level overlap, and requires at least one owned `enclosed` room with complete boundary validation. `Tools/examples/map_recipe_single_level_building.json` provides a 4×4 `office_building` containing the already-proven office, its seven wall tiles, and exterior door. The footprint does not generate or modify geometry, furniture, roofs, collision, navigation, lighting, weather, or indoor state; it only gives authored validated evidence a first building-level grouping.
+The generator, standalone map validator, and `DMap` save/load path validate or preserve definitions and references. A first `buildings` root field groups existing room content under one explicit, data-only rectangular footprint at one logical z. Each record names a nonempty set of known rooms, requires every owned membership, boundary target, and named door-connection target to sit inside its bounds, disallows same-level overlap, and requires at least one owned `enclosed` room with complete boundary validation. `Tools/examples/map_recipe_single_level_building.json` provides a 4×4 `office_building` containing the already-proven office, its seven wall tiles, and exterior door. The footprint does not generate or modify geometry, furniture, roofs, collision, navigation, lighting, weather, or indoor state; it only gives authored validated evidence a first building-level grouping.
 
-This foundation intentionally does **not** yet define polygons, topology-derived room boundaries, indoor/outdoor runtime behavior, wall/roof generation, roof/ceiling semantics, multi-level building records, furniture anchors, or generalized templates.
+`building_surfaces` now adds one narrow overhead semantic layer to that validated footprint. Each root record has a unique `id`, names one existing `building`, declares `kind` as `roof` or `ceiling`, and declares the immediately overhead logical level (`building.z + 1`). One building may carry one authored record of each kind; the records inherit the building rectangle rather than duplicate per-cell geometry. `Tools/examples/map_recipe_building_surfaces.json` demonstrates both classifications over `office_building` at `z: 1`. These records do not generate roof/ceiling tiles or meshes, mark any cell occupied or indoors, imply support/collision, or alter lighting, weather, or runtime behavior.
+
+This foundation intentionally does **not** yet define polygons, topology-derived room boundaries, indoor/outdoor runtime behavior, wall/roof generation, multi-level building records, furniture anchors, or generalized templates.
 
 Capabilities:
 
@@ -860,7 +862,7 @@ An agent can create a new playable, potentially multi-level map from a concise d
 
 # Recommended immediate next task
 
-**Phase 6 is in progress.** Its runtime-compatible area foundation, catalog-validated per-instance entity variation, authored room semantics, explicit door-link metadata, partial physical boundary references, opt-in enclosed-room completeness validation, and first single-level authored footprint are complete. The next contribution should add one narrow authored roof/ceiling semantic contract for the validated footprint without introducing multi-level structures or generalized templates.
+**Phase 6 is in progress.** Its runtime-compatible area foundation, catalog-validated per-instance entity variation, authored room semantics, explicit door-link metadata, partial physical boundary references, opt-in enclosed-room completeness validation, first single-level authored footprint, and narrow authored roof/ceiling metadata are complete. The next contribution should extend validated building content carefully without introducing multi-level structures or generalized templates.
 
 Do not yet generate walls, doors, roofs, multi-level building footprints, furniture anchors, roads, towns, or generalized building templates. Preserve the established map-level `areas` plus per-tile area membership representation, keep room semantics independent from runtime areas, and validate any physical semantics in the editor and runtime.
 
@@ -902,7 +904,8 @@ Do not commit or push unless explicitly requested.
 [Complete] Authored existing-wall and connected-door boundary references
 [Complete] Opt-in directional completeness validation for `enclosed` rooms
 [Complete] Small single-level authored building footprint
-[Next]     Authored roof/ceiling semantics for validated footprints
+[Complete] Authored roof/ceiling semantics for validated footprints
+[Next]     Validated building-level composition constraints
 [Planned]  Rooms and buildings
 [Planned]  Roads and map connections
 [Planned]  Multi-level reusable templates and richer composition

--- a/Documentation/Modding/map_example_generation.md
+++ b/Documentation/Modding/map_example_generation.md
@@ -30,6 +30,7 @@ The maintained recipe examples are:
 | `Tools/examples/map_recipe_room_connections.json` | `Mods/Dimensionfall/Maps/generated_room_connections.json` | Existing `door_wood` features with explicit room-to-exterior and room-to-room semantic links, without inferred topology or new runtime door behavior. |
 | `Tools/examples/map_recipe_room_boundaries.json` | `Mods/Dimensionfall/Maps/generated_room_boundaries.json` | A complete opt-in `enclosed` office with directional existing `brick_wall_00`/`door_wood` evidence, plus deliberately partial `covered_open` and `ruin` room references. |
 | `Tools/examples/map_recipe_single_level_building.json` | `Mods/Dimensionfall/Maps/generated_single_level_building.json` | One data-only rectangular `office_building` footprint containing the complete authored office and its existing wall/door evidence at logical `z: 0`. |
+| `Tools/examples/map_recipe_building_surfaces.json` | `Mods/Dimensionfall/Maps/generated_building_surfaces.json` | One validated `office_building` with authored `roof` and `ceiling` classifications at its immediately overhead logical `z: 1`, without generated overhead geometry. |
 | `Tools/examples/map_recipe_two_level_hill.json` | `Mods/Dimensionfall/Maps/generated_two_level_hill.json` | Ground level `z: 0`, raised terrain at `z: 1`, and all four slope rotations. |
 | `Tools/examples/map_recipe_two_level_depression.json` | `Mods/Dimensionfall/Maps/generated_two_level_depression.json` | Ground level `z: 0`, lowered terrain at `z: -1`, and all four slope rotations. |
 
@@ -88,6 +89,11 @@ python3 Tools/map_generator.py \
   Tools/examples/map_recipe_single_level_building.json \
   Mods/Dimensionfall/Maps/generated_single_level_building.json
 
+# Ground-level authored roof/ceiling semantics for a validated building
+python3 Tools/map_generator.py \
+  Tools/examples/map_recipe_building_surfaces.json \
+  Mods/Dimensionfall/Maps/generated_building_surfaces.json
+
 # Two-level hill
 python3 Tools/map_generator.py \
   Tools/examples/map_recipe_two_level_hill.json \
@@ -119,6 +125,7 @@ rm Mods/Dimensionfall/Maps/generated_room_semantics.json
 rm Mods/Dimensionfall/Maps/generated_room_connections.json
 rm Mods/Dimensionfall/Maps/generated_room_boundaries.json
 rm Mods/Dimensionfall/Maps/generated_single_level_building.json
+rm Mods/Dimensionfall/Maps/generated_building_surfaces.json
 rm Mods/Dimensionfall/Maps/generated_two_level_hill.json
 rm Mods/Dimensionfall/Maps/generated_two_level_depression.json
 ```
@@ -197,6 +204,8 @@ For the maintained room-connections map, open `generated_room_connections`, save
 For the maintained room-boundaries map, open `generated_room_boundaries`, save it, close it, and re-open it. Confirm that `office` retains `boundary_validation: "complete"`, its eight directed boundary records retain their cardinal `side`, and the office’s seven existing `brick_wall_00` tiles plus one existing `door_wood` feature remain present. The partial garage and ruin records deliberately have no completeness requirement. **Save and test** should confirm normal loading and existing door interaction only: this validation adds no geometry, collision, navigation, lighting, weather, or indoor behavior.
 
 For the maintained single-level building map, open `generated_single_level_building`, save it, close it, and re-open it. Confirm the root `buildings` array retains `office_building` with its `office` room list, `[7, 7]` `4×4` footprint, and logical `z: 0`. Confirm the existing seven `brick_wall_00` tiles and one `door_wood` opening still load and retain normal interaction. The footprint is metadata only: **save and test** must not produce new terrain, walls, roofs, collision, navigation, lighting, weather, or indoor behavior.
+
+For the maintained building-surfaces map, open `generated_building_surfaces`, save it, close it, and re-open it. Confirm the root `building_surfaces` array retains `office_roof` (`roof`) and `office_ceiling` (`ceiling`), both bound to `office_building` at logical `z: 1`. Confirm the underlying validated `[7, 7]` `4×4` footprint plus its seven `brick_wall_00` tiles and `door_wood` remain unchanged. **Save and test** must not add roof/ceiling tiles, meshes, collision, support, lighting, weather, indoor state, or any runtime behavior; this slice verifies metadata persistence only.
 
 Dimensionfall also looks for a same-named `.png` map sprite during startup. The runner intentionally generates map JSON only, so Godot currently logs a non-fatal missing-resource error for that sprite. This does not prevent the JSON map from loading or the map editor's tile-grid preview from rendering it.
 

--- a/Documentation/Modding/map_recipe_generator.md
+++ b/Documentation/Modding/map_recipe_generator.md
@@ -383,7 +383,26 @@ Each record has exactly `id`, `rooms`, `footprint`, and `z`. `id` is unique; `ro
 
 Every owned room must have membership only at the building level and wholly inside its footprint. At least one owned room must be an `enclosed` room with `"boundary_validation": "complete"`. Its same-level `room_boundaries` and any same-level `room_connections` naming it must also lie inside the footprint. This makes the record a strict ownership/containment contract for already-authored physical evidence, not a claim that every footprint cell is occupied, roofed, or indoors.
 
-`DMap` preserves building records through editor save/load and removes records whose room list becomes stale. The standalone validator performs strict shape, containment, same-level overlap, and complete-enclosed-room checks. No generalized templates, polygons, multi-level building records, roof/ceiling semantics, furniture anchors, or generation operations are introduced.
+`DMap` preserves building records through editor save/load and removes records whose room list becomes stale. The standalone validator performs strict shape, containment, same-level overlap, and complete-enclosed-room checks.
+
+### `building_surfaces`
+
+`building_surfaces` declares authored overhead semantics for an existing validated building footprint without creating roof or ceiling geometry:
+
+```json
+{
+  "building_surfaces": [
+    {"id": "office_roof", "building": "office_building", "kind": "roof", "z": 1},
+    {"id": "office_ceiling", "building": "office_building", "kind": "ceiling", "z": 1}
+  ]
+}
+```
+
+Each record has exactly `id`, `building`, `kind`, and `z`. `id` is unique; `building` must name a root `buildings` record; and `kind` is exactly `roof` or `ceiling`. A building may have at most one record of each kind. `z` is the logical level immediately above the building footprint (`building.z + 1`), so surface semantics inherit the footprint bounds without duplicating coordinates.
+
+`roof` and `ceiling` are separate authored classifications and may both be present for one building. They do not place tiles on their `z`, create a roof or ceiling mesh, imply collision/support, change lighting/weather, mark rooms indoors, or make overhead cells occupied. `DMap` preserves valid records and removes surfaces whose referenced building is deleted; generator and standalone validation enforce the strict reference, uniqueness, and z relationship.
+
+No generalized templates, polygons, multi-level building records, furniture anchors, or generation operations are introduced.
 
 ### `set`
 

--- a/Scripts/Gamedata/DMap.gd
+++ b/Scripts/Gamedata/DMap.gd
@@ -97,6 +97,7 @@ var rooms: Array = []
 var room_connections: Array = []
 var room_boundaries: Array = []
 var buildings: Array = []
+var building_surfaces: Array = []
 var sprite: Texture = null
 # Variable to store connections. For example: {"south": "road","west": "ground"} default to ground
 var connections: Dictionary = {
@@ -153,6 +154,7 @@ func set_data(newdata: Dictionary) -> void:
 	room_connections = newdata.get("room_connections", [])
 	room_boundaries = newdata.get("room_boundaries", [])
 	buildings = newdata.get("buildings", [])
+	building_surfaces = newdata.get("building_surfaces", [])
 	connections = newdata.get("connections", {})  # Set connections from data if present
 
 
@@ -178,6 +180,8 @@ func get_data() -> Dictionary:
 		mydata["room_boundaries"] = room_boundaries
 	if not buildings.is_empty():
 		mydata["buildings"] = buildings
+	if not building_surfaces.is_empty():
+		mydata["building_surfaces"] = building_surfaces
 	if not connections.is_empty():  # Omit connections if empty
 		mydata["connections"] = connections
 	
@@ -187,6 +191,7 @@ func get_data() -> Dictionary:
 	_sanitize_room_connections(mydata)
 	_sanitize_room_boundaries(mydata)
 	_sanitize_buildings(mydata)
+	_sanitize_building_surfaces(mydata)
 
 	# NEW: Implement sanitization for corrupt tiles (missing or empty ID when metadata exists)
 	_sanitize_tile_objects(mydata)
@@ -337,6 +342,33 @@ func _sanitize_buildings(data: Dictionary) -> void:
 	)
 	if data["buildings"].is_empty():
 		data.erase("buildings")
+
+
+func _sanitize_building_surfaces(data: Dictionary) -> void:
+	if not data.has("building_surfaces") or not data["building_surfaces"] is Array:
+		return
+
+	var valid_building_ids: Array[String] = []
+	if data.has("buildings") and data["buildings"] is Array:
+		for building in data["buildings"]:
+			if building is Dictionary and building.has("id") and building["id"] is String:
+				valid_building_ids.append(building["id"])
+
+	data["building_surfaces"] = data["building_surfaces"].filter(func(surface):
+		return surface is Dictionary \
+			and surface.has("id") \
+			and surface["id"] is String \
+			and not surface["id"].is_empty() \
+			and surface.has("building") \
+			and surface["building"] is String \
+			and surface["building"] in valid_building_ids \
+			and surface.has("kind") \
+			and surface["kind"] is String \
+			and surface.has("z") \
+			and surface["z"] is int
+	)
+	if data["building_surfaces"].is_empty():
+		data.erase("building_surfaces")
 
 
 func load_data_from_disk():

--- a/Tests/Unit/test_dmap_sanitization.gd
+++ b/Tests/Unit/test_dmap_sanitization.gd
@@ -224,3 +224,34 @@ func test_dmap_buildings_roundtrip_and_sanitization():
 		"footprint": {"x": 7, "y": 7, "width": 4, "height": 4},
 		"z": 0,
 	}])
+
+
+func test_dmap_building_surfaces_roundtrip_and_sanitization():
+	var DMap = load("res://Scripts/Gamedata/DMap.gd")
+	var map = DMap.new("test_building_surfaces", "/tmp/", null)
+	map.set_data({
+		"name": "Building surfaces",
+		"description": "Preserve authored roof metadata.",
+		"rooms": [
+			{"id": "office", "kind": "enclosed", "boundary_validation": "complete"},
+		],
+		"buildings": [{
+			"id": "office_building",
+			"rooms": ["office"],
+			"footprint": {"x": 7, "y": 7, "width": 4, "height": 4},
+			"z": 0,
+		}],
+		"building_surfaces": [
+			{"id": "office_roof", "building": "office_building", "kind": "roof", "z": 1},
+			{"id": "stale_roof", "building": "missing_building", "kind": "roof", "z": 1},
+		],
+		"levels": [[
+			{"id": "concrete_00"},
+		]],
+	})
+
+	var data = map.get_data()
+
+	assert_eq(data["building_surfaces"], [
+		{"id": "office_roof", "building": "office_building", "kind": "roof", "z": 1},
+	])

--- a/Tools/examples/map_recipe_building_surfaces.json
+++ b/Tools/examples/map_recipe_building_surfaces.json
@@ -1,0 +1,53 @@
+{
+	"id": "generated_building_surfaces",
+	"name": "Generated Building Surfaces",
+	"description": "A data-only authored roof and ceiling classification for an existing validated office footprint.",
+	"seed": 20260818,
+	"base_tile": {"id": "grass_plain_01"},
+	"rooms": [
+		{"id": "office", "kind": "enclosed", "boundary_validation": "complete"}
+	],
+	"buildings": [
+		{
+			"id": "office_building",
+			"rooms": ["office"],
+			"footprint": {"x": 7, "y": 7, "width": 4, "height": 4},
+			"z": 0
+		}
+	],
+	"building_surfaces": [
+		{"id": "office_roof", "building": "office_building", "kind": "roof", "z": 1},
+		{"id": "office_ceiling", "building": "office_building", "kind": "ceiling", "z": 1}
+	],
+	"room_connections": [
+		{
+			"id": "office_front_door",
+			"at": [8, 9],
+			"z": 0,
+			"from": {"kind": "room", "id": "office"},
+			"to": {"kind": "exterior"}
+		}
+	],
+	"room_boundaries": [
+		{"id": "office_northwest_north", "room": "office", "at": [8, 7], "z": 0, "element": "wall_tile", "side": "south"},
+		{"id": "office_northeast_north", "room": "office", "at": [9, 7], "z": 0, "element": "wall_tile", "side": "south"},
+		{"id": "office_southwest_south", "room": "office", "at": [8, 10], "z": 0, "element": "wall_tile", "side": "north"},
+		{"id": "office_southeast_south", "room": "office", "at": [9, 10], "z": 0, "element": "wall_tile", "side": "north"},
+		{"id": "office_northwest_west", "room": "office", "at": [7, 8], "z": 0, "element": "wall_tile", "side": "east"},
+		{"id": "office_northeast_east", "room": "office", "at": [10, 8], "z": 0, "element": "wall_tile", "side": "west"},
+		{"id": "office_southeast_east", "room": "office", "at": [10, 9], "z": 0, "element": "wall_tile", "side": "west"},
+		{"id": "office_southwest_door", "room": "office", "at": [8, 9], "z": 0, "element": "door_furniture", "side": "west"}
+	],
+	"operations": [
+		{"type": "rectangle", "x": 8, "y": 8, "width": 2, "height": 2, "tile": {"id": "concrete_00"}},
+		{"type": "room_rectangle", "room": "office", "x": 8, "y": 8, "width": 2, "height": 2},
+		{"type": "set", "x": 8, "y": 7, "tile": {"id": "brick_wall_00"}},
+		{"type": "set", "x": 9, "y": 7, "tile": {"id": "brick_wall_00"}},
+		{"type": "set", "x": 8, "y": 10, "tile": {"id": "brick_wall_00"}},
+		{"type": "set", "x": 9, "y": 10, "tile": {"id": "brick_wall_00"}},
+		{"type": "set", "x": 7, "y": 8, "tile": {"id": "brick_wall_00"}},
+		{"type": "set", "x": 10, "y": 8, "tile": {"id": "brick_wall_00"}},
+		{"type": "set", "x": 10, "y": 9, "tile": {"id": "brick_wall_00"}},
+		{"type": "furniture", "id": "door_wood", "x": 8, "y": 9, "rotation": 0}
+	]
+}

--- a/Tools/map_generator.py
+++ b/Tools/map_generator.py
@@ -80,6 +80,8 @@ ROOM_BOUNDARY_FIELDS = {"id", "room", "at", "z", "element", "side"}
 ROOM_BOUNDARY_ELEMENTS = {"wall_tile", "door_furniture"}
 BUILDING_FIELDS = {"id", "rooms", "footprint", "z"}
 BUILDING_FOOTPRINT_FIELDS = {"x", "y", "width", "height"}
+BUILDING_SURFACE_FIELDS = {"id", "building", "kind", "z"}
+BUILDING_SURFACE_KINDS = {"roof", "ceiling"}
 TILE_OPERATION_TYPES = {"set", "rectangle", "rectangle_outline", "line", "scatter"}
 LEVEL_FIELDS = {"z", "base_tile", "regions", "operations"}
 RECIPE_FIELDS = {
@@ -95,6 +97,7 @@ RECIPE_FIELDS = {
     "room_connections",
     "room_boundaries",
     "buildings",
+    "building_surfaces",
     "patterns",
     "regions",
     "operations",
@@ -1099,6 +1102,53 @@ def _validate_recipe_buildings(
     return validated
 
 
+def _validate_recipe_building_surfaces(
+    surfaces: Any, buildings: list[dict[str, Any]]
+) -> list[dict[str, Any]]:
+    if not isinstance(surfaces, list):
+        raise RecipeError("building_surfaces must be an array")
+    building_by_id = {building["id"]: building for building in buildings}
+    validated: list[dict[str, Any]] = []
+    seen_ids: set[str] = set()
+    seen_kinds: set[tuple[str, str]] = set()
+    for index, surface in enumerate(surfaces):
+        context = f"building_surfaces[{index}]"
+        if not isinstance(surface, dict):
+            raise RecipeError(f"{context} must be an object")
+        unknown_fields = sorted(set(surface) - BUILDING_SURFACE_FIELDS)
+        if unknown_fields:
+            raise RecipeError(f"unknown {context} field '{unknown_fields[0]}'")
+        if set(surface) != BUILDING_SURFACE_FIELDS:
+            raise RecipeError(f"{context} must define id, building, kind, and z")
+        surface_id = surface["id"]
+        if not isinstance(surface_id, str) or not surface_id.strip():
+            raise RecipeError(f"{context}.id must be a non-empty string")
+        _validate_unicode(surface_id, f"{context}.id")
+        if DEFINITION_NAME_PATTERN.fullmatch(surface_id) is None:
+            raise RecipeError(f"{context}.id may contain only letters, numbers, underscores, and hyphens")
+        if surface_id in seen_ids:
+            raise RecipeError(f"duplicate building surface ID '{surface_id}'")
+        seen_ids.add(surface_id)
+        building_id = surface["building"]
+        if not isinstance(building_id, str) or building_id not in building_by_id:
+            raise RecipeError(f"{context}.building references unknown building '{building_id}'")
+        kind = surface["kind"]
+        if kind not in BUILDING_SURFACE_KINDS:
+            raise RecipeError(f"{context}.kind has unsupported kind '{kind}'")
+        surface_key = (building_id, kind)
+        if surface_key in seen_kinds:
+            raise RecipeError(f"{context} duplicates {kind} surface for building '{building_id}'")
+        seen_kinds.add(surface_key)
+        z = surface["z"]
+        expected_z = building_by_id[building_id]["z"] + 1
+        if type(z) is not int or z != expected_z or not MIN_LOGICAL_Z <= z <= MAX_LOGICAL_Z:
+            raise RecipeError(
+                f"{context}.z must be immediately above building '{building_id}' at z {expected_z}"
+            )
+        validated.append({"id": surface_id, "building": building_id, "kind": kind, "z": z})
+    return validated
+
+
 def _point_in_building_footprint(x: int, y: int, footprint: dict[str, int]) -> bool:
     return (
         footprint["x"] <= x < footprint["x"] + footprint["width"]
@@ -1809,6 +1859,9 @@ def generate_map(
     rooms = _validate_recipe_rooms(recipe.get("rooms", []))
     known_room_ids = {room["id"] for room in rooms}
     buildings = _validate_recipe_buildings(recipe.get("buildings", []), known_room_ids)
+    building_surfaces = _validate_recipe_building_surfaces(
+        recipe.get("building_surfaces", []), buildings
+    )
     room_connections = _validate_recipe_room_connections(
         recipe.get("room_connections", []), known_room_ids
     )
@@ -1865,6 +1918,8 @@ def generate_map(
         generated["room_boundaries"] = room_boundaries
     if buildings:
         generated["buildings"] = buildings
+    if building_surfaces:
+        generated["building_surfaces"] = building_surfaces
     return generated
 
 

--- a/Tools/map_validator.py
+++ b/Tools/map_validator.py
@@ -23,6 +23,8 @@ ROOM_BOUNDARY_FIELDS = {'id', 'room', 'at', 'z', 'element', 'side'}
 ROOM_BOUNDARY_ELEMENTS = {'wall_tile', 'door_furniture'}
 BUILDING_FIELDS = {'id', 'rooms', 'footprint', 'z'}
 BUILDING_FOOTPRINT_FIELDS = {'x', 'y', 'width', 'height'}
+BUILDING_SURFACE_FIELDS = {'id', 'building', 'kind', 'z'}
+BUILDING_SURFACE_KINDS = {'roof', 'ceiling'}
 
 class MapValidationError(Exception):
     """Custom exception for map validation errors."""
@@ -138,6 +140,10 @@ class MapValidator:
         if not isinstance(buildings, list):
             self.add_error(file_path, "top-level buildings must be an array.")
             buildings = []
+        building_surfaces = data.get('building_surfaces', [])
+        if not isinstance(building_surfaces, list):
+            self.add_error(file_path, "top-level building_surfaces must be an array.")
+            building_surfaces = []
 
         # 2. Check Optional Metadata Types
         metadata_checks = {
@@ -784,6 +790,45 @@ class MapValidator:
                         x, y = connection['at']
                         if not (footprint['x'] <= x < footprint['x'] + footprint['width'] and footprint['y'] <= y < footprint['y'] + footprint['height']):
                             self.add_error(file_path, f"{context} room connection '{connection['id']}' is outside building footprint.")
+
+        building_by_id = {building['id']: building for building in validated_buildings}
+        seen_surface_ids: Set[str] = set()
+        seen_surface_kinds: Set[tuple] = set()
+        for idx, surface in enumerate(building_surfaces):
+            context = f"Building surface at index {idx}"
+            if not isinstance(surface, dict):
+                self.add_error(file_path, f"{context} is not an object.")
+                continue
+            unknown_fields = sorted(set(surface) - BUILDING_SURFACE_FIELDS)
+            if unknown_fields:
+                self.add_error(file_path, f"{context} has unknown field '{unknown_fields[0]}'.")
+            for field in BUILDING_SURFACE_FIELDS:
+                if field not in surface:
+                    self.add_error(file_path, f"{context} is missing required field '{field}'.")
+            surface_id = surface.get('id')
+            if not isinstance(surface_id, str) or not surface_id:
+                self.add_error(file_path, f"{context} has invalid or missing ID.")
+            elif surface_id in seen_surface_ids:
+                self.add_error(file_path, f"Duplicate building surface ID detected: '{surface_id}'")
+            else:
+                seen_surface_ids.add(surface_id)
+            building_id = surface.get('building')
+            building = building_by_id.get(building_id) if isinstance(building_id, str) else None
+            if building is None:
+                self.add_error(file_path, f"{context} references non-existent building '{building_id}'.")
+            kind = surface.get('kind')
+            if kind not in BUILDING_SURFACE_KINDS:
+                self.add_error(file_path, f"{context} has unsupported kind '{kind}'.")
+            elif building is not None:
+                surface_key = (building_id, kind)
+                if surface_key in seen_surface_kinds:
+                    self.add_error(file_path, f"{context} duplicates {kind} surface for building '{building_id}'.")
+                seen_surface_kinds.add(surface_key)
+            z = surface.get('z')
+            if type(z) is not int or not -10 <= z <= 10:
+                self.add_error(file_path, f"{context} z must be an integer from -10 through 10.")
+            elif building is not None and z != building['z'] + 1:
+                self.add_error(file_path, f"{context} z must be immediately above building '{building_id}' at z {building['z'] + 1}.")
 
     def run(self, path: str):
         if os.path.isdir(path):

--- a/Tools/tests/test_map_generator.py
+++ b/Tools/tests/test_map_generator.py
@@ -1636,6 +1636,48 @@ class MapGeneratorTests(unittest.TestCase):
                 with self.assertRaisesRegex(RecipeError, message):
                     generate_map(invalid_recipe, TILES_PATH)
 
+    def test_building_surfaces_require_existing_building_and_overhead_level(self):
+        recipe_path = ROOT / "Tools" / "examples" / "map_recipe_single_level_building.json"
+        recipe = json.loads(recipe_path.read_text(encoding="utf-8"))
+        surface = {
+            "id": "office_roof",
+            "building": "office_building",
+            "kind": "roof",
+            "z": 1,
+        }
+        recipe["building_surfaces"] = [surface]
+
+        generated = generate_map(recipe, TILES_PATH)
+
+        self.assertEqual(generated["building_surfaces"], [surface])
+
+        invalid_cases = [
+            ("not-an-array", "building_surfaces must be an array"),
+            ([{**surface, "extra": True}], r"unknown building_surfaces\[0\] field 'extra'"),
+            ([{**surface, "building": "missing"}], "references unknown building 'missing'"),
+            ([{**surface, "kind": "awning"}], "unsupported kind 'awning'"),
+            ([{**surface, "z": 0}], "must be immediately above building 'office_building' at z 1"),
+            ([surface, {**surface, "id": "duplicate_surface"}], "duplicates roof surface for building 'office_building'"),
+        ]
+        for surfaces, message in invalid_cases:
+            with self.subTest(surfaces=surfaces):
+                invalid_recipe = json.loads(recipe_path.read_text(encoding="utf-8"))
+                invalid_recipe["building_surfaces"] = surfaces
+                with self.assertRaisesRegex(RecipeError, message):
+                    generate_map(invalid_recipe, TILES_PATH)
+
+    def test_building_surfaces_example_preserves_authored_roof_and_ceiling(self):
+        recipe_path = ROOT / "Tools" / "examples" / "map_recipe_building_surfaces.json"
+        generated = generate_map(json.loads(recipe_path.read_text(encoding="utf-8")), TILES_PATH)
+
+        self.assertEqual(generated["id"], "generated_building_surfaces")
+        self.assertEqual(generated["building_surfaces"], [
+            {"id": "office_roof", "building": "office_building", "kind": "roof", "z": 1},
+            {"id": "office_ceiling", "building": "office_building", "kind": "ceiling", "z": 1},
+        ])
+        self.assertEqual(generated["levels"][10][7 * 32 + 8]["id"], "brick_wall_00")
+        self.assertEqual(generated["levels"][10][9 * 32 + 8]["feature"]["id"], "door_wood")
+
     def test_buildings_require_contained_complete_enclosed_room_content(self):
         recipe_path = ROOT / "Tools" / "examples" / "map_recipe_room_boundaries.json"
         recipe = json.loads(recipe_path.read_text(encoding="utf-8"))
@@ -2360,6 +2402,33 @@ class MapValidatorDimensionTests(unittest.TestCase):
         non_enclosed["rooms"][0]["kind"] = "covered_open"
         errors = self.validate(non_enclosed)
         self.assertTrue(any("only supported for enclosed rooms" in error for error in errors))
+    def test_validates_building_surface_contract(self):
+        recipe_path = ROOT / "Tools" / "examples" / "map_recipe_single_level_building.json"
+        recipe = json.loads(recipe_path.read_text(encoding="utf-8"))
+        recipe["building_surfaces"] = [{
+            "id": "office_roof",
+            "building": "office_building",
+            "kind": "roof",
+            "z": 1,
+        }]
+        valid_map = generate_map(recipe, TILES_PATH)
+        self.assertEqual(self.validate(valid_map), [])
+
+        unknown_building = json.loads(json.dumps(valid_map))
+        unknown_building["building_surfaces"][0]["building"] = "missing"
+        errors = self.validate(unknown_building)
+        self.assertTrue(any("references non-existent building 'missing'" in error for error in errors))
+
+        wrong_level = json.loads(json.dumps(valid_map))
+        wrong_level["building_surfaces"][0]["z"] = 0
+        errors = self.validate(wrong_level)
+        self.assertTrue(any("must be immediately above building 'office_building' at z 1" in error for error in errors))
+
+        invalid_kind = json.loads(json.dumps(valid_map))
+        invalid_kind["building_surfaces"][0]["kind"] = "awning"
+        errors = self.validate(invalid_kind)
+        self.assertTrue(any("unsupported kind 'awning'" in error for error in errors))
+
     def test_validates_single_level_building_footprint_contract(self):
         recipe_path = ROOT / "Tools" / "examples" / "map_recipe_room_boundaries.json"
         recipe = json.loads(recipe_path.read_text(encoding="utf-8"))


### PR DESCRIPTION
## Summary

Adds a strict, data-only `building_surfaces` contract for authored roof and ceiling classifications over existing validated building footprints.

- adds root-level `building_surfaces` records with `id`, `building`, `kind`, and `z`;
- supports exactly `roof` and `ceiling` classifications;
- requires each record to target an existing validated building;
- requires surface z to be immediately above the building footprint;
- permits one roof and one ceiling classification per building;
- preserves valid surface metadata through DMap editor save/load;
- removes editor-saved records targeting deleted buildings;
- adds a maintained office footprint example with both roof and ceiling records;
- updates Phase 6 roadmap and map-generation documentation.

## Scope

This is authored metadata and validation only.

It does not generate roof or ceiling geometry, mark cells indoors or occupied, alter collision/support/navigation, add lighting or weather behavior, change walls or doors, or introduce multi-level buildings or templates.

## Validation

- `python3 -m unittest discover -s Tools/tests` — 95 passed
- all 11 maintained recipes generated and validated
- `python3 Tools/map_validator.py Mods/Dimensionfall/Maps` — 51 maps, no errors
- focused DMap GUT — 6 passed, 15 assertions
- full GUT suite — 86 passed, 387 assertions
- `godot --headless --path . --editor --quit`
- `git diff --check`