### PR TITLE
Add authored road endpoint anchoring

### DIFF
--- a/Documentation/Game_design/Map_generation_plan.md
+++ b/Documentation/Game_design/Map_generation_plan.md
@@ -703,15 +703,17 @@ Generate one small, enterable building that loads correctly and has a reachable 
 
 ## Phase 7 — Roads and map connections
 
-**Status: in progress; authored map-edge connection metadata complete**
+**Status: in progress; authored map-edge connection metadata and road endpoint anchoring complete**
 
-The prototype previously hardcoded all four edge connections as `"ground"`. These now become authored recipe-level metadata.
+The prototype previously hardcoded all four edge connections as `"ground"`. These are now authored recipe-level metadata, with named endpoint anchors identifying the exact map-edge cells where roads enter or exit.
 
 ### Completed foundation
 
-The recipe generator now supports a root-level `connections` field. It accepts up to four keys — `north`, `east`, `south`, and `west` — each with a value of `ground` or `road`, matching the existing runtime map format. Omitted directions default to `ground`, so existing recipes without the field remain compatible. The generator validates unknown directions and unsupported connection types and outputs the complete four-direction dictionary. The standalone validator independently checks the same content: it rejects unknown directions and non-`ground`/`road` values. `Tools/examples/map_recipe_road_connections.json` is the maintained evidence: a simple outdoor map with roads entering from east and west.
+The recipe generator supports a root-level `connections` field. It accepts up to four keys — `north`, `east`, `south`, and `west` — each with a value of `ground` or `road`, matching the existing runtime map format. Omitted directions default to `ground`, so existing recipes without the field remain compatible. The generator validates unknown directions and unsupported connection types and outputs the complete four-direction dictionary. The standalone validator independently checks the same content.
 
-This foundation authors metadata only: it does not generate road tiles, path routing, or edge tile placement. It declares what the runtime should expect at each edge so the overworld generator can connect adjacent maps correctly.
+The recipe generator now also supports root-level `road_endpoints`. Each endpoint has a unique `id`, a cardinal `direction`, an edge coordinate `at`, and ground-level `z: 0`. Its direction must be declared as `"road"` in `connections`, and its coordinate must lie on the corresponding map edge. The generator, standalone validator, and DMap save/load path validate or preserve these authored references. `Tools/examples/map_recipe_road_endpoints.json` is the maintained evidence: a simple outdoor map with west and east road endpoints and a deterministic connecting dirt path.
+
+This foundation authors metadata only: it does not generate road tiles, perform path routing, or alter edge tile placement. It declares what the runtime should expect at each edge and where the authored road entry/exit anchors are so later routing and adjacent-map integration can build on a validated contract.
 
 Capabilities:
 
@@ -892,9 +894,9 @@ An agent can create a new playable, potentially multi-level map from a concise d
 
 # Recommended immediate next task
 
-**Phase 6 is in progress.** Its runtime-compatible area foundation, catalog-validated per-instance entity variation, authored room semantics, explicit door-link metadata, partial physical boundary references, opt-in enclosed-room completeness validation, first single-level authored footprint, narrow authored roof/ceiling metadata, opt-in building-level composition constraints, authored building access-completeness validation, authored interior classification constraints, authored exterior/open-space classification constraints, validated building-level room partition constraints, validated building overhead-classification constraints, authored external footprint context, validated exterior-access context, authored building-level entrance semantics, validated building-level entrance orientation and approach alignment, authored multi-entrance building semantics with per-entrance validation, and authored furniture anchor metadata are complete. **Phase 7 is in progress** with authored map-edge connection metadata. The next contribution should extend road or building content carefully without introducing multi-level structures or generalized templates.
+**Phase 6 is in progress.** Its runtime-compatible area foundation, catalog-validated per-instance entity variation, authored room semantics, explicit door-link metadata, partial physical boundary references, opt-in enclosed-room completeness validation, first single-level authored footprint, narrow authored roof/ceiling metadata, opt-in building-level composition constraints, authored building access-completeness validation, authored interior classification constraints, authored exterior/open-space classification constraints, validated building-level room partition constraints, validated building overhead-classification constraints, authored external footprint context, validated exterior-access context, authored building-level entrance semantics, validated building-level entrance orientation and approach alignment, authored multi-entrance building semantics with per-entrance validation, and authored furniture anchor metadata are complete. **Phase 7 is in progress** with authored map-edge connection metadata and road endpoint anchoring. The next contribution should extend road or building content carefully without introducing multi-level structures or generalized templates.
 
-Do not yet generate walls, doors, roofs, multi-level building footprints, roads, towns, or generalized building templates. Preserve the established map-level `areas` plus per-tile area membership representation, keep room semantics independent from runtime areas, and validate any physical semantics in the editor and runtime.
+Do not yet generate walls, doors, roofs, multi-level building footprints, road geometry, towns, or generalized building templates. Preserve the established map-level `areas` plus per-tile area membership representation, keep room semantics independent from runtime areas, and validate any physical semantics in the editor and runtime.
 
 Run the complete Python suite, relevant Godot tests or smoke checks, all maintained example generations through `Tools/map_validator.py`, and `git diff --check`.
 
@@ -948,7 +950,8 @@ Do not commit or push unless explicitly requested.
 [Complete] Authored multi-entrance building semantics with per-entrance validation
 [Complete] Authored furniture anchor metadata
 [Complete] Authored map-edge connection metadata
-[Next]     Road endpoint anchoring or multi-level building footprint foundations
+[Complete] Authored road endpoint anchoring
+[Next]     Road path routing or multi-level building footprint foundations
 [Planned]  Rooms and buildings
 [In Progress]  Roads and map connections
 [Planned]  Multi-level reusable templates and richer composition

--- a/Documentation/Modding/map_recipe_generator.md
+++ b/Documentation/Modding/map_recipe_generator.md
@@ -36,6 +36,7 @@ The root must be a JSON object with these fields:
 | `operations` | array | Ordered placement operations. Optional; defaults to `[]`. |
 | `levels` | non-empty array | Explicit grouped level definitions. Cannot be combined with root `base_tile`, `regions`, or `operations`. |
 | `connections` | object | Authored map-edge connection metadata. Optional; defaults to all `"ground"`. |
+| `road_endpoints` | array | Authored road endpoint anchors at map edges. Optional; defaults to `[]`. |
 
 A recipe does not define map dimensions: all generated maps are 32 x 32. Top-down `[x, y]` coordinates start at the top-left. Logical `z` is vertical elevation, not a third element in `[x, y]`. Every shape must fit entirely within the map; operations are never silently clipped.
 
@@ -86,6 +87,26 @@ Each key is one of `north`, `east`, `south`, or `west`; each value is one of `gr
 This field authors metadata only: it does not generate road tiles, path routing, or edge tile placement. It declares what the runtime should expect at each edge so the overworld generator can connect adjacent maps correctly.
 
 `Tools/examples/map_recipe_road_connections.json` demonstrates a simple outdoor map with roads entering from east and west.
+
+## Road endpoints
+
+The `road_endpoints` field authors named anchor points that identify where roads enter or exit the map at its edges. Each endpoint is a data-only reference point — it does not generate road tiles, path routing, or geometry.
+
+```json
+{
+  "connections": {"north": "ground", "east": "road", "south": "ground", "west": "road"},
+  "road_endpoints": [
+    {"id": "west_entrance", "direction": "west", "at": [0, 16], "z": 0},
+    {"id": "east_exit", "direction": "east", "at": [31, 16], "z": 0}
+  ]
+}
+```
+
+Each entry has exactly `id`, `direction`, `at`, and `z`. `id` is unique within the recipe and follows the standard naming pattern. `direction` is one of `north`, `east`, `south`, or `west` and must match a `connections` entry whose value is `"road"` — a road endpoint cannot be placed on an edge declared as `"ground"`. `at` is a two-integer `[x, y]` coordinate that must lie on the correct map edge for its `direction` (north edge: `y = 0`, south edge: `y = 31`, west edge: `x = 0`, east edge: `x = 31`). `z` must be `0` — road endpoints are ground-level only in this first slice.
+
+The standalone validator independently checks the same content: it rejects unknown directions, duplicate IDs, coordinates not on the correct edge, and non-zero `z` values. `DMap` preserves valid road endpoints through editor save/load and removes entries with missing fields, invalid directions, duplicate IDs, or malformed coordinates.
+
+`Tools/examples/map_recipe_road_endpoints.json` demonstrates the maintained example with two road endpoints: `west_entrance` at the west edge and `east_exit` at the east edge.
 
 ## Logical levels
 

--- a/Scripts/Gamedata/DMap.gd
+++ b/Scripts/Gamedata/DMap.gd
@@ -99,6 +99,7 @@ var room_boundaries: Array = []
 var buildings: Array = []
 var building_surfaces: Array = []
 var building_compositions: Array = []
+var road_endpoints: Array = []
 var sprite: Texture = null
 # Variable to store connections. For example: {"south": "road","west": "ground"} default to ground
 var connections: Dictionary = {
@@ -157,6 +158,7 @@ func set_data(newdata: Dictionary) -> void:
 	buildings = newdata.get("buildings", [])
 	building_surfaces = newdata.get("building_surfaces", [])
 	building_compositions = newdata.get("building_compositions", [])
+	road_endpoints = newdata.get("road_endpoints", [])
 	connections = newdata.get("connections", {})  # Set connections from data if present
 
 
@@ -186,6 +188,8 @@ func get_data() -> Dictionary:
 		mydata["building_surfaces"] = building_surfaces
 	if not building_compositions.is_empty():
 		mydata["building_compositions"] = building_compositions
+	if not road_endpoints.is_empty():
+		mydata["road_endpoints"] = road_endpoints
 	if not connections.is_empty():  # Omit connections if empty
 		mydata["connections"] = connections
 	
@@ -197,6 +201,7 @@ func get_data() -> Dictionary:
 	_sanitize_buildings(mydata)
 	_sanitize_building_surfaces(mydata)
 	_sanitize_building_compositions(mydata)
+	_sanitize_road_endpoints(mydata)
 
 	# NEW: Implement sanitization for corrupt tiles (missing or empty ID when metadata exists)
 	_sanitize_tile_objects(mydata)
@@ -506,6 +511,48 @@ func _sanitize_building_compositions(data: Dictionary) -> void:
 	)
 	if data["building_compositions"].is_empty():
 		data.erase("building_compositions")
+
+
+func _sanitize_road_endpoints(data: Dictionary) -> void:
+	if not data.has("road_endpoints") or not data["road_endpoints"] is Array:
+		return
+
+	var valid_directions: Array[String] = ["north", "east", "south", "west"]
+	var seen_ids: Array[String] = []
+	var map_connections: Dictionary = data.get("connections", {})
+	data["road_endpoints"] = data["road_endpoints"].filter(func(endpoint):
+		if not endpoint is Dictionary:
+			return false
+		if not endpoint.has("id") or not endpoint["id"] is String or endpoint["id"].is_empty():
+			return false
+		if endpoint["id"] in seen_ids:
+			return false
+		seen_ids.append(endpoint["id"])
+		if not endpoint.has("direction") or not endpoint["direction"] is String:
+			return false
+		if endpoint["direction"] not in valid_directions:
+			return false
+		if map_connections.get(endpoint["direction"], "ground") != "road":
+			return false
+		if not endpoint.has("at") or not endpoint["at"] is Array or endpoint["at"].size() != 2:
+			return false
+		if not endpoint.has("z") or not endpoint["z"] is int or endpoint["z"] != 0:
+			return false
+		var at: Array = endpoint["at"]
+		if not at[0] is int or not at[1] is int or at[0] < 0 or at[0] >= 32 or at[1] < 0 or at[1] >= 32:
+			return false
+		if endpoint["direction"] == "north" and at[1] != 0:
+			return false
+		if endpoint["direction"] == "south" and at[1] != 31:
+			return false
+		if endpoint["direction"] == "west" and at[0] != 0:
+			return false
+		if endpoint["direction"] == "east" and at[0] != 31:
+			return false
+		return true
+	)
+	if data["road_endpoints"].is_empty():
+		data.erase("road_endpoints")
 
 
 func load_data_from_disk():

--- a/Tools/examples/map_recipe_road_endpoints.json
+++ b/Tools/examples/map_recipe_road_endpoints.json
@@ -1,0 +1,20 @@
+{
+	"id": "generated_road_endpoints",
+	"name": "Generated Road Endpoints",
+	"description": "An outdoor map with authored road endpoint anchors at the east and west edges, identifying where roads enter the map.",
+	"seed": 20260822,
+	"base_tile": {"id": "grass_plain_01"},
+	"connections": {
+		"north": "ground",
+		"east": "road",
+		"south": "ground",
+		"west": "road"
+	},
+	"road_endpoints": [
+		{"id": "west_entrance", "direction": "west", "at": [0, 16], "z": 0},
+		{"id": "east_exit", "direction": "east", "at": [31, 16], "z": 0}
+	],
+	"operations": [
+		{"type": "line", "from": [0, 16], "to": [31, 16], "tile": {"id": "dirt_light_00"}}
+	]
+}

--- a/Tools/map_generator.py
+++ b/Tools/map_generator.py
@@ -33,6 +33,13 @@ DEFAULT_CONNECTIONS = {
 }
 CONNECTION_DIRECTIONS = {"north", "east", "south", "west"}
 CONNECTION_TYPES = {"ground", "road"}
+ROAD_ENDPOINT_FIELDS = {"id", "direction", "at", "z"}
+EDGE_COORDINATES = {
+    "north": lambda x, y: y == 0,
+    "south": lambda x, y: y == MAP_HEIGHT - 1,
+    "west": lambda x, y: x == 0,
+    "east": lambda x, y: x == MAP_WIDTH - 1,
+}
 # Recipe rotations use the same editor-facing values stored in map JSON. Keep
 # them unchanged here; Chunk.get_block_rotation() applies shape-specific runtime
 # conversion when a newly generated map is loaded.
@@ -118,6 +125,7 @@ RECIPE_FIELDS = {
     "operations",
     "levels",
     "connections",
+    "road_endpoints",
 }
 
 
@@ -2312,6 +2320,72 @@ def _validate_connections(connections: Any) -> dict[str, str]:
     return validated
 
 
+def _validate_road_endpoints(
+    road_endpoints: Any,
+    connections: dict[str, str],
+    levels: list[list[dict[str, Any]]],
+) -> list[dict[str, Any]]:
+    if road_endpoints is None:
+        return []
+    if not isinstance(road_endpoints, list):
+        raise RecipeError("road_endpoints must be an array")
+    if not road_endpoints:
+        raise RecipeError("road_endpoints must not be empty")
+    validated: list[dict[str, Any]] = []
+    seen_ids: set[str] = set()
+    for index, endpoint in enumerate(road_endpoints):
+        context = f"road_endpoints[{index}]"
+        if not isinstance(endpoint, dict):
+            raise RecipeError(f"{context} must be an object")
+        unknown_fields = sorted(set(endpoint) - ROAD_ENDPOINT_FIELDS)
+        if unknown_fields:
+            raise RecipeError(f"unknown {context} field '{unknown_fields[0]}'")
+        if set(endpoint) != ROAD_ENDPOINT_FIELDS:
+            raise RecipeError(f"{context} must define id, direction, at, and z")
+        endpoint_id = endpoint["id"]
+        if not isinstance(endpoint_id, str) or not endpoint_id.strip():
+            raise RecipeError(f"{context}.id must be a non-empty string")
+        _validate_unicode(endpoint_id, f"{context}.id")
+        if DEFINITION_NAME_PATTERN.fullmatch(endpoint_id) is None:
+            raise RecipeError(f"{context}.id may contain only letters, numbers, underscores, and hyphens")
+        if endpoint_id in seen_ids:
+            raise RecipeError(f"duplicate road endpoint ID '{endpoint_id}'")
+        seen_ids.add(endpoint_id)
+        direction = endpoint["direction"]
+        if direction not in CONNECTION_DIRECTIONS:
+            raise RecipeError(f"{context}.direction must be north, east, south, or west")
+        if connections[direction] != "road":
+            raise RecipeError(
+                f"{context}.direction '{direction}' requires connections.{direction} to be 'road'"
+            )
+        at = endpoint["at"]
+        if (
+            not isinstance(at, list)
+            or len(at) != 2
+            or any(type(value) is not int for value in at)
+            or not 0 <= at[0] < MAP_WIDTH
+            or not 0 <= at[1] < MAP_HEIGHT
+        ):
+            raise RecipeError(f"{context}.at must be within map bounds as a two-integer array")
+        ep_x, ep_y = at
+        if not EDGE_COORDINATES[direction](ep_x, ep_y):
+            raise RecipeError(f"{context}.at must be on the {direction} edge of the map")
+        z = endpoint["z"]
+        if type(z) is not int or z != 0:
+            raise RecipeError(f"{context}.z must be 0")
+        level = levels[_level_index(z)]
+        tile = level[ep_y * MAP_WIDTH + ep_x] if level else {}
+        if not isinstance(tile, dict) or not isinstance(tile.get("id"), str) or not tile["id"]:
+            raise RecipeError(f"{context} must reference existing terrain at [{ep_x}, {ep_y}] on z {z}")
+        validated.append({
+            "id": endpoint_id,
+            "direction": direction,
+            "at": at,
+            "z": z,
+        })
+    return validated
+
+
 def generate_map(
     recipe: dict[str, Any],
     tiles_path: Path,
@@ -2429,6 +2503,7 @@ def generate_map(
         levels,
     )
     connections = _validate_connections(recipe.get("connections"))
+    road_endpoints = _validate_road_endpoints(recipe.get("road_endpoints"), connections, levels)
 
     generated = {
         "id": recipe["id"],
@@ -2455,6 +2530,8 @@ def generate_map(
         generated["building_surfaces"] = building_surfaces
     if building_compositions:
         generated["building_compositions"] = building_compositions
+    if road_endpoints:
+        generated["road_endpoints"] = road_endpoints
     return generated
 
 

--- a/Tools/map_validator.py
+++ b/Tools/map_validator.py
@@ -10,6 +10,7 @@ LEVEL_COUNT = 21
 POPULATED_LEVEL_TILE_COUNT = MAP_WIDTH * MAP_HEIGHT
 CONNECTION_DIRECTIONS = {'north', 'east', 'south', 'west'}
 CONNECTION_TYPES = {'ground', 'road'}
+ROAD_ENDPOINT_FIELDS = {'id', 'direction', 'at', 'z'}
 ROOM_KINDS = {'enclosed', 'covered_open', 'ruin'}
 ROOM_BOUNDARY_VALIDATIONS = {'complete'}
 CARDINAL_SIDES = {
@@ -188,6 +189,62 @@ class MapValidator:
                     self.add_error(file_path, f"connections has unknown direction '{direction}'.")
                 if not isinstance(value, str) or value not in CONNECTION_TYPES:
                     self.add_error(file_path, f"connections.{direction} has unsupported type '{value}'.")
+
+        # 2c. Validate road_endpoints
+        road_endpoints = data.get('road_endpoints', [])
+        if not isinstance(road_endpoints, list):
+            self.add_error(file_path, "top-level road_endpoints must be an array.")
+            road_endpoints = []
+        else:
+            seen_endpoint_ids: Set[str] = set()
+            for idx, endpoint in enumerate(road_endpoints):
+                if not isinstance(endpoint, dict):
+                    self.add_error(file_path, f"road_endpoints[{idx}] is not an object.")
+                    continue
+                context = f"road_endpoints[{idx}]"
+                unknown_fields = set(endpoint) - ROAD_ENDPOINT_FIELDS
+                if unknown_fields:
+                    self.add_error(file_path, f"{context} has unknown field '{sorted(unknown_fields)[0]}'.")
+                if set(endpoint) != ROAD_ENDPOINT_FIELDS:
+                    self.add_error(file_path, f"{context} must define id, direction, at, and z.")
+                    continue
+                endpoint_id = endpoint.get('id')
+                if not isinstance(endpoint_id, str) or not endpoint_id:
+                    self.add_error(file_path, f"{context} id must be a non-empty string.")
+                elif endpoint_id in seen_endpoint_ids:
+                    self.add_error(file_path, f"{context} duplicates road endpoint ID '{endpoint_id}'.")
+                else:
+                    seen_endpoint_ids.add(endpoint_id)
+                direction = endpoint.get('direction')
+                if direction not in CONNECTION_DIRECTIONS:
+                    self.add_error(file_path, f"{context} direction must be north, east, south, or west.")
+                elif isinstance(connections, dict) and connections.get(direction) != 'road':
+                    self.add_error(file_path, f"{context} direction '{direction}' requires connections.{direction} to be 'road'.")
+                at = endpoint.get('at')
+                if isinstance(at, list) and len(at) == 2 and all(type(v) is int for v in at):
+                    ep_x, ep_y = at
+                    if not 0 <= ep_x < MAP_WIDTH or not 0 <= ep_y < MAP_HEIGHT:
+                        self.add_error(file_path, f"{context} at must be within map bounds.")
+                    elif direction in CONNECTION_DIRECTIONS:
+                        edge_checks = {
+                            'north': ep_y == 0,
+                            'south': ep_y == MAP_HEIGHT - 1,
+                            'west': ep_x == 0,
+                            'east': ep_x == MAP_WIDTH - 1,
+                        }
+                        if not edge_checks[direction]:
+                            self.add_error(file_path, f"{context} at must be on the {direction} edge of the map.")
+                        elif endpoint.get('z') == 0:
+                            level_index = 10
+                            level = levels[level_index] if isinstance(levels, list) and level_index < len(levels) else []
+                            tile = level[ep_y * MAP_WIDTH + ep_x] if isinstance(level, list) and len(level) == POPULATED_LEVEL_TILE_COUNT else {}
+                            if not isinstance(tile, dict) or not isinstance(tile.get('id'), str) or not tile.get('id'):
+                                self.add_error(file_path, f"{context} must reference existing terrain at [{ep_x}, {ep_y}] on z 0.")
+                else:
+                    self.add_error(file_path, f"{context} at must be a two-integer coordinate within map bounds.")
+                z = endpoint.get('z')
+                if z is not None and (type(z) is not int or z != 0):
+                    self.add_error(file_path, f"{context} z must be 0.")
 
         # 3. Enforce the fixed map dimensions used by the loader and editor.
         map_width = data.get('mapwidth', MAP_WIDTH)

--- a/Tools/tests/test_map_generator.py
+++ b/Tools/tests/test_map_generator.py
@@ -2642,6 +2642,94 @@ class MapGeneratorTests(unittest.TestCase):
         with self.assertRaisesRegex(RecipeError, "connections must be an object"):
             generate_map(recipe, TILES_PATH)
 
+    def test_road_endpoints_generate_and_validate(self):
+        recipe_path = ROOT / "Tools" / "examples" / "map_recipe_road_endpoints.json"
+        recipe = json.loads(recipe_path.read_text(encoding="utf-8"))
+
+        generated = generate_map(recipe, TILES_PATH)
+
+        self.assertIn("road_endpoints", generated)
+        endpoints = generated["road_endpoints"]
+        self.assertEqual(len(endpoints), 2)
+        self.assertEqual(endpoints[0], {"id": "west_entrance", "direction": "west", "at": [0, 16], "z": 0})
+        self.assertEqual(endpoints[1], {"id": "east_exit", "direction": "east", "at": [31, 16], "z": 0})
+
+    def test_road_endpoints_require_road_connection(self):
+        recipe = valid_recipe()
+        recipe["connections"] = {"east": "ground", "west": "road"}
+        recipe["road_endpoints"] = [
+            {"id": "west_entrance", "direction": "west", "at": [0, 16], "z": 0},
+        ]
+        generate_map(recipe, TILES_PATH)
+
+        no_road = json.loads(json.dumps(recipe))
+        no_road["connections"] = {"west": "ground"}
+        with self.assertRaisesRegex(RecipeError, "requires connections.west to be 'road'"):
+            generate_map(no_road, TILES_PATH)
+
+    def test_road_endpoints_reject_duplicate_ids_and_wrong_edge(self):
+        recipe = valid_recipe()
+        recipe["connections"] = {"east": "road", "west": "road"}
+        recipe["road_endpoints"] = [
+            {"id": "west_entrance", "direction": "west", "at": [0, 16], "z": 0},
+            {"id": "west_entrance", "direction": "east", "at": [31, 16], "z": 0},
+        ]
+        with self.assertRaisesRegex(RecipeError, "duplicate road endpoint ID 'west_entrance'"):
+            generate_map(recipe, TILES_PATH)
+
+        wrong_edge = valid_recipe()
+        wrong_edge["connections"] = {"west": "road"}
+        wrong_edge["road_endpoints"] = [
+            {"id": "west_entrance", "direction": "west", "at": [5, 16], "z": 0},
+        ]
+        with self.assertRaisesRegex(RecipeError, "at must be on the west edge of the map"):
+            generate_map(wrong_edge, TILES_PATH)
+
+    def test_road_endpoints_reject_invalid_entries(self):
+        recipe = valid_recipe()
+        recipe["connections"] = {"west": "road"}
+
+        missing_fields = json.loads(json.dumps(recipe))
+        missing_fields["road_endpoints"] = [{"id": "test", "direction": "west", "at": [0, 16]}]
+        with self.assertRaisesRegex(RecipeError, "must define id, direction, at, and z"):
+            generate_map(missing_fields, TILES_PATH)
+
+        bad_direction = json.loads(json.dumps(recipe))
+        bad_direction["road_endpoints"] = [{"id": "test", "direction": "up", "at": [0, 16], "z": 0}]
+        with self.assertRaisesRegex(RecipeError, "direction must be north, east, south, or west"):
+            generate_map(bad_direction, TILES_PATH)
+
+        bad_z = json.loads(json.dumps(recipe))
+        bad_z["road_endpoints"] = [{"id": "test", "direction": "west", "at": [0, 16], "z": 1}]
+        with self.assertRaisesRegex(RecipeError, "z must be 0"):
+            generate_map(bad_z, TILES_PATH)
+
+        empty = json.loads(json.dumps(recipe))
+        empty["road_endpoints"] = []
+        with self.assertRaisesRegex(RecipeError, "road_endpoints must not be empty"):
+            generate_map(empty, TILES_PATH)
+
+    def test_road_endpoints_omitted_produces_no_field(self):
+        recipe = valid_recipe()
+        generated = generate_map(recipe, TILES_PATH)
+        self.assertNotIn("road_endpoints", generated)
+
+    def test_road_endpoints_require_existing_terrain(self):
+        recipe = valid_recipe()
+        recipe["connections"] = {"west": "road"}
+        recipe["road_endpoints"] = [
+            {"id": "west_entrance", "direction": "west", "at": [0, 16], "z": 0},
+        ]
+        recipe["operations"] = [{"type": "set", "x": 0, "y": 16, "tile": None}]
+        with self.assertRaisesRegex(RecipeError, "must reference existing terrain"):
+            generate_map(recipe, TILES_PATH)
+
+    def test_road_endpoints_reject_non_array(self):
+        recipe = valid_recipe()
+        recipe["road_endpoints"] = {"id": "west_entrance"}
+        with self.assertRaisesRegex(RecipeError, "road_endpoints must be an array"):
+            generate_map(recipe, TILES_PATH)
+
 
 class MapValidatorDimensionTests(unittest.TestCase):
     def validate(self, map_data):
@@ -3359,6 +3447,48 @@ class MapValidatorDimensionTests(unittest.TestCase):
         bad_type["connections"]["north"] = "river"
         errors = self.validate(bad_type)
         self.assertTrue(any("unsupported type 'river'" in error for error in errors))
+
+    def test_validates_road_endpoints_content(self):
+        recipe_path = ROOT / "Tools" / "examples" / "map_recipe_road_endpoints.json"
+        recipe = json.loads(recipe_path.read_text(encoding="utf-8"))
+        valid_map = generate_map(recipe, TILES_PATH)
+        self.assertEqual(self.validate(valid_map), [])
+
+        # Duplicate id
+        dup_id = json.loads(json.dumps(valid_map))
+        dup_id["road_endpoints"][1]["id"] = "west_entrance"
+        errors = self.validate(dup_id)
+        self.assertTrue(any("duplicates road endpoint ID 'west_entrance'" in error for error in errors))
+
+        # Wrong edge
+        wrong_edge = json.loads(json.dumps(valid_map))
+        wrong_edge["road_endpoints"][0]["at"] = [5, 16]
+        errors = self.validate(wrong_edge)
+        self.assertTrue(any("at must be on the west edge" in error for error in errors))
+
+        # Direction not road in connections
+        ground_dir = json.loads(json.dumps(valid_map))
+        ground_dir["connections"]["west"] = "ground"
+        errors = self.validate(ground_dir)
+        self.assertTrue(any("requires connections.west to be 'road'" in error for error in errors))
+
+        # Bad z
+        bad_z = json.loads(json.dumps(valid_map))
+        bad_z["road_endpoints"][0]["z"] = 1
+        errors = self.validate(bad_z)
+        self.assertTrue(any("z must be 0" in error for error in errors))
+
+        # Missing terrain
+        missing_terrain = json.loads(json.dumps(valid_map))
+        missing_terrain["levels"][10][16 * 32] = {}
+        errors = self.validate(missing_terrain)
+        self.assertTrue(any("must reference existing terrain" in error for error in errors))
+
+        # Non-array field
+        non_array = json.loads(json.dumps(valid_map))
+        non_array["road_endpoints"] = {}
+        errors = self.validate(non_array)
+        self.assertTrue(any("top-level road_endpoints must be an array" in error for error in errors))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

Adds authored road endpoint anchoring as the next increment of Phase 7
(Roads and map connections).

Recipes can now declare named points where roads enter or exit the map
at its edges.

## Design

Each `road_endpoints` entry has:

```json
{
  "id": "west_entrance",
  "direction": "west",
  "at": [0, 16],
  "z": 0
}