### PR TITLE
Add authored map-edge connection metadata

### DIFF
--- a/Documentation/Game_design/Map_generation_plan.md
+++ b/Documentation/Game_design/Map_generation_plan.md
@@ -703,9 +703,15 @@ Generate one small, enterable building that loads correctly and has a reachable 
 
 ## Phase 7 — Roads and map connections
 
-**Status: planned**
+**Status: in progress; authored map-edge connection metadata complete**
 
-The prototype currently puts placeholder connection values in the output. These need to become meaningful.
+The prototype previously hardcoded all four edge connections as `"ground"`. These now become authored recipe-level metadata.
+
+### Completed foundation
+
+The recipe generator now supports a root-level `connections` field. It accepts up to four keys — `north`, `east`, `south`, and `west` — each with a value of `ground` or `road`, matching the existing runtime map format. Omitted directions default to `ground`, so existing recipes without the field remain compatible. The generator validates unknown directions and unsupported connection types and outputs the complete four-direction dictionary. The standalone validator independently checks the same content: it rejects unknown directions and non-`ground`/`road` values. `Tools/examples/map_recipe_road_connections.json` is the maintained evidence: a simple outdoor map with roads entering from east and west.
+
+This foundation authors metadata only: it does not generate road tiles, path routing, or edge tile placement. It declares what the runtime should expect at each edge so the overworld generator can connect adjacent maps correctly.
 
 Capabilities:
 
@@ -886,7 +892,7 @@ An agent can create a new playable, potentially multi-level map from a concise d
 
 # Recommended immediate next task
 
-**Phase 6 is in progress.** Its runtime-compatible area foundation, catalog-validated per-instance entity variation, authored room semantics, explicit door-link metadata, partial physical boundary references, opt-in enclosed-room completeness validation, first single-level authored footprint, narrow authored roof/ceiling metadata, opt-in building-level composition constraints, authored building access-completeness validation, authored interior classification constraints, authored exterior/open-space classification constraints, validated building-level room partition constraints, validated building overhead-classification constraints, authored external footprint context, validated exterior-access context, authored building-level entrance semantics, validated building-level entrance orientation and approach alignment, authored multi-entrance building semantics with per-entrance validation, and authored furniture anchor metadata are complete. The next contribution should extend validated building content carefully without introducing multi-level structures or generalized templates.
+**Phase 6 is in progress.** Its runtime-compatible area foundation, catalog-validated per-instance entity variation, authored room semantics, explicit door-link metadata, partial physical boundary references, opt-in enclosed-room completeness validation, first single-level authored footprint, narrow authored roof/ceiling metadata, opt-in building-level composition constraints, authored building access-completeness validation, authored interior classification constraints, authored exterior/open-space classification constraints, validated building-level room partition constraints, validated building overhead-classification constraints, authored external footprint context, validated exterior-access context, authored building-level entrance semantics, validated building-level entrance orientation and approach alignment, authored multi-entrance building semantics with per-entrance validation, and authored furniture anchor metadata are complete. **Phase 7 is in progress** with authored map-edge connection metadata. The next contribution should extend road or building content carefully without introducing multi-level structures or generalized templates.
 
 Do not yet generate walls, doors, roofs, multi-level building footprints, roads, towns, or generalized building templates. Preserve the established map-level `areas` plus per-tile area membership representation, keep room semantics independent from runtime areas, and validate any physical semantics in the editor and runtime.
 
@@ -941,9 +947,10 @@ Do not commit or push unless explicitly requested.
 [Complete] Validated building-level entrance orientation and approach alignment
 [Complete] Authored multi-entrance building semantics with per-entrance validation
 [Complete] Authored furniture anchor metadata
-[Next]     Multi-level building footprint foundations or road/map connection semantics
+[Complete] Authored map-edge connection metadata
+[Next]     Road endpoint anchoring or multi-level building footprint foundations
 [Planned]  Rooms and buildings
-[Planned]  Roads and map connections
+[In Progress]  Roads and map connections
 [Planned]  Multi-level reusable templates and richer composition
 [Planned]  Semantic map planning
 [Planned]  3D connectivity and gameplay validation

--- a/Documentation/Modding/map_recipe_generator.md
+++ b/Documentation/Modding/map_recipe_generator.md
@@ -35,6 +35,7 @@ The root must be a JSON object with these fields:
 | `regions` | array | Legacy filled rectangles. Optional; defaults to `[]`. |
 | `operations` | array | Ordered placement operations. Optional; defaults to `[]`. |
 | `levels` | non-empty array | Explicit grouped level definitions. Cannot be combined with root `base_tile`, `regions`, or `operations`. |
+| `connections` | object | Authored map-edge connection metadata. Optional; defaults to all `"ground"`. |
 
 A recipe does not define map dimensions: all generated maps are 32 x 32. Top-down `[x, y]` coordinates start at the top-left. Logical `z` is vertical elevation, not a third element in `[x, y]`. Every shape must fit entirely within the map; operations are never silently clipped.
 
@@ -64,6 +65,27 @@ Palette entries are objects with `id`, optional positive integer `weight` (defau
 ```
 
 Legacy `regions` are applied first in array order, followed by `operations` in array order. Pattern cells are expanded in their definition order at the position of the invoking operation. Later tile placements on the same logical level overwrite earlier cells, including the complete `feature` of an earlier furnished tile. A furniture operation instead rejects a cell that already has a feature. `regions` remain supported for version-one recipes and use the same filled-rectangle placement implementation as `rectangle` operations.
+
+## Map-edge connections
+
+The `connections` field authors the map's edge connection metadata — the type of terrain or road that connects at each cardinal edge. The runtime uses these values to select appropriate edge tiles when the map is instanced in the overworld.
+
+```json
+{
+  "connections": {
+    "north": "ground",
+    "east": "road",
+    "south": "ground",
+    "west": "road"
+  }
+}
+```
+
+Each key is one of `north`, `east`, `south`, or `west`; each value is one of `ground` or `road`. Omitted directions default to `"ground"`, so existing recipes without a `connections` field remain compatible. The standalone validator rejects unknown directions and unsupported connection types.
+
+This field authors metadata only: it does not generate road tiles, path routing, or edge tile placement. It declares what the runtime should expect at each edge so the overworld generator can connect adjacent maps correctly.
+
+`Tools/examples/map_recipe_road_connections.json` demonstrates a simple outdoor map with roads entering from east and west.
 
 ## Logical levels
 

--- a/Tools/examples/map_recipe_road_connections.json
+++ b/Tools/examples/map_recipe_road_connections.json
@@ -1,0 +1,16 @@
+{
+	"id": "generated_road_connections",
+	"name": "Generated Road Connections",
+	"description": "A simple outdoor map demonstrating authored map-edge connection metadata with roads entering from east and west.",
+	"seed": 20260822,
+	"base_tile": {"id": "grass_plain_01"},
+	"connections": {
+		"north": "ground",
+		"east": "road",
+		"south": "ground",
+		"west": "road"
+	},
+	"operations": [
+		{"type": "line", "from": [0, 16], "to": [31, 16], "tile": {"id": "dirt_light_00"}}
+	]
+}

--- a/Tools/map_generator.py
+++ b/Tools/map_generator.py
@@ -31,6 +31,8 @@ DEFAULT_CONNECTIONS = {
     "south": "ground",
     "west": "ground",
 }
+CONNECTION_DIRECTIONS = {"north", "east", "south", "west"}
+CONNECTION_TYPES = {"ground", "road"}
 # Recipe rotations use the same editor-facing values stored in map JSON. Keep
 # them unchanged here; Chunk.get_block_rotation() applies shape-specific runtime
 # conversion when a newly generated map is loaded.
@@ -115,6 +117,7 @@ RECIPE_FIELDS = {
     "regions",
     "operations",
     "levels",
+    "connections",
 }
 
 
@@ -2291,6 +2294,24 @@ def _generate_levels(
     return levels
 
 
+def _validate_connections(connections: Any) -> dict[str, str]:
+    if connections is None:
+        return DEFAULT_CONNECTIONS.copy()
+    if not isinstance(connections, dict):
+        raise RecipeError("connections must be an object")
+    unknown_keys = set(connections) - CONNECTION_DIRECTIONS
+    if unknown_keys:
+        raise RecipeError(f"unknown connections direction '{sorted(unknown_keys)[0]}'")
+    validated = DEFAULT_CONNECTIONS.copy()
+    for direction, value in connections.items():
+        if not isinstance(value, str) or not value.strip():
+            raise RecipeError(f"connections.{direction} must be a non-empty string")
+        if value not in CONNECTION_TYPES:
+            raise RecipeError(f"connections.{direction} has unsupported type '{value}'")
+        validated[direction] = value
+    return validated
+
+
 def generate_map(
     recipe: dict[str, Any],
     tiles_path: Path,
@@ -2407,6 +2428,7 @@ def generate_map(
         building_surfaces,
         levels,
     )
+    connections = _validate_connections(recipe.get("connections"))
 
     generated = {
         "id": recipe["id"],
@@ -2417,7 +2439,7 @@ def generate_map(
         "mapwidth": MAP_WIDTH,
         "mapheight": MAP_HEIGHT,
         "levels": levels,
-        "connections": DEFAULT_CONNECTIONS.copy(),
+        "connections": connections,
     }
     if areas:
         generated["areas"] = areas

--- a/Tools/map_validator.py
+++ b/Tools/map_validator.py
@@ -8,6 +8,8 @@ MAP_WIDTH = 32
 MAP_HEIGHT = 32
 LEVEL_COUNT = 21
 POPULATED_LEVEL_TILE_COUNT = MAP_WIDTH * MAP_HEIGHT
+CONNECTION_DIRECTIONS = {'north', 'east', 'south', 'west'}
+CONNECTION_TYPES = {'ground', 'road'}
 ROOM_KINDS = {'enclosed', 'covered_open', 'ruin'}
 ROOM_BOUNDARY_VALIDATIONS = {'complete'}
 CARDINAL_SIDES = {
@@ -177,6 +179,15 @@ class MapValidator:
                 val = data[field]
                 if not isinstance(str(val) if expected_type == str else val, expected_type):
                     self.add_error(file_path, f"Field '{field}' has incorrect type (expected {expected_type})")
+
+        # 2b. Validate connections content
+        connections = data.get('connections')
+        if isinstance(connections, dict):
+            for direction, value in connections.items():
+                if direction not in CONNECTION_DIRECTIONS:
+                    self.add_error(file_path, f"connections has unknown direction '{direction}'.")
+                if not isinstance(value, str) or value not in CONNECTION_TYPES:
+                    self.add_error(file_path, f"connections.{direction} has unsupported type '{value}'.")
 
         # 3. Enforce the fixed map dimensions used by the loader and editor.
         map_width = data.get('mapwidth', MAP_WIDTH)

--- a/Tools/tests/test_map_generator.py
+++ b/Tools/tests/test_map_generator.py
@@ -2587,6 +2587,61 @@ class MapGeneratorTests(unittest.TestCase):
         with self.assertRaisesRegex(RecipeError, "furniture_anchors must be a non-empty array"):
             generate_map(recipe, TILES_PATH)
 
+    def test_connections_generates_authored_values(self):
+        recipe_path = ROOT / "Tools" / "examples" / "map_recipe_road_connections.json"
+        recipe = json.loads(recipe_path.read_text(encoding="utf-8"))
+
+        generated = generate_map(recipe, TILES_PATH)
+
+        self.assertEqual(generated["connections"], {
+            "north": "ground",
+            "east": "road",
+            "south": "ground",
+            "west": "road",
+        })
+
+    def test_connections_defaults_to_ground_when_omitted(self):
+        recipe = valid_recipe()
+        generated = generate_map(recipe, TILES_PATH)
+
+        self.assertEqual(generated["connections"], {
+            "north": "ground",
+            "east": "ground",
+            "south": "ground",
+            "west": "ground",
+        })
+
+    def test_connections_partial_authoring_fills_defaults(self):
+        recipe = valid_recipe()
+        recipe["connections"] = {"east": "road"}
+        generated = generate_map(recipe, TILES_PATH)
+
+        self.assertEqual(generated["connections"], {
+            "north": "ground",
+            "east": "road",
+            "south": "ground",
+            "west": "ground",
+        })
+
+    def test_connections_rejects_invalid_directions_and_types(self):
+        recipe = valid_recipe()
+
+        recipe["connections"] = {"up": "ground"}
+        with self.assertRaisesRegex(RecipeError, "unknown connections direction 'up'"):
+            generate_map(recipe, TILES_PATH)
+
+        recipe["connections"] = {"north": "river"}
+        with self.assertRaisesRegex(RecipeError, "unsupported type 'river'"):
+            generate_map(recipe, TILES_PATH)
+
+        recipe["connections"] = {"north": 42}
+        with self.assertRaisesRegex(RecipeError, "must be a non-empty string"):
+            generate_map(recipe, TILES_PATH)
+
+        recipe["connections"] = "road"
+        with self.assertRaisesRegex(RecipeError, "connections must be an object"):
+            generate_map(recipe, TILES_PATH)
+
 
 class MapValidatorDimensionTests(unittest.TestCase):
     def validate(self, map_data):
@@ -3286,6 +3341,24 @@ class MapValidatorDimensionTests(unittest.TestCase):
         no_furniture["buildings"][0]["furniture_anchors"][0]["at"] = [9, 8]
         errors = self.validate(no_furniture)
         self.assertTrue(any("must reference furniture at" in error for error in errors))
+
+    def test_validates_connections_content(self):
+        recipe_path = ROOT / "Tools" / "examples" / "map_recipe_road_connections.json"
+        recipe = json.loads(recipe_path.read_text(encoding="utf-8"))
+        valid_map = generate_map(recipe, TILES_PATH)
+        self.assertEqual(self.validate(valid_map), [])
+
+        # Unknown direction
+        bad_direction = json.loads(json.dumps(valid_map))
+        bad_direction["connections"]["up"] = "ground"
+        errors = self.validate(bad_direction)
+        self.assertTrue(any("unknown direction 'up'" in error for error in errors))
+
+        # Unsupported type
+        bad_type = json.loads(json.dumps(valid_map))
+        bad_type["connections"]["north"] = "river"
+        errors = self.validate(bad_type)
+        self.assertTrue(any("unsupported type 'river'" in error for error in errors))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

First step of Phase 7 (Roads and map connections). Replaces the generator's hardcoded `DEFAULT_CONNECTIONS` (all `"ground"`) with a recipe-level `connections` field that lets the author declare `ground` or `road` for each cardinal map edge.

## Design

- **Backwards compatible**: recipes without `connections` still produce all-`"ground"` output
- **Schema**: `connections` is a dict with keys `north`/`east`/`south`/`west`, values `ground` or `road`
- **Defaults**: omitted directions fill with `"ground"`
- **Validation**: generator and standalone validator both reject unknown directions and unsupported types
- **Metadata only**: does not generate road tiles, path routing, or edge tile placement — that's future Phase 7 work

## Changed files

| File | Change |
|---|---|
| `Tools/map_generator.py` | `connections` recipe field, `_validate_connections()`, output uses validated connections |
| `Tools/map_validator.py` | Connections content validation (directions + types) |
| `Tools/examples/map_recipe_road_connections.json` | New maintained example (roads east/west) |
| `Tools/tests/test_map_generator.py` | 5 new tests (4 generator + 1 validator) |
| `Documentation/Modding/map_recipe_generator.md` | `connections` field documented + new "Map-edge connections" section |
| `Documentation/Game_design/Map_generation_plan.md` | Phase 7 → "in progress", roadmap narrative + `[Next]` updated |

## Validation

- Python tests: **134 pass** (129 existing + 5 new)
- GUT tests: **all pass**
- Standalone validator: all 11 example recipes pass
- `git diff --check`: no whitespace errors

## Roadmap

`[Next]` updated to: **Road endpoint anchoring or multi-level building footprint foundations**
Phase 7 status: **in progress** (authored map-edge connection metadata complete)