### PR TITLE
Add entrance orientation and approach validation

### DIFF
--- a/Documentation/Game_design/Map_generation_plan.md
+++ b/Documentation/Game_design/Map_generation_plan.md
@@ -645,6 +645,8 @@ An opted-in `overhead_validation: "complete"` requires that the validated buildi
 
 `entrance` now authors one data-only building-level entrance semantic. Each record has exactly `connection` and `facing`: `connection` names an existing same-z room-to-exterior connection owned by the building (the same contract as `exterior_access_context.connection`), and `facing` is one of `north`, `east`, `south`, or `west`. It requires `exterior_context` and, when `exterior_access_context` is also present, `entrance.connection` must match it. The `facing` direction must point from `exterior_context.at` toward the building footprint: stepping one cell in that direction from the context coordinate must land inside the footprint. The maintained building authors `office_front_door` facing `east`, matching its west-of-footprint exterior context. This validates authored entrance orientation only: it does not generate a door, infer a physical route, require coordinate adjacency between the context tile and the referenced door, or alter collision, navigation, lighting, weather, or runtime behavior.
 
+`entrance_validation: "complete"` now opts a building into complete entrance orientation and approach validation. It requires `entrance` and then checks two authored constraints. First, the `room_boundaries` record with `element: "door_furniture"` at the entrance connection's `at` and `z`, naming a building-owned room, must have a `side` equal to the opposite of `entrance.facing`—the door opens toward the approaching direction. Second, `exterior_context.at` and the entrance connection's `at` must both fall within the footprint's perpendicular range, ensuring the approach path runs along the correct building side. The maintained building opts in; its `office_southwest_door` boundary at `[8, 9]` with `side: "west"` matches `entrance.facing: "east"`, and both the context Y (8) and door Y (9) fall within the footprint height (7–10). This validates authored orientation and alignment only: it does not generate or modify geometry, infer a walkable path, check collision or navigation, or alter runtime behavior.
+
 This foundation intentionally does **not** yet define polygons, topology-derived room boundaries, indoor/outdoor runtime behavior, wall/roof generation, multi-level building records, furniture anchors, or generalized templates.
 
 Capabilities:
@@ -880,7 +882,7 @@ An agent can create a new playable, potentially multi-level map from a concise d
 
 # Recommended immediate next task
 
-**Phase 6 is in progress.** Its runtime-compatible area foundation, catalog-validated per-instance entity variation, authored room semantics, explicit door-link metadata, partial physical boundary references, opt-in enclosed-room completeness validation, first single-level authored footprint, narrow authored roof/ceiling metadata, opt-in building-level composition constraints, authored building access-completeness validation, authored interior classification constraints, authored exterior/open-space classification constraints, validated building-level room partition constraints, validated building overhead-classification constraints, authored external footprint context, validated exterior-access context, and authored building-level entrance semantics are complete. The next contribution should extend validated building content carefully without introducing multi-level structures or generalized templates.
+**Phase 6 is in progress.** Its runtime-compatible area foundation, catalog-validated per-instance entity variation, authored room semantics, explicit door-link metadata, partial physical boundary references, opt-in enclosed-room completeness validation, first single-level authored footprint, narrow authored roof/ceiling metadata, opt-in building-level composition constraints, authored building access-completeness validation, authored interior classification constraints, authored exterior/open-space classification constraints, validated building-level room partition constraints, validated building overhead-classification constraints, authored external footprint context, validated exterior-access context, authored building-level entrance semantics, and validated building-level entrance orientation and approach alignment are complete. The next contribution should extend validated building content carefully without introducing multi-level structures or generalized templates.
 
 Do not yet generate walls, doors, roofs, multi-level building footprints, furniture anchors, roads, towns, or generalized building templates. Preserve the established map-level `areas` plus per-tile area membership representation, keep room semantics independent from runtime areas, and validate any physical semantics in the editor and runtime.
 
@@ -932,7 +934,8 @@ Do not commit or push unless explicitly requested.
 [Complete] Authored building-level external footprint context constraints
 [Complete] Validated building-level exterior-access context constraints
 [Complete] Authored building-level entrance semantics constraints
-[Next]     Authored building-level entrance orientation and approach validation
+[Complete] Validated building-level entrance orientation and approach alignment
+[Next]     Authored multi-entrance buildings or furniture anchor metadata
 [Planned]  Rooms and buildings
 [Planned]  Roads and map connections
 [Planned]  Multi-level reusable templates and richer composition

--- a/Documentation/Modding/map_recipe_generator.md
+++ b/Documentation/Modding/map_recipe_generator.md
@@ -379,7 +379,7 @@ Boundary metadata preserves existing terrain, furniture, rotation, collision, an
 }
 ```
 
-Each record has required `id`, `rooms`, `footprint`, and `z`, plus optional `access_validation`, `interior_rooms`, `open_space_rooms`, `room_partition_validation`, `overhead_validation`, `exterior_context`, `exterior_access_context`, and `entrance`. `id` is unique; `rooms` is a nonempty list of unique known room IDs; `footprint` has exactly non-negative integer `x`/`y` plus positive integer `width`/`height`, fully inside the 32×32 map; and `z` is a required logical level from `-10` through `10`. Footprints on the same logical z must not overlap, though they may touch.
+Each record has required `id`, `rooms`, `footprint`, and `z`, plus optional `access_validation`, `interior_rooms`, `open_space_rooms`, `room_partition_validation`, `overhead_validation`, `exterior_context`, `exterior_access_context`, `entrance`, and `entrance_validation`. `id` is unique; `rooms` is a nonempty list of unique known room IDs; `footprint` has exactly non-negative integer `x`/`y` plus positive integer `width`/`height`, fully inside the 32×32 map; and `z` is a required logical level from `-10` through `10`. Footprints on the same logical z must not overlap, though they may touch.
 
 Every owned room must have membership only at the building level and wholly inside its footprint. At least one owned room must be an `enclosed` room with `"boundary_validation": "complete"`. Its same-level `room_boundaries` and any same-level `room_connections` naming it must also lie inside the footprint. This makes the record a strict ownership/containment contract for already-authored physical evidence, not a claim that every footprint cell is occupied, roofed, or indoors.
 
@@ -447,7 +447,20 @@ A building may author one data-only entrance semantic with `entrance`:
 
 `entrance` has exactly `connection` and `facing`. It requires `exterior_context` and names an existing same-z `room_connections` record for one of the building’s owned rooms whose other endpoint is `exterior`, following the same contract as `exterior_access_context.connection`. When `exterior_access_context` is also present, `entrance.connection` must match it. `facing` is one of `north`, `east`, `south`, or `west` and must point from `exterior_context.at` toward the building footprint: stepping one cell in the facing direction from the context coordinate must land inside the footprint. This validates authored entrance orientation only—it does not generate a door, infer a physical route, require coordinate adjacency between the context tile and the referenced door, or alter collision, navigation, lighting, weather, or runtime behavior.
 
-`DMap` preserves building records through editor save/load and removes records whose room list, declared interior rooms, declared open-space rooms, malformed exterior context, stale exterior-access connection, or stale entrance connection becomes stale. The standalone validator performs strict shape, containment, same-level overlap, complete-enclosed-room, opted-in access, and authored interior/open-space/partition/overhead/exterior-context/exterior-access-context/entrance checks.
+A building may opt into complete entrance orientation and approach validation with `entrance_validation: "complete"`:
+
+```json
+{"id": "office_building", "rooms": ["office", "garage_bay"], "footprint": {"x": 7, "y": 7, "width": 5, "height": 4}, "z": 0, "exterior_context": {"at": [6, 8], "z": 0}, "exterior_access_context": {"connection": "office_front_door"}, "entrance": {"connection": "office_front_door", "facing": "east"}, "entrance_validation": "complete"}
+```
+
+For an opted-in building, `entrance_validation` requires `entrance` and then checks two authored constraints:
+
+1. **Door orientation**: the `room_boundaries` record with `element: "door_furniture"` at the entrance connection's `at` and `z`, naming a building-owned room, must have a `side` equal to `OPPOSITE_SIDES[facing]`—the door opens toward the approaching direction. A missing door boundary, missing `side`, or wrong-facing door is rejected.
+2. **Approach alignment**: `exterior_context.at` and the entrance connection's `at` must both fall within the footprint's perpendicular range. For `east`/`west` facing, both Y values must be within the footprint height; for `north`/`south` facing, both X values must be within the footprint width. This ensures the approach path from the context tile to the door runs along the correct building side.
+
+This validates authored orientation and alignment only: it does not generate or modify geometry, infer a walkable path, check collision or navigation, require the context tile and door to be cardinally adjacent, or alter runtime behavior.
+
+`DMap` preserves building records through editor save/load and removes records whose room list, declared interior rooms, declared open-space rooms, malformed exterior context, stale exterior-access connection, stale entrance connection, or malformed entrance validation becomes stale. The standalone validator performs strict shape, containment, same-level overlap, complete-enclosed-room, opted-in access, and authored interior/open-space/partition/overhead/exterior-context/exterior-access-context/entrance/entrance-validation checks.
 
 ### `building_surfaces`
 

--- a/Scripts/Gamedata/DMap.gd
+++ b/Scripts/Gamedata/DMap.gd
@@ -387,6 +387,11 @@ func _sanitize_buildings(data: Dictionary) -> void:
 			or building["entrance"]["facing"] not in ["north", "east", "south", "west"] \
 			or not building.has("exterior_context"):
 				return false
+		if building.has("entrance_validation"):
+			if not building["entrance_validation"] is String \
+			or building["entrance_validation"] != "complete" \
+			or not building.has("entrance"):
+				return false
 		return true
 	)
 	if data["buildings"].is_empty():

--- a/Tools/examples/map_recipe_building_surfaces.json
+++ b/Tools/examples/map_recipe_building_surfaces.json
@@ -21,7 +21,8 @@
 			"overhead_validation": "complete",
 			"exterior_context": {"at": [6, 8], "z": 0},
 			"exterior_access_context": {"connection": "office_front_door"},
-			"entrance": {"connection": "office_front_door", "facing": "east"}
+			"entrance": {"connection": "office_front_door", "facing": "east"},
+		"entrance_validation": "complete"
 		}
 	],
 	"building_surfaces": [

--- a/Tools/map_generator.py
+++ b/Tools/map_generator.py
@@ -78,12 +78,13 @@ ROOM_CONNECTION_ENDPOINT_FIELDS = {"kind", "id"}
 ROOM_CONNECTION_ENDPOINT_KINDS = {"room", "exterior"}
 ROOM_BOUNDARY_FIELDS = {"id", "room", "at", "z", "element", "side"}
 ROOM_BOUNDARY_ELEMENTS = {"wall_tile", "door_furniture"}
-BUILDING_FIELDS = {"id", "rooms", "footprint", "z", "access_validation", "interior_rooms", "open_space_rooms", "room_partition_validation", "overhead_validation", "exterior_context", "exterior_access_context", "entrance"}
+BUILDING_FIELDS = {"id", "rooms", "footprint", "z", "access_validation", "interior_rooms", "open_space_rooms", "room_partition_validation", "overhead_validation", "exterior_context", "exterior_access_context", "entrance", "entrance_validation"}
 BUILDING_REQUIRED_FIELDS = {"id", "rooms", "footprint", "z"}
 BUILDING_EXTERIOR_CONTEXT_FIELDS = {"at", "z"}
 BUILDING_EXTERIOR_ACCESS_CONTEXT_FIELDS = {"connection"}
 BUILDING_ENTRANCE_FIELDS = {"connection", "facing"}
 BUILDING_ENTRANCE_FACINGS = {"north", "east", "south", "west"}
+BUILDING_ENTRANCE_VALIDATIONS = {"complete"}
 BUILDING_ACCESS_VALIDATIONS = {"complete"}
 BUILDING_ROOM_PARTITION_VALIDATIONS = {"complete"}
 BUILDING_OVERHEAD_VALIDATIONS = {"complete"}
@@ -1189,6 +1190,13 @@ def _validate_recipe_buildings(
                 raise RecipeError(f"{context}.entrance requires exterior_context")
             if exterior_access_context is not None and entrance["connection"] != exterior_access_context["connection"]:
                 raise RecipeError(f"{context}.entrance.connection must match exterior_access_context.connection")
+        entrance_validation = building.get("entrance_validation")
+        if entrance_validation is not None and entrance_validation not in BUILDING_ENTRANCE_VALIDATIONS:
+            raise RecipeError(
+                f"{context}.entrance_validation has unsupported validation '{entrance_validation}'"
+            )
+        if entrance_validation is not None and entrance is None:
+            raise RecipeError(f"{context}.entrance_validation requires entrance")
         validated_building = {
             "id": building_id,
             "rooms": room_ids,
@@ -1211,6 +1219,8 @@ def _validate_recipe_buildings(
             validated_building["exterior_access_context"] = exterior_access_context
         if entrance is not None:
             validated_building["entrance"] = entrance
+        if entrance_validation is not None:
+            validated_building["entrance_validation"] = entrance_validation
         validated.append(validated_building)
     return validated
 
@@ -1477,6 +1487,47 @@ def _validate_building_targets(
                 raise RecipeError(
                     f"{context}.entrance.facing '{facing}' does not point from exterior_context toward the building footprint"
                 )
+        if building.get("entrance_validation") == "complete":
+            entrance = building["entrance"]
+            facing = entrance["facing"]
+            connection_id = entrance["connection"]
+            connection = next(conn for conn in room_connections if conn["id"] == connection_id)
+            door_x, door_y = connection["at"]
+            door_boundary = None
+            for boundary in room_boundaries:
+                if (
+                    boundary["at"] == [door_x, door_y]
+                    and boundary["z"] == z
+                    and boundary["element"] == "door_furniture"
+                    and boundary["room"] in building["rooms"]
+                ):
+                    door_boundary = boundary
+                    break
+            if door_boundary is None:
+                raise RecipeError(
+                    f"{context}.entrance_validation requires a door_furniture boundary at the entrance connection"
+                )
+            if door_boundary.get("side") is None:
+                raise RecipeError(
+                    f"{context}.entrance_validation requires a side on the door_furniture boundary"
+                )
+            if door_boundary["side"] != OPPOSITE_SIDES[facing]:
+                raise RecipeError(
+                    f"{context}.entrance_validation door side '{door_boundary['side']}' must face '{OPPOSITE_SIDES[facing]}'"
+                )
+            context_x, context_y = building["exterior_context"]["at"]
+            if facing in ("east", "west"):
+                if not (footprint["y"] <= context_y < footprint["y"] + footprint["height"]
+                        and footprint["y"] <= door_y < footprint["y"] + footprint["height"]):
+                    raise RecipeError(
+                        f"{context}.entrance_validation requires exterior_context and entrance door aligned within the footprint height"
+                    )
+            else:
+                if not (footprint["x"] <= context_x < footprint["x"] + footprint["width"]
+                        and footprint["x"] <= door_x < footprint["x"] + footprint["width"]):
+                    raise RecipeError(
+                        f"{context}.entrance_validation requires exterior_context and entrance door aligned within the footprint width"
+                    )
         if building.get("overhead_validation") == "complete":
             surface_kinds = {
                 surface["kind"]

--- a/Tools/map_validator.py
+++ b/Tools/map_validator.py
@@ -21,12 +21,13 @@ ROOM_CONNECTION_FIELDS = {'id', 'at', 'z', 'from', 'to'}
 ROOM_CONNECTION_ENDPOINT_KINDS = {'room', 'exterior'}
 ROOM_BOUNDARY_FIELDS = {'id', 'room', 'at', 'z', 'element', 'side'}
 ROOM_BOUNDARY_ELEMENTS = {'wall_tile', 'door_furniture'}
-BUILDING_FIELDS = {'id', 'rooms', 'footprint', 'z', 'access_validation', 'interior_rooms', 'open_space_rooms', 'room_partition_validation', 'overhead_validation', 'exterior_context', 'exterior_access_context', 'entrance'}
+BUILDING_FIELDS = {'id', 'rooms', 'footprint', 'z', 'access_validation', 'interior_rooms', 'open_space_rooms', 'room_partition_validation', 'overhead_validation', 'exterior_context', 'exterior_access_context', 'entrance', 'entrance_validation'}
 BUILDING_REQUIRED_FIELDS = {'id', 'rooms', 'footprint', 'z'}
 BUILDING_EXTERIOR_CONTEXT_FIELDS = {'at', 'z'}
 BUILDING_EXTERIOR_ACCESS_CONTEXT_FIELDS = {'connection'}
 BUILDING_ENTRANCE_FIELDS = {'connection', 'facing'}
 BUILDING_ENTRANCE_FACINGS = {'north', 'east', 'south', 'west'}
+BUILDING_ENTRANCE_VALIDATIONS = {'complete'}
 BUILDING_ACCESS_VALIDATIONS = {'complete'}
 BUILDING_ROOM_PARTITION_VALIDATIONS = {'complete'}
 BUILDING_OVERHEAD_VALIDATIONS = {'complete'}
@@ -836,6 +837,12 @@ class MapValidator:
                     and entrance.get('connection') != exterior_access_context.get('connection')
                 ):
                     self.add_error(file_path, f"{context} entrance.connection must match exterior_access_context.connection.")
+            entrance_validation = building.get('entrance_validation')
+            if entrance_validation is not None:
+                if entrance_validation not in BUILDING_ENTRANCE_VALIDATIONS:
+                    self.add_error(file_path, f"{context} entrance_validation has unsupported validation '{entrance_validation}'.")
+                if entrance is None:
+                    self.add_error(file_path, f"{context} entrance_validation requires entrance.")
             if (
                 isinstance(building_id, str) and building_id
                 and rooms_valid and footprint_valid and z_valid
@@ -952,6 +959,49 @@ class MapValidator:
                         and footprint['y'] <= facing_y < footprint['y'] + footprint['height']
                     ):
                         self.add_error(file_path, f"{context} entrance.facing '{facing}' does not point from exterior_context toward the building footprint.")
+                if building.get('entrance_validation') == 'complete' and isinstance(entrance, dict):
+                    entrance_facing = entrance.get('facing')
+                    entrance_connection_id = entrance.get('connection')
+                    matching_entrance_connections = [
+                        conn for conn in validated_room_connections
+                        if conn.get('id') == entrance_connection_id
+                    ]
+                    if matching_entrance_connections:
+                        entrance_connection = matching_entrance_connections[0]
+                        door_x, door_y = entrance_connection['at']
+                        door_boundary = None
+                        for boundary in validated_room_boundaries:
+                            if (
+                                boundary['at'] == [door_x, door_y]
+                                and boundary['z'] == z
+                                and boundary['element'] == 'door_furniture'
+                                and boundary['room'] in building['rooms']
+                            ):
+                                door_boundary = boundary
+                                break
+                        if door_boundary is None:
+                            self.add_error(file_path, f"{context} entrance_validation requires a door_furniture boundary at the entrance connection.")
+                        else:
+                            if door_boundary.get('side') is None:
+                                self.add_error(file_path, f"{context} entrance_validation requires a side on the door_furniture boundary.")
+                            elif entrance_facing in OPPOSITE_SIDES and door_boundary['side'] != OPPOSITE_SIDES[entrance_facing]:
+                                self.add_error(file_path, f"{context} entrance_validation door side '{door_boundary['side']}' must face '{OPPOSITE_SIDES[entrance_facing]}'.")
+                        ext_ctx = building.get('exterior_context')
+                        if (
+                            isinstance(ext_ctx, dict)
+                            and isinstance(ext_ctx.get('at'), list)
+                            and len(ext_ctx['at']) == 2
+                            and all(type(value) is int for value in ext_ctx['at'])
+                        ):
+                            ctx_x, ctx_y = ext_ctx['at']
+                            if entrance_facing in ('east', 'west'):
+                                if not (footprint['y'] <= ctx_y < footprint['y'] + footprint['height']
+                                        and footprint['y'] <= door_y < footprint['y'] + footprint['height']):
+                                    self.add_error(file_path, f"{context} entrance_validation requires exterior_context and entrance door aligned within the footprint height.")
+                            elif entrance_facing in ('north', 'south'):
+                                if not (footprint['x'] <= ctx_x < footprint['x'] + footprint['width']
+                                        and footprint['x'] <= door_x < footprint['x'] + footprint['width']):
+                                    self.add_error(file_path, f"{context} entrance_validation requires exterior_context and entrance door aligned within the footprint width.")
             if building.get('exterior_context') is not None and isinstance(building.get('exterior_context'), dict):
                 exterior_context = building['exterior_context']
                 at = exterior_context.get('at')

--- a/Tools/tests/test_map_generator.py
+++ b/Tools/tests/test_map_generator.py
@@ -1684,6 +1684,7 @@ class MapGeneratorTests(unittest.TestCase):
             "exterior_context": {"at": [6, 8], "z": 0},
             "exterior_access_context": {"connection": "office_front_door"},
             "entrance": {"connection": "office_front_door", "facing": "east"},
+            "entrance_validation": "complete",
         }])
         self.assertEqual(generated["building_surfaces"], [
             {"id": "office_roof", "building": "office_building", "kind": "roof", "z": 1},
@@ -1754,6 +1755,7 @@ class MapGeneratorTests(unittest.TestCase):
             with self.subTest(access_context=access_context):
                 invalid_recipe = json.loads(recipe_path.read_text(encoding="utf-8"))
                 invalid_recipe["buildings"][0].pop("entrance", None)
+                invalid_recipe["buildings"][0].pop("entrance_validation", None)
                 invalid_recipe["buildings"][0]["exterior_context"] = {"at": [6, 8], "z": 0}
                 invalid_recipe["buildings"][0]["exterior_access_context"] = access_context
                 with self.assertRaisesRegex(RecipeError, message):
@@ -1761,6 +1763,7 @@ class MapGeneratorTests(unittest.TestCase):
 
         no_exterior_context = json.loads(recipe_path.read_text(encoding="utf-8"))
         no_exterior_context["buildings"][0].pop("entrance", None)
+        no_exterior_context["buildings"][0].pop("entrance_validation", None)
         no_exterior_context["buildings"][0].pop("exterior_context", None)
         no_exterior_context["buildings"][0]["exterior_access_context"] = {
             "connection": "office_front_door"
@@ -1770,6 +1773,7 @@ class MapGeneratorTests(unittest.TestCase):
 
         non_exterior_connection = json.loads(recipe_path.read_text(encoding="utf-8"))
         non_exterior_connection["buildings"][0].pop("entrance", None)
+        non_exterior_connection["buildings"][0].pop("entrance_validation", None)
         non_exterior_connection["buildings"][0]["exterior_context"] = {"at": [6, 8], "z": 0}
         non_exterior_connection["room_connections"][0]["to"] = {"kind": "room", "id": "garage_bay"}
         non_exterior_connection["buildings"][0]["exterior_access_context"] = {
@@ -1828,6 +1832,35 @@ class MapGeneratorTests(unittest.TestCase):
         non_exterior["buildings"][0]["entrance"] = {"connection": "office_front_door", "facing": "east"}
         with self.assertRaisesRegex(RecipeError, "entrance must reference a room-to-exterior connection"):
             generate_map(non_exterior, TILES_PATH)
+
+    def test_building_entrance_validation_requires_oriented_door_and_alignment(self):
+        recipe_path = ROOT / "Tools" / "examples" / "map_recipe_building_surfaces.json"
+        recipe = json.loads(recipe_path.read_text(encoding="utf-8"))
+        recipe["buildings"][0]["entrance_validation"] = "complete"
+
+        generated = generate_map(recipe, TILES_PATH)
+        self.assertEqual(generated["buildings"][0]["entrance_validation"], "complete")
+
+        no_entrance = json.loads(recipe_path.read_text(encoding="utf-8"))
+        no_entrance["buildings"][0].pop("entrance", None)
+        no_entrance["buildings"][0]["entrance_validation"] = "complete"
+        with self.assertRaisesRegex(RecipeError, "entrance_validation requires entrance"):
+            generate_map(no_entrance, TILES_PATH)
+
+        bad_validation = json.loads(recipe_path.read_text(encoding="utf-8"))
+        bad_validation["buildings"][0]["entrance_validation"] = "partial"
+        with self.assertRaisesRegex(RecipeError, "entrance_validation has unsupported validation 'partial'"):
+            generate_map(bad_validation, TILES_PATH)
+
+        no_boundary = json.loads(recipe_path.read_text(encoding="utf-8"))
+        no_boundary["buildings"][0].pop("entrance", None)
+        no_boundary["buildings"][0].pop("entrance_validation", None)
+        no_boundary["buildings"][0].pop("exterior_access_context", None)
+        no_boundary["buildings"][0]["exterior_context"] = {"at": [6, 8], "z": 0}
+        no_boundary["buildings"][0]["entrance"] = {"connection": "garage_opening", "facing": "east"}
+        no_boundary["buildings"][0]["entrance_validation"] = "complete"
+        with self.assertRaisesRegex(RecipeError, "entrance_validation requires a door_furniture boundary at the entrance connection"):
+            generate_map(no_boundary, TILES_PATH)
 
     def test_complete_building_overhead_requires_roof_and_ceiling_classifications(self):
         recipe_path = ROOT / "Tools" / "examples" / "map_recipe_building_surfaces.json"
@@ -1948,6 +1981,7 @@ class MapGeneratorTests(unittest.TestCase):
         missing_exterior_route["buildings"][0].pop("open_space_rooms")
         missing_exterior_route["buildings"][0].pop("exterior_access_context", None)
         missing_exterior_route["buildings"][0].pop("entrance", None)
+        missing_exterior_route["buildings"][0].pop("entrance_validation", None)
         missing_exterior_route["room_connections"][0]["to"] = {"kind": "room", "id": "garage_bay"}
         with self.assertRaisesRegex(RecipeError, "room 'office' has no route to exterior"):
             generate_map(missing_exterior_route, TILES_PATH)
@@ -2791,6 +2825,33 @@ class MapValidatorDimensionTests(unittest.TestCase):
         mismatch["buildings"][0]["exterior_access_context"] = {"connection": "garage_opening"}
         errors = self.validate(mismatch)
         self.assertTrue(any("entrance.connection must match exterior_access_context.connection" in error for error in errors))
+
+    def test_validates_building_entrance_validation_constraints(self):
+        recipe_path = ROOT / "Tools" / "examples" / "map_recipe_building_surfaces.json"
+        recipe = json.loads(recipe_path.read_text(encoding="utf-8"))
+        recipe["buildings"][0]["entrance_validation"] = "complete"
+        valid_map = generate_map(recipe, TILES_PATH)
+        self.assertEqual(self.validate(valid_map), [])
+
+        bad_validation = json.loads(json.dumps(valid_map))
+        bad_validation["buildings"][0]["entrance_validation"] = "partial"
+        errors = self.validate(bad_validation)
+        self.assertTrue(any("entrance_validation has unsupported validation 'partial'" in error for error in errors))
+
+        no_entrance = json.loads(json.dumps(valid_map))
+        no_entrance["buildings"][0].pop("entrance")
+        errors = self.validate(no_entrance)
+        self.assertTrue(any("entrance_validation requires entrance" in error for error in errors))
+
+        wrong_side = json.loads(json.dumps(valid_map))
+        wrong_side["room_boundaries"][7]["side"] = "east"
+        errors = self.validate(wrong_side)
+        self.assertTrue(any("entrance_validation door side 'east' must face 'west'" in error for error in errors))
+
+        no_boundary = json.loads(json.dumps(valid_map))
+        no_boundary["room_boundaries"] = no_boundary["room_boundaries"][:7]
+        errors = self.validate(no_boundary)
+        self.assertTrue(any("entrance_validation requires a door_furniture boundary at the entrance connection" in error for error in errors))
 
     def test_validates_building_exterior_context_constraints(self):
         recipe_path = ROOT / "Tools" / "examples" / "map_recipe_building_surfaces.json"


### PR DESCRIPTION
## Add entrance orientation and approach validation

### Summary
Introduces an optional `entrance_validation` field on building records that opts a building into complete entrance orientation and approach alignment validation. This advances Phase 6 ("Areas, rooms, and buildings") of the map generation roadmap.

When set to `"complete"`, `entrance_validation` requires `entrance` and checks two authored constraints:

1. **Door orientation** — the `room_boundaries` record with `element: "door_furniture"` at the entrance connection's `at` and `z`, naming a building-owned room, must have a `side` equal to `OPPOSITE_SIDES[facing]`. The door opens toward the approaching direction. A missing door boundary, missing `side`, or wrong-facing door is rejected.

2. **Approach alignment** — `exterior_context.at` and the entrance connection's `at` must both fall within the footprint's perpendicular range. For east/west facing, both Y values must be within the footprint height; for north/south facing, both X values must be within the footprint width.

This is a data-only semantic assertion — it does not generate or modify geometry, infer a walkable path, check collision or navigation, or alter runtime behavior.

### Changed files
- `Tools/map_generator.py` — `BUILDING_ENTRANCE_VALIDATIONS` constant, shape validation, cross-checks (door boundary side + approach alignment), serialization
- `Tools/map_validator.py` — matching constant, shape check, cross-reference checks
- `Scripts/Gamedata/DMap.gd` — entrance_validation sanitization (drops buildings with malformed validation or missing entrance)
- `Tools/examples/map_recipe_building_surfaces.json` — maintained building now opts in
- `Tools/tests/test_map_generator.py` — 2 new tests (generator + validator), 4 existing tests updated
- `Documentation/Modding/map_recipe_generator.md` — entrance_validation contract documented
- `Documentation/Game_design/Map_generation_plan.md` — Phase 6 deliverables, recommended next task, one-view summary updated

### Validation
- 115 Python tests pass (113 previous + 2 new), 0 failures
- All 11 maintained example recipes generate and validate cleanly through the full pipeline
- 7 GUT DMap sanitization tests pass (16 assertions)
- `git diff --check` clean