### PR TITLE
Add multi-level building footprint foundation

### DIFF
--- a/Documentation/Game_design/Map_generation_plan.md
+++ b/Documentation/Game_design/Map_generation_plan.md
@@ -595,7 +595,7 @@ Generate an outdoor map with trees, rocks, vegetation, and simple interactable o
 
 ## Phase 6 — Areas, rooms, and buildings
 
-**Status: in progress; level-aware runtime area foundation complete**
+**Status: in progress; level-aware runtime area and multi-level footprint foundations complete**
 
 The generator needs semantic areas before it can create convincing buildings.
 
@@ -651,7 +651,9 @@ An opted-in `overhead_validation: "complete"` requires that the validated buildi
 
 `furniture_anchors` now authors named data-only furniture anchor metadata for a validated building. Each record is a non-empty array of `{ "id", "at", "z", "kind" }` entries. Each `id` is unique within the building and follows the standard naming pattern. `at` is a two-integer `[x, y]` coordinate within map bounds. `z` is a logical level from `-10` through `10` and must match the building's own `z`. `kind` is a non-empty free-form semantic label (e.g. `"door"`, `"storage"`, `"workstation"`) — not an enumerated set and carrying no runtime behavior. Each anchor must reference a tile inside the building footprint that has an existing furniture feature at the authored `[x, y, z]`; the anchor does not generate furniture, modify terrain, infer walkability, check furniture category or function, or alter collision, navigation, lighting, weather, or runtime behavior. `Tools/examples/map_recipe_furniture_anchors.json` demonstrates the maintained office building with two furniture anchors: `office_door_anchor` and `garage_door_anchor`, each pointing to an existing `door_wood` feature inside the footprint. This is a data-only authored reference point that future template composition and gameplay validation can use as an anchor.
 
-This foundation intentionally does **not** yet define polygons, topology-derived room boundaries, indoor/outdoor runtime behavior, wall/roof generation, multi-level building records, or generalized templates.
+`building_levels` now provides the first multi-level building footprint foundation. A building remains rooted at ground floor `z: 0` and may declare strictly ascending occupied floor levels at even logical z values: `z: 0` ground, `z: 1` intentional open gap, `z: 2` ceiling/first floor, `z: 3` open gap, and so on through `z: 10`. `Tools/examples/map_recipe_multi_level_building_foundation.json` demonstrates the two-floor declaration `[{"z": 0}, {"z": 2}]`. The generator, standalone validator, and DMap save/load path validate or preserve this metadata-only foundation. It does not generate upper floors, ceilings, walls, roofs, supports, stairs, vertical transitions, collision, navigation, or indoor runtime behavior; existing room and furniture metadata remains associated with the root ground level until a later per-floor schema is defined.
+
+This foundation intentionally does **not** yet define polygons, topology-derived room boundaries, indoor/outdoor runtime behavior, wall/roof generation, per-floor room or furniture ownership, vertical transitions, or generalized templates.
 
 Capabilities:
 
@@ -894,9 +896,9 @@ An agent can create a new playable, potentially multi-level map from a concise d
 
 # Recommended immediate next task
 
-**Phase 6 is in progress.** Its runtime-compatible area foundation, catalog-validated per-instance entity variation, authored room semantics, explicit door-link metadata, partial physical boundary references, opt-in enclosed-room completeness validation, first single-level authored footprint, narrow authored roof/ceiling metadata, opt-in building-level composition constraints, authored building access-completeness validation, authored interior classification constraints, authored exterior/open-space classification constraints, validated building-level room partition constraints, validated building overhead-classification constraints, authored external footprint context, validated exterior-access context, authored building-level entrance semantics, validated building-level entrance orientation and approach alignment, authored multi-entrance building semantics with per-entrance validation, and authored furniture anchor metadata are complete. **Phase 7 is in progress** with authored map-edge connection metadata and road endpoint anchoring. The next contribution should extend road or building content carefully without introducing multi-level structures or generalized templates.
+**Phase 6 is in progress.** Its runtime-compatible area foundation, catalog-validated per-instance entity variation, authored room semantics, explicit door-link metadata, partial physical boundary references, opt-in enclosed-room completeness validation, first single-level authored footprint, narrow authored roof/ceiling metadata, opt-in building-level composition constraints, authored building access-completeness validation, authored interior classification constraints, authored exterior/open-space classification constraints, validated building-level room partition constraints, validated building overhead-classification constraints, authored external footprint context, validated exterior-access context, authored building-level entrance semantics, validated building-level entrance orientation and approach alignment, authored multi-entrance building semantics with per-entrance validation, authored furniture anchor metadata, and the first multi-level building footprint foundation are complete. **Phase 7 is in progress** with authored map-edge connection metadata and road endpoint anchoring. The next contribution should extend per-floor building semantics or road content without introducing generated geometry or generalized templates.
 
-Do not yet generate walls, doors, roofs, multi-level building footprints, road geometry, towns, or generalized building templates. Preserve the established map-level `areas` plus per-tile area membership representation, keep room semantics independent from runtime areas, and validate any physical semantics in the editor and runtime.
+Do not yet generate walls, doors, roofs, multi-level building geometry, road geometry, towns, or generalized building templates. Preserve the established map-level `areas` plus per-tile area membership representation, keep room semantics independent from runtime areas, and validate any physical semantics in the editor and runtime.
 
 Run the complete Python suite, relevant Godot tests or smoke checks, all maintained example generations through `Tools/map_validator.py`, and `git diff --check`.
 
@@ -951,8 +953,9 @@ Do not commit or push unless explicitly requested.
 [Complete] Authored furniture anchor metadata
 [Complete] Authored map-edge connection metadata
 [Complete] Authored road endpoint anchoring
-[Next]     Road path routing or multi-level building footprint foundations
-[Planned]  Rooms and buildings
+[Complete] Multi-level building footprint foundation with intentional open gaps
+[Next]     Per-floor room/furniture ownership or road path routing
+[In Progress]  Rooms and buildings
 [In Progress]  Roads and map connections
 [Planned]  Multi-level reusable templates and richer composition
 [Planned]  Semantic map planning

--- a/Documentation/Modding/map_recipe_generator.md
+++ b/Documentation/Modding/map_recipe_generator.md
@@ -422,9 +422,25 @@ Boundary metadata preserves existing terrain, furniture, rotation, collision, an
 }
 ```
 
-Each record has required `id`, `rooms`, `footprint`, and `z`, plus optional `access_validation`, `interior_rooms`, `open_space_rooms`, `room_partition_validation`, `overhead_validation`, `exterior_context`, `exterior_access_context`, `entrance`, `entrances`, `entrance_validation`, and `furniture_anchors`. `id` is unique; `rooms` is a nonempty list of unique known room IDs; `footprint` has exactly non-negative integer `x`/`y` plus positive integer `width`/`height`, fully inside the 32×32 map; and `z` is a required logical level from `-10` through `10`. Footprints on the same logical z must not overlap, though they may touch.
+Each record has required `id`, `rooms`, `footprint`, and `z`, plus optional `building_levels`, `access_validation`, `interior_rooms`, `open_space_rooms`, `room_partition_validation`, `overhead_validation`, `exterior_context`, `exterior_access_context`, `entrance`, `entrances`, `entrance_validation`, and `furniture_anchors`. `id` is unique; `rooms` is a nonempty list of unique known room IDs; `footprint` has exactly non-negative integer `x`/`y` plus positive integer `width`/`height`, fully inside the 32×32 map; and `z` is a required logical level from `-10` through `10`. Footprints on the same logical z must not overlap, though they may touch.
 
 Every owned room must have membership only at the building level and wholly inside its footprint. At least one owned room must be an `enclosed` room with `"boundary_validation": "complete"`. Its same-level `room_boundaries` and any same-level `room_connections` naming it must also lie inside the footprint. This makes the record a strict ownership/containment contract for already-authored physical evidence, not a claim that every footprint cell is occupied, roofed, or indoors.
+
+A building may declare a multi-level footprint foundation with `building_levels`:
+
+```json
+{
+  "id": "office_building",
+  "rooms": ["office"],
+  "footprint": {"x": 7, "y": 7, "width": 4, "height": 4},
+  "z": 0,
+  "building_levels": [{"z": 0}, {"z": 2}]
+}
+```
+
+`building_levels` is an optional non-empty, strictly ascending array of objects with exactly `z`. The building record itself remains rooted at ground level `z: 0`. Declared occupied floor levels must be even logical levels: `z: 0` is the ground floor, `z: 1` is an intentional open gap, `z: 2` is the ceiling/first-floor level, `z: 3` is another open gap, and so on. The current supported range is `0` through `10`. The declaration must start with `{"z": 0}`; odd levels are not occupied floor declarations. A declaration such as `[{"z": 0}, {"z": 2}, {"z": 4}]` describes ground, first, and second occupied floors with open gaps at `z: 1` and `z: 3`.
+
+This is a metadata-only foundation. It does not generate upper floors, ceilings, walls, roofs, supports, stairs, vertical transitions, collision, navigation, or indoor runtime behavior. Existing room, boundary, entrance, and furniture-anchor metadata remains associated with the building's root ground level until later multi-level schema work defines per-floor ownership and transitions. `DMap` preserves valid `building_levels` declarations through save/load and removes malformed declarations.
 
 A building may opt into authored access completeness with `"access_validation": "complete"`:
 

--- a/Scripts/Gamedata/DMap.gd
+++ b/Scripts/Gamedata/DMap.gd
@@ -351,6 +351,23 @@ func _sanitize_buildings(data: Dictionary) -> void:
 			or not building.has("z") \
 			or not building["z"] is int:
 			return false
+		if building.has("building_levels"):
+			if not building["building_levels"] is Array or building["building_levels"].is_empty() or building["z"] != 0:
+				return false
+			var previous_level_z: int = -1
+			for level_definition in building["building_levels"]:
+				if not level_definition is Dictionary \
+				or level_definition.keys().size() != 1 \
+				or not level_definition.has("z") \
+				or not level_definition["z"] is int \
+				or level_definition["z"] < 0 \
+				or level_definition["z"] > 10 \
+				or level_definition["z"] % 2 != 0 \
+				or level_definition["z"] <= previous_level_z:
+					return false
+				previous_level_z = level_definition["z"]
+			if building["building_levels"][0].get("z") != 0:
+				return false
 		for room_id in building["rooms"]:
 			if not room_id is String or room_id not in valid_room_ids:
 				return false

--- a/Tests/Unit/test_dmap_sanitization.gd
+++ b/Tests/Unit/test_dmap_sanitization.gd
@@ -249,6 +249,47 @@ func test_dmap_buildings_roundtrip_and_sanitization():
 	}])
 
 
+func test_dmap_building_levels_roundtrip_and_sanitization():
+	var DMap = load("res://Scripts/Gamedata/DMap.gd")
+	var map = DMap.new("test_building_levels", "/tmp/", null)
+	map.set_data({
+		"name": "Building levels",
+		"description": "Preserve multi-level footprint metadata.",
+		"rooms": [
+			{"id": "office", "kind": "enclosed", "boundary_validation": "complete"},
+		],
+		"buildings": [
+			{
+				"id": "office_building",
+				"rooms": ["office"],
+				"footprint": {"x": 7, "y": 7, "width": 4, "height": 4},
+				"z": 0,
+				"building_levels": [{"z": 0}, {"z": 2}],
+			},
+			{
+				"id": "bad_levels",
+				"rooms": ["office"],
+				"footprint": {"x": 16, "y": 7, "width": 4, "height": 4},
+				"z": 0,
+				"building_levels": [{"z": 0}, {"z": 1}],
+			},
+		],
+		"levels": [[
+			{"id": "concrete_00"},
+		]],
+	})
+
+	var data = map.get_data()
+
+	assert_eq(data["buildings"], [{
+		"id": "office_building",
+		"rooms": ["office"],
+		"footprint": {"x": 7, "y": 7, "width": 4, "height": 4},
+		"z": 0,
+		"building_levels": [{"z": 0}, {"z": 2}],
+	}])
+
+
 func test_dmap_building_surfaces_roundtrip_and_sanitization():
 	var DMap = load("res://Scripts/Gamedata/DMap.gd")
 	var map = DMap.new("test_building_surfaces", "/tmp/", null)

--- a/Tools/examples/map_recipe_multi_level_building_foundation.json
+++ b/Tools/examples/map_recipe_multi_level_building_foundation.json
@@ -1,0 +1,77 @@
+{
+	"id": "generated_multi_level_building_foundation",
+	"name": "Generated Multi-Level Building Foundation",
+	"description": "A metadata-only two-floor building foundation with a ground floor at z 0, an open gap at z 1, and a first floor at z 2.",
+	"seed": 20260822,
+	"base_tile": {"id": "grass_plain_01"},
+	"rooms": [
+		{"id": "office", "kind": "enclosed", "boundary_validation": "complete"},
+		{"id": "garage_bay", "kind": "covered_open"}
+	],
+	"buildings": [
+		{
+			"id": "office_building",
+			"rooms": ["office", "garage_bay"],
+			"footprint": {"x": 7, "y": 7, "width": 5, "height": 4},
+			"z": 0,
+			"building_levels": [{"z": 0}, {"z": 2}],
+			"access_validation": "complete",
+			"interior_rooms": ["office"],
+			"open_space_rooms": ["garage_bay"],
+			"room_partition_validation": "complete",
+			"exterior_context": {"at": [6, 8], "z": 0},
+			"exterior_access_context": {"connection": "office_front_door"},
+			"entrances": [
+				{"id": "front_entrance", "connection": "office_front_door", "facing": "east"},
+				{"id": "garage_entrance", "connection": "garage_opening", "facing": "west"}
+			],
+			"entrance_validation": "complete",
+			"furniture_anchors": [
+				{"id": "office_door_anchor", "at": [8, 9], "z": 0, "kind": "door"},
+				{"id": "garage_door_anchor", "at": [11, 8], "z": 0, "kind": "door"}
+			]
+		}
+	],
+	"room_connections": [
+		{
+			"id": "office_front_door",
+			"at": [8, 9],
+			"z": 0,
+			"from": {"kind": "room", "id": "office"},
+			"to": {"kind": "exterior"}
+		},
+		{
+			"id": "garage_opening",
+			"at": [11, 8],
+			"z": 0,
+			"from": {"kind": "room", "id": "garage_bay"},
+			"to": {"kind": "exterior"}
+		}
+	],
+	"room_boundaries": [
+		{"id": "office_northwest_north", "room": "office", "at": [8, 7], "z": 0, "element": "wall_tile", "side": "south"},
+		{"id": "office_northeast_north", "room": "office", "at": [9, 7], "z": 0, "element": "wall_tile", "side": "south"},
+		{"id": "office_southwest_south", "room": "office", "at": [8, 10], "z": 0, "element": "wall_tile", "side": "north"},
+		{"id": "office_southeast_south", "room": "office", "at": [9, 10], "z": 0, "element": "wall_tile", "side": "north"},
+		{"id": "office_northwest_west", "room": "office", "at": [7, 8], "z": 0, "element": "wall_tile", "side": "east"},
+		{"id": "office_northeast_east", "room": "office", "at": [10, 8], "z": 0, "element": "wall_tile", "side": "west"},
+		{"id": "office_southeast_east", "room": "office", "at": [10, 9], "z": 0, "element": "wall_tile", "side": "west"},
+		{"id": "office_southwest_door", "room": "office", "at": [8, 9], "z": 0, "element": "door_furniture", "side": "west"},
+		{"id": "garage_east_door", "room": "garage_bay", "at": [11, 8], "z": 0, "element": "door_furniture", "side": "east"}
+	],
+	"operations": [
+		{"type": "rectangle", "x": 8, "y": 8, "width": 2, "height": 2, "tile": {"id": "concrete_00"}},
+		{"type": "room_rectangle", "room": "office", "x": 8, "y": 8, "width": 2, "height": 2},
+		{"type": "set", "x": 11, "y": 8, "tile": {"id": "concrete_00"}},
+		{"type": "room_rectangle", "room": "garage_bay", "x": 11, "y": 8, "width": 1, "height": 1},
+		{"type": "set", "x": 8, "y": 7, "tile": {"id": "brick_wall_00"}},
+		{"type": "set", "x": 9, "y": 7, "tile": {"id": "brick_wall_00"}},
+		{"type": "set", "x": 8, "y": 10, "tile": {"id": "brick_wall_00"}},
+		{"type": "set", "x": 9, "y": 10, "tile": {"id": "brick_wall_00"}},
+		{"type": "set", "x": 7, "y": 8, "tile": {"id": "brick_wall_00"}},
+		{"type": "set", "x": 10, "y": 8, "tile": {"id": "brick_wall_00"}},
+		{"type": "set", "x": 10, "y": 9, "tile": {"id": "brick_wall_00"}},
+		{"type": "furniture", "id": "door_wood", "x": 8, "y": 9, "rotation": 0},
+		{"type": "furniture", "id": "door_wood", "x": 11, "y": 8, "rotation": 0}
+	]
+}

--- a/Tools/map_generator.py
+++ b/Tools/map_generator.py
@@ -87,8 +87,9 @@ ROOM_CONNECTION_ENDPOINT_FIELDS = {"kind", "id"}
 ROOM_CONNECTION_ENDPOINT_KINDS = {"room", "exterior"}
 ROOM_BOUNDARY_FIELDS = {"id", "room", "at", "z", "element", "side"}
 ROOM_BOUNDARY_ELEMENTS = {"wall_tile", "door_furniture"}
-BUILDING_FIELDS = {"id", "rooms", "footprint", "z", "access_validation", "interior_rooms", "open_space_rooms", "room_partition_validation", "overhead_validation", "exterior_context", "exterior_access_context", "entrance", "entrances", "entrance_validation", "furniture_anchors"}
+BUILDING_FIELDS = {"id", "rooms", "footprint", "z", "building_levels", "access_validation", "interior_rooms", "open_space_rooms", "room_partition_validation", "overhead_validation", "exterior_context", "exterior_access_context", "entrance", "entrances", "entrance_validation", "furniture_anchors"}
 BUILDING_REQUIRED_FIELDS = {"id", "rooms", "footprint", "z"}
+BUILDING_LEVEL_FIELDS = {"z"}
 BUILDING_EXTERIOR_CONTEXT_FIELDS = {"at", "z"}
 BUILDING_EXTERIOR_ACCESS_CONTEXT_FIELDS = {"connection"}
 BUILDING_ENTRANCE_FIELDS = {"connection", "facing"}
@@ -1117,6 +1118,35 @@ def _validate_recipe_buildings(
         z = building["z"]
         if type(z) is not int or not MIN_LOGICAL_Z <= z <= MAX_LOGICAL_Z:
             raise RecipeError(f"{context}.z must be an integer from -10 through 10")
+        building_levels = building.get("building_levels")
+        if building_levels is not None:
+            if not isinstance(building_levels, list) or not building_levels:
+                raise RecipeError(f"{context}.building_levels must be a non-empty array")
+            level_z_values: list[int] = []
+            for level_index, level_definition in enumerate(building_levels):
+                level_context = f"{context}.building_levels[{level_index}]"
+                if (
+                    not isinstance(level_definition, dict)
+                    or set(level_definition) != BUILDING_LEVEL_FIELDS
+                    or type(level_definition.get("z")) is not int
+                ):
+                    raise RecipeError(f"{level_context} must define integer z")
+                level_z = level_definition["z"]
+                if not 0 <= level_z <= MAX_LOGICAL_Z:
+                    raise RecipeError(f"{level_context}.z must be an integer from 0 through 10")
+                if level_z % 2 != 0:
+                    raise RecipeError(
+                        f"{level_context}.z must be even; odd levels are intentional open gaps"
+                    )
+                if level_z_values and level_z <= level_z_values[-1]:
+                    raise RecipeError(
+                        f"{level_context}.z must be strictly greater than the previous building level"
+                    )
+                level_z_values.append(level_z)
+            if level_z_values[0] != 0:
+                raise RecipeError(f"{context}.building_levels must start with ground floor z 0")
+            if z != 0:
+                raise RecipeError(f"{context}.z must be 0 when building_levels is declared")
         access_validation = building.get("access_validation")
         if access_validation is not None and access_validation not in BUILDING_ACCESS_VALIDATIONS:
             raise RecipeError(
@@ -1286,6 +1316,8 @@ def _validate_recipe_buildings(
             "footprint": {"x": x, "y": y, "width": width, "height": height},
             "z": z,
         }
+        if building_levels is not None:
+            validated_building["building_levels"] = building_levels
         if access_validation is not None:
             validated_building["access_validation"] = access_validation
         if interior_rooms is not None:

--- a/Tools/map_validator.py
+++ b/Tools/map_validator.py
@@ -24,8 +24,9 @@ ROOM_CONNECTION_FIELDS = {'id', 'at', 'z', 'from', 'to'}
 ROOM_CONNECTION_ENDPOINT_KINDS = {'room', 'exterior'}
 ROOM_BOUNDARY_FIELDS = {'id', 'room', 'at', 'z', 'element', 'side'}
 ROOM_BOUNDARY_ELEMENTS = {'wall_tile', 'door_furniture'}
-BUILDING_FIELDS = {'id', 'rooms', 'footprint', 'z', 'access_validation', 'interior_rooms', 'open_space_rooms', 'room_partition_validation', 'overhead_validation', 'exterior_context', 'exterior_access_context', 'entrance', 'entrances', 'entrance_validation', 'furniture_anchors'}
+BUILDING_FIELDS = {'id', 'rooms', 'footprint', 'z', 'building_levels', 'access_validation', 'interior_rooms', 'open_space_rooms', 'room_partition_validation', 'overhead_validation', 'exterior_context', 'exterior_access_context', 'entrance', 'entrances', 'entrance_validation', 'furniture_anchors'}
 BUILDING_REQUIRED_FIELDS = {'id', 'rooms', 'footprint', 'z'}
+BUILDING_LEVEL_FIELDS = {'z'}
 BUILDING_EXTERIOR_CONTEXT_FIELDS = {'at', 'z'}
 BUILDING_EXTERIOR_ACCESS_CONTEXT_FIELDS = {'connection'}
 BUILDING_ENTRANCE_FIELDS = {'connection', 'facing'}
@@ -815,6 +816,29 @@ class MapValidator:
             z_valid = type(z) is int and -10 <= z <= 10
             if not z_valid:
                 self.add_error(file_path, f"{context} z must be an integer from -10 through 10.")
+            building_levels = building.get('building_levels')
+            if building_levels is not None:
+                if not isinstance(building_levels, list) or not building_levels:
+                    self.add_error(file_path, f"{context} building_levels must be a non-empty array.")
+                else:
+                    previous_z = None
+                    for level_index, level_definition in enumerate(building_levels):
+                        level_context = f"{context} building_levels[{level_index}]"
+                        if not isinstance(level_definition, dict) or set(level_definition) != BUILDING_LEVEL_FIELDS or type(level_definition.get('z')) is not int:
+                            self.add_error(file_path, f"{level_context} must define integer z.")
+                            continue
+                        level_z = level_definition['z']
+                        if not 0 <= level_z <= 10:
+                            self.add_error(file_path, f"{level_context} z must be an integer from 0 through 10.")
+                        elif level_z % 2 != 0:
+                            self.add_error(file_path, f"{level_context} z must be even; odd levels are intentional open gaps.")
+                        if previous_z is not None and level_z <= previous_z:
+                            self.add_error(file_path, f"{level_context} z must be strictly greater than the previous building level.")
+                        previous_z = level_z
+                    if isinstance(building_levels[0], dict) and building_levels[0].get('z') != 0:
+                        self.add_error(file_path, f"{context} building_levels must start with ground floor z 0.")
+                if z_valid and z != 0:
+                    self.add_error(file_path, f"{context} z must be 0 when building_levels is declared.")
             access_validation = building.get('access_validation')
             if access_validation is not None and access_validation not in BUILDING_ACCESS_VALIDATIONS:
                 self.add_error(file_path, f"{context} access_validation has unsupported validation '{access_validation}'.")

--- a/Tools/tests/test_map_generator.py
+++ b/Tools/tests/test_map_generator.py
@@ -2730,6 +2730,43 @@ class MapGeneratorTests(unittest.TestCase):
         with self.assertRaisesRegex(RecipeError, "road_endpoints must be an array"):
             generate_map(recipe, TILES_PATH)
 
+    def test_multi_level_building_foundation_preserves_even_floor_levels(self):
+        recipe_path = ROOT / "Tools" / "examples" / "map_recipe_multi_level_building_foundation.json"
+        recipe = json.loads(recipe_path.read_text(encoding="utf-8"))
+
+        generated = generate_map(recipe, TILES_PATH)
+
+        building = generated["buildings"][0]
+        self.assertEqual(building["z"], 0)
+        self.assertEqual(building["building_levels"], [{"z": 0}, {"z": 2}])
+        self.assertNotIn("building_surfaces", generated)
+
+    def test_multi_level_building_foundation_requires_ground_and_even_levels(self):
+        recipe_path = ROOT / "Tools" / "examples" / "map_recipe_multi_level_building_foundation.json"
+        recipe = json.loads(recipe_path.read_text(encoding="utf-8"))
+
+        def with_levels(levels):
+            candidate = json.loads(json.dumps(recipe))
+            candidate["buildings"][0]["building_levels"] = levels
+            return candidate
+
+        invalid_cases = [
+            ([], "building_levels must be a non-empty array"),
+            ([{"z": 2}], "building_levels must start with ground floor z 0"),
+            ([{"z": 0}, {"z": 1}], "z must be even; odd levels are intentional open gaps"),
+            ([{"z": 0}, {"z": 4}, {"z": 2}], "z must be strictly greater than the previous building level"),
+            ([{"z": 0, "kind": "floor"}], "must define integer z"),
+        ]
+        for levels, message in invalid_cases:
+            with self.subTest(levels=levels):
+                with self.assertRaisesRegex(RecipeError, message):
+                    generate_map(with_levels(levels), TILES_PATH)
+
+        non_ground_building = with_levels([{"z": 0}, {"z": 2}])
+        non_ground_building["buildings"][0]["z"] = 1
+        with self.assertRaisesRegex(RecipeError, "z must be 0 when building_levels is declared"):
+            generate_map(non_ground_building, TILES_PATH)
+
 
 class MapValidatorDimensionTests(unittest.TestCase):
     def validate(self, map_data):
@@ -3489,6 +3526,22 @@ class MapValidatorDimensionTests(unittest.TestCase):
         non_array["road_endpoints"] = {}
         errors = self.validate(non_array)
         self.assertTrue(any("top-level road_endpoints must be an array" in error for error in errors))
+
+    def test_validates_multi_level_building_foundation_content(self):
+        recipe_path = ROOT / "Tools" / "examples" / "map_recipe_multi_level_building_foundation.json"
+        recipe = json.loads(recipe_path.read_text(encoding="utf-8"))
+        valid_map = generate_map(recipe, TILES_PATH)
+        self.assertEqual(self.validate(valid_map), [])
+
+        odd_level = json.loads(json.dumps(valid_map))
+        odd_level["buildings"][0]["building_levels"][1]["z"] = 1
+        errors = self.validate(odd_level)
+        self.assertTrue(any("z must be even" in error for error in errors))
+
+        missing_ground = json.loads(json.dumps(valid_map))
+        missing_ground["buildings"][0]["building_levels"] = [{"z": 2}]
+        errors = self.validate(missing_ground)
+        self.assertTrue(any("must start with ground floor z 0" in error for error in errors))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

Adds the first multi-level building footprint foundation for Phase 6.

Buildings can now declare occupied floor levels while preserving the
project's intended vertical convention:

```text
z: 0  ground floor
z: 1  intentional open gap
z: 2  ceiling / first floor
z: 3  intentional open gap
z: 4  second occupied floor