### PR TITLE
Add authored building-level entrance semantics

### DIFF
--- a/Documentation/Game_design/Map_generation_plan.md
+++ b/Documentation/Game_design/Map_generation_plan.md
@@ -643,6 +643,8 @@ An opted-in `overhead_validation: "complete"` requires that the validated buildi
 
 `exterior_access_context` now explicitly associates that context with one existing owned room-to-exterior connection at the same logical z. The maintained building names `office_front_door`. This validates authored semantic association only: it does not infer physical routes or door/context adjacency, create entrances, alter collision/navigation, or change runtime behavior.
 
+`entrance` now authors one data-only building-level entrance semantic. Each record has exactly `connection` and `facing`: `connection` names an existing same-z room-to-exterior connection owned by the building (the same contract as `exterior_access_context.connection`), and `facing` is one of `north`, `east`, `south`, or `west`. It requires `exterior_context` and, when `exterior_access_context` is also present, `entrance.connection` must match it. The `facing` direction must point from `exterior_context.at` toward the building footprint: stepping one cell in that direction from the context coordinate must land inside the footprint. The maintained building authors `office_front_door` facing `east`, matching its west-of-footprint exterior context. This validates authored entrance orientation only: it does not generate a door, infer a physical route, require coordinate adjacency between the context tile and the referenced door, or alter collision, navigation, lighting, weather, or runtime behavior.
+
 This foundation intentionally does **not** yet define polygons, topology-derived room boundaries, indoor/outdoor runtime behavior, wall/roof generation, multi-level building records, furniture anchors, or generalized templates.
 
 Capabilities:
@@ -878,7 +880,7 @@ An agent can create a new playable, potentially multi-level map from a concise d
 
 # Recommended immediate next task
 
-**Phase 6 is in progress.** Its runtime-compatible area foundation, catalog-validated per-instance entity variation, authored room semantics, explicit door-link metadata, partial physical boundary references, opt-in enclosed-room completeness validation, first single-level authored footprint, narrow authored roof/ceiling metadata, opt-in building-level composition constraints, authored building access-completeness validation, authored interior classification constraints, authored exterior/open-space classification constraints, validated building-level room partition constraints, validated building overhead-classification constraints, authored external footprint context, and validated exterior-access context are complete. The next contribution should extend validated building content carefully without introducing multi-level structures or generalized templates.
+**Phase 6 is in progress.** Its runtime-compatible area foundation, catalog-validated per-instance entity variation, authored room semantics, explicit door-link metadata, partial physical boundary references, opt-in enclosed-room completeness validation, first single-level authored footprint, narrow authored roof/ceiling metadata, opt-in building-level composition constraints, authored building access-completeness validation, authored interior classification constraints, authored exterior/open-space classification constraints, validated building-level room partition constraints, validated building overhead-classification constraints, authored external footprint context, validated exterior-access context, and authored building-level entrance semantics are complete. The next contribution should extend validated building content carefully without introducing multi-level structures or generalized templates.
 
 Do not yet generate walls, doors, roofs, multi-level building footprints, furniture anchors, roads, towns, or generalized building templates. Preserve the established map-level `areas` plus per-tile area membership representation, keep room semantics independent from runtime areas, and validate any physical semantics in the editor and runtime.
 
@@ -929,7 +931,8 @@ Do not commit or push unless explicitly requested.
 [Complete] Validated building overhead-classification constraints
 [Complete] Authored building-level external footprint context constraints
 [Complete] Validated building-level exterior-access context constraints
-[Next]     Authored building-level entrance semantics constraints
+[Complete] Authored building-level entrance semantics constraints
+[Next]     Authored building-level entrance orientation and approach validation
 [Planned]  Rooms and buildings
 [Planned]  Roads and map connections
 [Planned]  Multi-level reusable templates and richer composition

--- a/Documentation/Modding/map_recipe_generator.md
+++ b/Documentation/Modding/map_recipe_generator.md
@@ -379,7 +379,7 @@ Boundary metadata preserves existing terrain, furniture, rotation, collision, an
 }
 ```
 
-Each record has required `id`, `rooms`, `footprint`, and `z`, plus optional `access_validation`, `interior_rooms`, `open_space_rooms`, `room_partition_validation`, `overhead_validation`, `exterior_context`, and `exterior_access_context`. `id` is unique; `rooms` is a nonempty list of unique known room IDs; `footprint` has exactly non-negative integer `x`/`y` plus positive integer `width`/`height`, fully inside the 32×32 map; and `z` is a required logical level from `-10` through `10`. Footprints on the same logical z must not overlap, though they may touch.
+Each record has required `id`, `rooms`, `footprint`, and `z`, plus optional `access_validation`, `interior_rooms`, `open_space_rooms`, `room_partition_validation`, `overhead_validation`, `exterior_context`, `exterior_access_context`, and `entrance`. `id` is unique; `rooms` is a nonempty list of unique known room IDs; `footprint` has exactly non-negative integer `x`/`y` plus positive integer `width`/`height`, fully inside the 32×32 map; and `z` is a required logical level from `-10` through `10`. Footprints on the same logical z must not overlap, though they may touch.
 
 Every owned room must have membership only at the building level and wholly inside its footprint. At least one owned room must be an `enclosed` room with `"boundary_validation": "complete"`. Its same-level `room_boundaries` and any same-level `room_connections` naming it must also lie inside the footprint. This makes the record a strict ownership/containment contract for already-authored physical evidence, not a claim that every footprint cell is occupied, roofed, or indoors.
 
@@ -439,7 +439,15 @@ A building may explicitly associate that external context with one existing sema
 
 `exterior_access_context` has exactly `connection`. It requires `exterior_context` and names an existing same-z `room_connections` record for one of the building’s owned rooms whose other endpoint is `exterior`. The association is explicit—it does not infer a physical route, coordinate adjacency, door rotation, collision, navigation, or player traversal between the context tile and the referenced door.
 
-`DMap` preserves building records through editor save/load and removes records whose room list, declared interior rooms, declared open-space rooms, malformed exterior context, or stale exterior-access connection becomes stale. The standalone validator performs strict shape, containment, same-level overlap, complete-enclosed-room, opted-in access, and authored interior/open-space/partition/overhead/exterior-context/exterior-access-context checks.
+A building may author one data-only entrance semantic with `entrance`:
+
+```json
+{"id": "office_building", "rooms": ["office", "garage_bay"], "footprint": {"x": 7, "y": 7, "width": 5, "height": 4}, "z": 0, "exterior_context": {"at": [6, 8], "z": 0}, "exterior_access_context": {"connection": "office_front_door"}, "entrance": {"connection": "office_front_door", "facing": "east"}}
+```
+
+`entrance` has exactly `connection` and `facing`. It requires `exterior_context` and names an existing same-z `room_connections` record for one of the building’s owned rooms whose other endpoint is `exterior`, following the same contract as `exterior_access_context.connection`. When `exterior_access_context` is also present, `entrance.connection` must match it. `facing` is one of `north`, `east`, `south`, or `west` and must point from `exterior_context.at` toward the building footprint: stepping one cell in the facing direction from the context coordinate must land inside the footprint. This validates authored entrance orientation only—it does not generate a door, infer a physical route, require coordinate adjacency between the context tile and the referenced door, or alter collision, navigation, lighting, weather, or runtime behavior.
+
+`DMap` preserves building records through editor save/load and removes records whose room list, declared interior rooms, declared open-space rooms, malformed exterior context, stale exterior-access connection, or stale entrance connection becomes stale. The standalone validator performs strict shape, containment, same-level overlap, complete-enclosed-room, opted-in access, and authored interior/open-space/partition/overhead/exterior-context/exterior-access-context/entrance checks.
 
 ### `building_surfaces`
 

--- a/Scripts/Gamedata/DMap.gd
+++ b/Scripts/Gamedata/DMap.gd
@@ -376,6 +376,17 @@ func _sanitize_buildings(data: Dictionary) -> void:
 			or building["exterior_access_context"]["connection"].is_empty() \
 			or building["exterior_access_context"]["connection"] not in valid_connection_ids:
 				return false
+		if building.has("entrance"):
+			if not building["entrance"] is Dictionary \
+			or not building["entrance"].has("connection") \
+			or not building["entrance"]["connection"] is String \
+			or building["entrance"]["connection"].is_empty() \
+			or building["entrance"]["connection"] not in valid_connection_ids \
+			or not building["entrance"].has("facing") \
+			or not building["entrance"]["facing"] is String \
+			or building["entrance"]["facing"] not in ["north", "east", "south", "west"] \
+			or not building.has("exterior_context"):
+				return false
 		return true
 	)
 	if data["buildings"].is_empty():

--- a/Tools/examples/map_recipe_building_surfaces.json
+++ b/Tools/examples/map_recipe_building_surfaces.json
@@ -20,7 +20,8 @@
 			"room_partition_validation": "complete",
 			"overhead_validation": "complete",
 			"exterior_context": {"at": [6, 8], "z": 0},
-			"exterior_access_context": {"connection": "office_front_door"}
+			"exterior_access_context": {"connection": "office_front_door"},
+			"entrance": {"connection": "office_front_door", "facing": "east"}
 		}
 	],
 	"building_surfaces": [

--- a/Tools/map_generator.py
+++ b/Tools/map_generator.py
@@ -78,10 +78,12 @@ ROOM_CONNECTION_ENDPOINT_FIELDS = {"kind", "id"}
 ROOM_CONNECTION_ENDPOINT_KINDS = {"room", "exterior"}
 ROOM_BOUNDARY_FIELDS = {"id", "room", "at", "z", "element", "side"}
 ROOM_BOUNDARY_ELEMENTS = {"wall_tile", "door_furniture"}
-BUILDING_FIELDS = {"id", "rooms", "footprint", "z", "access_validation", "interior_rooms", "open_space_rooms", "room_partition_validation", "overhead_validation", "exterior_context", "exterior_access_context"}
+BUILDING_FIELDS = {"id", "rooms", "footprint", "z", "access_validation", "interior_rooms", "open_space_rooms", "room_partition_validation", "overhead_validation", "exterior_context", "exterior_access_context", "entrance"}
 BUILDING_REQUIRED_FIELDS = {"id", "rooms", "footprint", "z"}
 BUILDING_EXTERIOR_CONTEXT_FIELDS = {"at", "z"}
 BUILDING_EXTERIOR_ACCESS_CONTEXT_FIELDS = {"connection"}
+BUILDING_ENTRANCE_FIELDS = {"connection", "facing"}
+BUILDING_ENTRANCE_FACINGS = {"north", "east", "south", "west"}
 BUILDING_ACCESS_VALIDATIONS = {"complete"}
 BUILDING_ROOM_PARTITION_VALIDATIONS = {"complete"}
 BUILDING_OVERHEAD_VALIDATIONS = {"complete"}
@@ -1171,6 +1173,22 @@ def _validate_recipe_buildings(
                 raise RecipeError(f"{context}.exterior_access_context must define connection")
             if exterior_context is None:
                 raise RecipeError(f"{context}.exterior_access_context requires exterior_context")
+        entrance = building.get("entrance")
+        if entrance is not None:
+            if (
+                not isinstance(entrance, dict)
+                or set(entrance) != BUILDING_ENTRANCE_FIELDS
+                or not isinstance(entrance["connection"], str)
+                or not entrance["connection"].strip()
+                or not isinstance(entrance["facing"], str)
+            ):
+                raise RecipeError(f"{context}.entrance must define connection and facing")
+            if entrance["facing"] not in BUILDING_ENTRANCE_FACINGS:
+                raise RecipeError(f"{context}.entrance.facing must be one of north, east, south, or west")
+            if exterior_context is None:
+                raise RecipeError(f"{context}.entrance requires exterior_context")
+            if exterior_access_context is not None and entrance["connection"] != exterior_access_context["connection"]:
+                raise RecipeError(f"{context}.entrance.connection must match exterior_access_context.connection")
         validated_building = {
             "id": building_id,
             "rooms": room_ids,
@@ -1191,6 +1209,8 @@ def _validate_recipe_buildings(
             validated_building["exterior_context"] = exterior_context
         if exterior_access_context is not None:
             validated_building["exterior_access_context"] = exterior_access_context
+        if entrance is not None:
+            validated_building["entrance"] = entrance
         validated.append(validated_building)
     return validated
 
@@ -1427,6 +1447,35 @@ def _validate_building_targets(
             ):
                 raise RecipeError(
                     f"{context}.exterior_access_context must reference a room-to-exterior connection owned by the building"
+                )
+        if building.get("entrance") is not None:
+            entrance = building["entrance"]
+            connection_id = entrance["connection"]
+            facing = entrance["facing"]
+            matching_connections = [connection for connection in room_connections if connection["id"] == connection_id]
+            if not matching_connections:
+                raise RecipeError(
+                    f"{context}.entrance references unknown room connection '{connection_id}'"
+                )
+            connection = matching_connections[0]
+            endpoints = (connection["from"], connection["to"])
+            named_rooms = [endpoint["id"] for endpoint in endpoints if endpoint["kind"] == "room"]
+            if (
+                connection["z"] != z
+                or not any(endpoint["kind"] == "exterior" for endpoint in endpoints)
+                or len(named_rooms) != 1
+                or named_rooms[0] not in building["rooms"]
+            ):
+                raise RecipeError(
+                    f"{context}.entrance must reference a room-to-exterior connection owned by the building"
+                )
+            context_x, context_y = building["exterior_context"]["at"]
+            delta_x, delta_y = CARDINAL_SIDES[facing]
+            facing_x = context_x + delta_x
+            facing_y = context_y + delta_y
+            if not _point_in_building_footprint(facing_x, facing_y, footprint):
+                raise RecipeError(
+                    f"{context}.entrance.facing '{facing}' does not point from exterior_context toward the building footprint"
                 )
         if building.get("overhead_validation") == "complete":
             surface_kinds = {

--- a/Tools/map_validator.py
+++ b/Tools/map_validator.py
@@ -21,10 +21,12 @@ ROOM_CONNECTION_FIELDS = {'id', 'at', 'z', 'from', 'to'}
 ROOM_CONNECTION_ENDPOINT_KINDS = {'room', 'exterior'}
 ROOM_BOUNDARY_FIELDS = {'id', 'room', 'at', 'z', 'element', 'side'}
 ROOM_BOUNDARY_ELEMENTS = {'wall_tile', 'door_furniture'}
-BUILDING_FIELDS = {'id', 'rooms', 'footprint', 'z', 'access_validation', 'interior_rooms', 'open_space_rooms', 'room_partition_validation', 'overhead_validation', 'exterior_context', 'exterior_access_context'}
+BUILDING_FIELDS = {'id', 'rooms', 'footprint', 'z', 'access_validation', 'interior_rooms', 'open_space_rooms', 'room_partition_validation', 'overhead_validation', 'exterior_context', 'exterior_access_context', 'entrance'}
 BUILDING_REQUIRED_FIELDS = {'id', 'rooms', 'footprint', 'z'}
 BUILDING_EXTERIOR_CONTEXT_FIELDS = {'at', 'z'}
 BUILDING_EXTERIOR_ACCESS_CONTEXT_FIELDS = {'connection'}
+BUILDING_ENTRANCE_FIELDS = {'connection', 'facing'}
+BUILDING_ENTRANCE_FACINGS = {'north', 'east', 'south', 'west'}
 BUILDING_ACCESS_VALIDATIONS = {'complete'}
 BUILDING_ROOM_PARTITION_VALIDATIONS = {'complete'}
 BUILDING_OVERHEAD_VALIDATIONS = {'complete'}
@@ -813,6 +815,27 @@ class MapValidator:
                     self.add_error(file_path, f"{context} exterior_access_context must define connection.")
                 if exterior_context is None:
                     self.add_error(file_path, f"{context} exterior_access_context requires exterior_context.")
+            entrance = building.get('entrance')
+            if entrance is not None:
+                if (
+                    not isinstance(entrance, dict)
+                    or set(entrance) != BUILDING_ENTRANCE_FIELDS
+                    or not isinstance(entrance.get('connection'), str)
+                    or not entrance.get('connection')
+                    or not isinstance(entrance.get('facing'), str)
+                ):
+                    self.add_error(file_path, f"{context} entrance must define connection and facing.")
+                elif entrance['facing'] not in BUILDING_ENTRANCE_FACINGS:
+                    self.add_error(file_path, f"{context} entrance.facing must be one of north, east, south, or west.")
+                if exterior_context is None:
+                    self.add_error(file_path, f"{context} entrance requires exterior_context.")
+                if (
+                    exterior_access_context is not None
+                    and isinstance(exterior_access_context, dict)
+                    and isinstance(entrance, dict)
+                    and entrance.get('connection') != exterior_access_context.get('connection')
+                ):
+                    self.add_error(file_path, f"{context} entrance.connection must match exterior_access_context.connection.")
             if (
                 isinstance(building_id, str) and building_id
                 and rooms_valid and footprint_valid and z_valid
@@ -891,6 +914,44 @@ class MapValidator:
                         or named_rooms[0] not in building['rooms']
                     ):
                         self.add_error(file_path, f"{context} exterior_access_context must reference a room-to-exterior connection owned by the building.")
+            if building.get('entrance') is not None and isinstance(building.get('entrance'), dict):
+                entrance = building['entrance']
+                connection_id = entrance.get('connection')
+                matching_connections = [
+                    connection for connection in validated_room_connections
+                    if connection.get('id') == connection_id
+                ]
+                if not matching_connections:
+                    self.add_error(file_path, f"{context} entrance references unknown room connection '{connection_id}'.")
+                else:
+                    connection = matching_connections[0]
+                    endpoints = (connection['from'], connection['to'])
+                    named_rooms = [endpoint['id'] for endpoint in endpoints if endpoint.get('kind') == 'room']
+                    if (
+                        connection['z'] != z
+                        or not any(endpoint.get('kind') == 'exterior' for endpoint in endpoints)
+                        or len(named_rooms) != 1
+                        or named_rooms[0] not in building['rooms']
+                    ):
+                        self.add_error(file_path, f"{context} entrance must reference a room-to-exterior connection owned by the building.")
+                facing = entrance.get('facing')
+                exterior_context = building.get('exterior_context')
+                if (
+                    facing in CARDINAL_SIDES
+                    and isinstance(exterior_context, dict)
+                    and isinstance(exterior_context.get('at'), list)
+                    and len(exterior_context['at']) == 2
+                    and all(type(value) is int for value in exterior_context['at'])
+                ):
+                    context_x, context_y = exterior_context['at']
+                    delta_x, delta_y = CARDINAL_SIDES[facing]
+                    facing_x = context_x + delta_x
+                    facing_y = context_y + delta_y
+                    if not (
+                        footprint['x'] <= facing_x < footprint['x'] + footprint['width']
+                        and footprint['y'] <= facing_y < footprint['y'] + footprint['height']
+                    ):
+                        self.add_error(file_path, f"{context} entrance.facing '{facing}' does not point from exterior_context toward the building footprint.")
             if building.get('exterior_context') is not None and isinstance(building.get('exterior_context'), dict):
                 exterior_context = building['exterior_context']
                 at = exterior_context.get('at')

--- a/Tools/tests/test_map_generator.py
+++ b/Tools/tests/test_map_generator.py
@@ -1683,6 +1683,7 @@ class MapGeneratorTests(unittest.TestCase):
             "overhead_validation": "complete",
             "exterior_context": {"at": [6, 8], "z": 0},
             "exterior_access_context": {"connection": "office_front_door"},
+            "entrance": {"connection": "office_front_door", "facing": "east"},
         }])
         self.assertEqual(generated["building_surfaces"], [
             {"id": "office_roof", "building": "office_building", "kind": "roof", "z": 1},
@@ -1752,12 +1753,14 @@ class MapGeneratorTests(unittest.TestCase):
         for access_context, message in invalid_cases:
             with self.subTest(access_context=access_context):
                 invalid_recipe = json.loads(recipe_path.read_text(encoding="utf-8"))
+                invalid_recipe["buildings"][0].pop("entrance", None)
                 invalid_recipe["buildings"][0]["exterior_context"] = {"at": [6, 8], "z": 0}
                 invalid_recipe["buildings"][0]["exterior_access_context"] = access_context
                 with self.assertRaisesRegex(RecipeError, message):
                     generate_map(invalid_recipe, TILES_PATH)
 
         no_exterior_context = json.loads(recipe_path.read_text(encoding="utf-8"))
+        no_exterior_context["buildings"][0].pop("entrance", None)
         no_exterior_context["buildings"][0].pop("exterior_context", None)
         no_exterior_context["buildings"][0]["exterior_access_context"] = {
             "connection": "office_front_door"
@@ -1766,6 +1769,7 @@ class MapGeneratorTests(unittest.TestCase):
             generate_map(no_exterior_context, TILES_PATH)
 
         non_exterior_connection = json.loads(recipe_path.read_text(encoding="utf-8"))
+        non_exterior_connection["buildings"][0].pop("entrance", None)
         non_exterior_connection["buildings"][0]["exterior_context"] = {"at": [6, 8], "z": 0}
         non_exterior_connection["room_connections"][0]["to"] = {"kind": "room", "id": "garage_bay"}
         non_exterior_connection["buildings"][0]["exterior_access_context"] = {
@@ -1773,6 +1777,57 @@ class MapGeneratorTests(unittest.TestCase):
         }
         with self.assertRaisesRegex(RecipeError, "must reference a room-to-exterior connection"):
             generate_map(non_exterior_connection, TILES_PATH)
+
+    def test_building_entrance_requires_owned_exterior_connection_and_facing(self):
+        recipe_path = ROOT / "Tools" / "examples" / "map_recipe_building_surfaces.json"
+        recipe = json.loads(recipe_path.read_text(encoding="utf-8"))
+        entrance = {"connection": "office_front_door", "facing": "east"}
+        recipe["buildings"][0]["exterior_context"] = {"at": [6, 8], "z": 0}
+        recipe["buildings"][0]["exterior_access_context"] = {"connection": "office_front_door"}
+        recipe["buildings"][0]["entrance"] = entrance
+
+        generated = generate_map(recipe, TILES_PATH)
+
+        self.assertEqual(generated["buildings"][0]["entrance"], entrance)
+
+        invalid_cases = [
+            ({}, "must define connection and facing"),
+            ({"connection": "office_front_door"}, "must define connection and facing"),
+            ({"connection": "office_front_door", "facing": "up"}, "facing must be one of north, east, south, or west"),
+            ({"connection": "missing", "facing": "east"}, "references unknown room connection 'missing'"),
+            ({"connection": "office_front_door", "facing": "north"}, "does not point from exterior_context toward the building footprint"),
+            ({"connection": "office_front_door", "facing": "east", "extra": True}, "must define connection and facing"),
+        ]
+        for entrance_value, message in invalid_cases:
+            with self.subTest(entrance=entrance_value):
+                invalid_recipe = json.loads(recipe_path.read_text(encoding="utf-8"))
+                invalid_recipe["buildings"][0].pop("exterior_access_context", None)
+                invalid_recipe["buildings"][0]["exterior_context"] = {"at": [6, 8], "z": 0}
+                invalid_recipe["buildings"][0]["entrance"] = entrance_value
+                with self.assertRaisesRegex(RecipeError, message):
+                    generate_map(invalid_recipe, TILES_PATH)
+
+        no_context = json.loads(recipe_path.read_text(encoding="utf-8"))
+        no_context["buildings"][0].pop("exterior_access_context", None)
+        no_context["buildings"][0].pop("exterior_context", None)
+        no_context["buildings"][0]["entrance"] = {"connection": "office_front_door", "facing": "east"}
+        with self.assertRaisesRegex(RecipeError, "entrance requires exterior_context"):
+            generate_map(no_context, TILES_PATH)
+
+        mismatch = json.loads(recipe_path.read_text(encoding="utf-8"))
+        mismatch["buildings"][0]["exterior_context"] = {"at": [6, 8], "z": 0}
+        mismatch["buildings"][0]["exterior_access_context"] = {"connection": "office_front_door"}
+        mismatch["buildings"][0]["entrance"] = {"connection": "garage_opening", "facing": "east"}
+        with self.assertRaisesRegex(RecipeError, "entrance.connection must match exterior_access_context.connection"):
+            generate_map(mismatch, TILES_PATH)
+
+        non_exterior = json.loads(recipe_path.read_text(encoding="utf-8"))
+        non_exterior["buildings"][0].pop("exterior_access_context", None)
+        non_exterior["buildings"][0]["exterior_context"] = {"at": [6, 8], "z": 0}
+        non_exterior["room_connections"][0]["to"] = {"kind": "room", "id": "garage_bay"}
+        non_exterior["buildings"][0]["entrance"] = {"connection": "office_front_door", "facing": "east"}
+        with self.assertRaisesRegex(RecipeError, "entrance must reference a room-to-exterior connection"):
+            generate_map(non_exterior, TILES_PATH)
 
     def test_complete_building_overhead_requires_roof_and_ceiling_classifications(self):
         recipe_path = ROOT / "Tools" / "examples" / "map_recipe_building_surfaces.json"
@@ -1892,6 +1947,7 @@ class MapGeneratorTests(unittest.TestCase):
         missing_exterior_route["buildings"][0]["rooms"] = ["office"]
         missing_exterior_route["buildings"][0].pop("open_space_rooms")
         missing_exterior_route["buildings"][0].pop("exterior_access_context", None)
+        missing_exterior_route["buildings"][0].pop("entrance", None)
         missing_exterior_route["room_connections"][0]["to"] = {"kind": "room", "id": "garage_bay"}
         with self.assertRaisesRegex(RecipeError, "room 'office' has no route to exterior"):
             generate_map(missing_exterior_route, TILES_PATH)
@@ -2701,6 +2757,40 @@ class MapValidatorDimensionTests(unittest.TestCase):
         no_exterior_context["buildings"][0].pop("exterior_context")
         errors = self.validate(no_exterior_context)
         self.assertTrue(any("requires exterior_context" in error for error in errors))
+
+    def test_validates_building_entrance_constraints(self):
+        recipe_path = ROOT / "Tools" / "examples" / "map_recipe_building_surfaces.json"
+        recipe = json.loads(recipe_path.read_text(encoding="utf-8"))
+        recipe["buildings"][0]["exterior_context"] = {"at": [6, 8], "z": 0}
+        recipe["buildings"][0]["exterior_access_context"] = {"connection": "office_front_door"}
+        recipe["buildings"][0]["entrance"] = {"connection": "office_front_door", "facing": "east"}
+        valid_map = generate_map(recipe, TILES_PATH)
+        self.assertEqual(self.validate(valid_map), [])
+
+        unknown_connection = json.loads(json.dumps(valid_map))
+        unknown_connection["buildings"][0]["entrance"] = {"connection": "missing", "facing": "east"}
+        errors = self.validate(unknown_connection)
+        self.assertTrue(any("entrance references unknown room connection 'missing'" in error for error in errors))
+
+        bad_facing = json.loads(json.dumps(valid_map))
+        bad_facing["buildings"][0]["entrance"] = {"connection": "office_front_door", "facing": "up"}
+        errors = self.validate(bad_facing)
+        self.assertTrue(any("entrance.facing must be one of north, east, south, or west" in error for error in errors))
+
+        wrong_facing = json.loads(json.dumps(valid_map))
+        wrong_facing["buildings"][0]["entrance"] = {"connection": "office_front_door", "facing": "north"}
+        errors = self.validate(wrong_facing)
+        self.assertTrue(any("does not point from exterior_context toward the building footprint" in error for error in errors))
+
+        no_context = json.loads(json.dumps(valid_map))
+        no_context["buildings"][0].pop("exterior_context")
+        errors = self.validate(no_context)
+        self.assertTrue(any("entrance requires exterior_context" in error for error in errors))
+
+        mismatch = json.loads(json.dumps(valid_map))
+        mismatch["buildings"][0]["exterior_access_context"] = {"connection": "garage_opening"}
+        errors = self.validate(mismatch)
+        self.assertTrue(any("entrance.connection must match exterior_access_context.connection" in error for error in errors))
 
     def test_validates_building_exterior_context_constraints(self):
         recipe_path = ROOT / "Tools" / "examples" / "map_recipe_building_surfaces.json"


### PR DESCRIPTION
## Add authored building-level entrance semantics

### Summary
Introduces an optional `entrance` field on building records that authors the semantic entrance orientation of a validated building footprint. This advances Phase 6 ("Areas, rooms, and buildings") of the map generation roadmap.

The field has exactly `connection` and `facing`:
- **`connection`** — names an existing same-z room-to-exterior connection owned by the building (the same contract as `exterior_access_context.connection`)
- **`facing`** — one of `north`, `east`, `south`, or `west`; must point from `exterior_context.at` toward the building footprint (stepping one cell in that direction from the context coordinate must land inside the footprint)

It requires `exterior_context`, and when `exterior_access_context` is also present, `entrance.connection` must match it. This is a data-only semantic assertion — it does not generate a door, infer a physical route, require coordinate adjacency between the context tile and the referenced door, or alter collision, navigation, lighting, weather, or runtime behavior.

### Changed files
- `Tools/map_generator.py` — constants, shape validation, cross-checks, serialization
- `Tools/map_validator.py` — matching constants, shape checks, cross-reference checks
- `Scripts/Gamedata/DMap.gd` — entrance sanitization (drops buildings with stale/malformed entrance connections or missing exterior_context)
- `Tools/examples/map_recipe_building_surfaces.json` — maintained building now authors `office_front_door` facing `east`
- `Tools/tests/test_map_generator.py` — 2 new tests (generator + validator), 3 existing tests updated
- `Documentation/Modding/map_recipe_generator.md` — entrance field contract documented
- `Documentation/Game_design/Map_generation_plan.md` — Phase 6 deliverables, recommended next task, and one-view summary updated

### Validation
- 113 Python tests pass (111 original + 2 new), 0 failures
- All 11 maintained example recipes generate and validate cleanly through the full pipeline
- 7 GUT DMap sanitization tests pass (16 assertions)
- `git diff --check` clean