### PR TITLE
Strengthen staircase metadata sanitization

### DIFF
--- a/Scripts/Gamedata/DMap.gd
+++ b/Scripts/Gamedata/DMap.gd
@@ -405,6 +405,16 @@ func _sanitize_buildings(data: Dictionary) -> void:
 				staircase_ids.append(staircase["id"])
 			if not (0 in building["building_levels"].map(func(level): return level.get("z")) and 2 in building["building_levels"].map(func(level): return level.get("z"))):
 				return false
+			for staircase in building["staircases"]:
+				var lower_at: Array = staircase["lower_at"]
+				var upper_at: Array = staircase["upper_at"]
+				if lower_at[0] < building["footprint"]["x"] or lower_at[0] >= building["footprint"]["x"] + building["footprint"]["width"] \
+				or lower_at[1] < building["footprint"]["y"] or lower_at[1] >= building["footprint"]["y"] + building["footprint"]["height"] \
+				or upper_at[0] < building["footprint"]["x"] or upper_at[0] >= building["footprint"]["x"] + building["footprint"]["width"] \
+				or upper_at[1] < building["footprint"]["y"] or upper_at[1] >= building["footprint"]["y"] + building["footprint"]["height"]:
+					return false
+				if abs(lower_at[0] - upper_at[0]) + abs(lower_at[1] - upper_at[1]) != 1:
+					return false
 		for room_id in building["rooms"]:
 			if not room_id is String or room_id not in valid_room_ids:
 				return false

--- a/Tests/Unit/test_dmap_sanitization.gd
+++ b/Tests/Unit/test_dmap_sanitization.gd
@@ -277,6 +277,14 @@ func test_dmap_building_levels_roundtrip_and_sanitization():
 				"z": 0,
 				"building_levels": [{"z": 0}, {"z": 1}],
 			},
+			{
+				"id": "bad_staircase",
+				"rooms": ["office"],
+				"footprint": {"x": 7, "y": 16, "width": 4, "height": 4},
+				"z": 0,
+				"building_levels": [{"z": 0}, {"z": 2}],
+				"staircases": [{"id": "bad_staircase", "lower_at": [8, 17], "upper_at": [10, 17], "rotation": 90}],
+			},
 		],
 		"levels": [[
 			{"id": "concrete_00"},

--- a/Tools/tests/test_map_generator.py
+++ b/Tools/tests/test_map_generator.py
@@ -3570,6 +3570,13 @@ class MapValidatorDimensionTests(unittest.TestCase):
         errors = self.validate(missing_ground)
         self.assertTrue(any("must start with ground floor z 0" in error for error in errors))
 
+        wrong_slope = json.loads(json.dumps(valid_map))
+        for operation in wrong_slope["levels"][11]:
+            if isinstance(operation, dict) and operation.get("id") == "grass_ramp_00":
+                operation["rotation"] = 0
+        errors = self.validate(wrong_slope)
+        self.assertTrue(any("requires a grass_ramp_00 slope" in error for error in errors))
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary

Completes the persistence and regression coverage for the per-floor
staircase physical-semantics feature already merged in PR #943.

## Changes

DMap sanitization now rejects staircase metadata when:

- lower or upper coordinates lie outside the building footprint
- lower and upper positions are not cardinally adjacent
- required building levels z 0 and z 2 are not declared
- staircase IDs are duplicated
- the staircase record is malformed

Added regression coverage for:

- valid staircase round-trip preservation
- invalid staircase sanitization
- mismatched upper-slope rotation

The staircase contract remains:

```text
z: 1  first slope block
z: 2  second slope block / upper-floor surface