### PR TITLE
Add authored road path routing metadata

### DIFF
--- a/Documentation/Game_design/Map_generation_plan.md
+++ b/Documentation/Game_design/Map_generation_plan.md
@@ -711,7 +711,7 @@ Generate one small, enterable building that loads correctly and has a reachable 
 
 ## Phase 7 — Roads and map connections
 
-**Status: in progress; authored map-edge connection metadata and road endpoint anchoring complete**
+**Status: in progress; authored map-edge connections, road endpoints, and route polylines complete**
 
 The prototype previously hardcoded all four edge connections as `"ground"`. These are now authored recipe-level metadata, with named endpoint anchors identifying the exact map-edge cells where roads enter or exit.
 
@@ -721,7 +721,7 @@ The recipe generator supports a root-level `connections` field. It accepts up to
 
 The recipe generator now also supports root-level `road_endpoints`. Each endpoint has a unique `id`, a cardinal `direction`, an edge coordinate `at`, and ground-level `z: 0`. Its direction must be declared as `"road"` in `connections`, and its coordinate must lie on the corresponding map edge. The generator, standalone validator, and DMap save/load path validate or preserve these authored references. `Tools/examples/map_recipe_road_endpoints.json` is the maintained evidence: a simple outdoor map with west and east road endpoints and a deterministic connecting dirt path.
 
-This foundation authors metadata only: it does not generate road tiles, perform path routing, or alter edge tile placement. It declares what the runtime should expect at each edge and where the authored road entry/exit anchors are so later routing and adjacent-map integration can build on a validated contract.
+`road_paths` now authors a named ground-level cardinal polyline between two validated `road_endpoints`. The generator and standalone validator require different existing endpoint IDs, optional map-bounded waypoints, and cardinal continuity across the complete endpoint-to-endpoint sequence. The maintained `map_recipe_road_endpoints.json` demonstrates a direct west-to-east route. This remains metadata-only: it does not paint road tiles, perform pathfinding, infer walkability, or alter collision/navigation.
 
 Capabilities:
 
@@ -959,13 +959,14 @@ Do not commit or push unless explicitly requested.
 [Complete] Authored furniture anchor metadata
 [Complete] Authored map-edge connection metadata
 [Complete] Authored road endpoint anchoring
+[Complete] Authored road path routing metadata
 [Complete] Multi-level building footprint foundation with intentional open gaps
 [Complete] Per-floor room and furniture ownership metadata
 [Complete] Two-slope staircase physical semantics at z 1 and z 2
 [Complete] Straight and corner staircase formations with no slope stacking
 [Complete] Per-floor ceiling/floor surface semantics (top-down)
 [Complete] Multi-level roof/support semantics
-[Next]     Road path routing
+[Next]     Road feature connectivity or map-to-map route integration
 [In Progress]  Rooms and buildings
 [In Progress]  Roads and map connections
 [Planned]  Multi-level reusable templates and richer composition

--- a/Documentation/Modding/map_recipe_generator.md
+++ b/Documentation/Modding/map_recipe_generator.md
@@ -108,6 +108,23 @@ Each entry has exactly `id`, `direction`, `at`, and `z`. `id` is unique within t
 
 The standalone validator independently checks the same content: it rejects unknown directions, duplicate IDs, coordinates not on the correct edge, and non-zero `z` values. `DMap` preserves valid road endpoints through editor save/load and removes entries with missing fields, invalid directions, duplicate IDs, or malformed coordinates.
 
+`road_paths` authors a named cardinal polyline between two road endpoints:
+
+```json
+{
+  "road_paths": [
+    {
+      "id": "west_to_east_road",
+      "from": "west_entrance",
+      "to": "east_exit",
+      "waypoints": []
+    }
+  ]
+}
+```
+
+Each path has exactly `id`, `from`, `to`, and `waypoints`. Both endpoint IDs must exist and be different. `waypoints` is an optional array of map-bounded `[x, y]` coordinates; the complete sequence from the `from` endpoint through the waypoints to the `to` endpoint must form cardinally aligned segments. Paths are ground-level metadata only: they do not paint road tiles, run pathfinding, infer walkability, or alter collision/navigation. `DMap` preserves valid paths and removes paths with stale endpoints, malformed points, duplicate IDs, or non-cardinal segments.
+
 `Tools/examples/map_recipe_road_endpoints.json` demonstrates the maintained example with two road endpoints: `west_entrance` at the west edge and `east_exit` at the east edge.
 
 ## Logical levels

--- a/Scripts/Gamedata/DMap.gd
+++ b/Scripts/Gamedata/DMap.gd
@@ -101,6 +101,7 @@ var building_surfaces: Array = []
 var building_supports: Array = []
 var building_compositions: Array = []
 var road_endpoints: Array = []
+var road_paths: Array = []
 var sprite: Texture = null
 # Variable to store connections. For example: {"south": "road","west": "ground"} default to ground
 var connections: Dictionary = {
@@ -161,6 +162,7 @@ func set_data(newdata: Dictionary) -> void:
 	building_supports = newdata.get("building_supports", [])
 	building_compositions = newdata.get("building_compositions", [])
 	road_endpoints = newdata.get("road_endpoints", [])
+	road_paths = newdata.get("road_paths", [])
 	connections = newdata.get("connections", {})  # Set connections from data if present
 
 
@@ -194,6 +196,8 @@ func get_data() -> Dictionary:
 		mydata["building_compositions"] = building_compositions
 	if not road_endpoints.is_empty():
 		mydata["road_endpoints"] = road_endpoints
+	if not road_paths.is_empty():
+		mydata["road_paths"] = road_paths
 	if not connections.is_empty():  # Omit connections if empty
 		mydata["connections"] = connections
 	
@@ -207,6 +211,7 @@ func get_data() -> Dictionary:
 	_sanitize_building_supports(mydata)
 	_sanitize_building_compositions(mydata)
 	_sanitize_road_endpoints(mydata)
+	_sanitize_road_paths(mydata)
 
 	# NEW: Implement sanitization for corrupt tiles (missing or empty ID when metadata exists)
 	_sanitize_tile_objects(mydata)
@@ -670,6 +675,38 @@ func _sanitize_road_endpoints(data: Dictionary) -> void:
 	)
 	if data["road_endpoints"].is_empty():
 		data.erase("road_endpoints")
+
+
+func _sanitize_road_paths(data: Dictionary) -> void:
+	if not data.has("road_paths") or not data["road_paths"] is Array:
+		return
+	var endpoint_ids: Array[String] = []
+	var seen_path_ids: Array[String] = []
+	for endpoint in data.get("road_endpoints", []):
+		if endpoint is Dictionary and endpoint.get("id") is String:
+			endpoint_ids.append(endpoint["id"])
+	data["road_paths"] = data["road_paths"].filter(func(path):
+		if not path is Dictionary or path.keys().size() != 4 or not path.has("id") or not path["id"] is String or path["id"].is_empty() or path["id"] in seen_path_ids or not path.has("from") or not path["from"] in endpoint_ids or not path.has("to") or not path["to"] in endpoint_ids or path["from"] == path["to"] or not path.has("waypoints") or not path["waypoints"] is Array:
+			return false
+		var points: Array = []
+		for endpoint in data["road_endpoints"]:
+			if endpoint.get("id") == path["from"]:
+				points.append(endpoint["at"])
+		for waypoint in path["waypoints"]:
+			points.append(waypoint)
+		for endpoint in data["road_endpoints"]:
+			if endpoint.get("id") == path["to"]:
+				points.append(endpoint["at"])
+		for index in points.size():
+			if not points[index] is Array or points[index].size() != 2 or not points[index][0] is int or not points[index][1] is int or points[index][0] < 0 or points[index][0] >= 32 or points[index][1] < 0 or points[index][1] >= 32:
+				return false
+			if index > 0 and points[index][0] != points[index - 1][0] and points[index][1] != points[index - 1][1]:
+				return false
+		seen_path_ids.append(path["id"])
+		return true
+	)
+	if data["road_paths"].is_empty():
+		data.erase("road_paths")
 
 
 func load_data_from_disk():

--- a/Tests/Unit/test_dmap_sanitization.gd
+++ b/Tests/Unit/test_dmap_sanitization.gd
@@ -358,6 +358,26 @@ func test_dmap_building_surfaces_roundtrip_and_sanitization():
 	])
 
 
+func test_dmap_road_paths_roundtrip_and_sanitization():
+	var DMap = load("res://Scripts/Gamedata/DMap.gd")
+	var map = DMap.new("test_road_paths", "/tmp/", null)
+	map.set_data({
+		"name": "Road paths",
+		"description": "Preserve authored routes.",
+		"connections": {"east": "road", "west": "road", "north": "ground", "south": "ground"},
+		"road_endpoints": [
+			{"id": "west", "direction": "west", "at": [0, 16], "z": 0},
+			{"id": "east", "direction": "east", "at": [31, 16], "z": 0},
+		],
+		"road_paths": [
+			{"id": "valid_route", "from": "west", "to": "east", "waypoints": []},
+			{"id": "bad_route", "from": "west", "to": "missing", "waypoints": []},
+		],
+	})
+	var data = map.get_data()
+	assert_eq(data["road_paths"], [{"id": "valid_route", "from": "west", "to": "east", "waypoints": []}])
+
+
 func test_dmap_building_compositions_roundtrip_and_sanitization():
 	var DMap = load("res://Scripts/Gamedata/DMap.gd")
 	var map = DMap.new("test_building_compositions", "/tmp/", null)

--- a/Tools/examples/map_recipe_road_endpoints.json
+++ b/Tools/examples/map_recipe_road_endpoints.json
@@ -14,6 +14,9 @@
 		{"id": "west_entrance", "direction": "west", "at": [0, 16], "z": 0},
 		{"id": "east_exit", "direction": "east", "at": [31, 16], "z": 0}
 	],
+	"road_paths": [
+		{"id": "west_to_east_road", "from": "west_entrance", "to": "east_exit", "waypoints": []}
+	],
 	"operations": [
 		{"type": "line", "from": [0, 16], "to": [31, 16], "tile": {"id": "dirt_light_00"}}
 	]

--- a/Tools/map_generator.py
+++ b/Tools/map_generator.py
@@ -34,6 +34,7 @@ DEFAULT_CONNECTIONS = {
 CONNECTION_DIRECTIONS = {"north", "east", "south", "west"}
 CONNECTION_TYPES = {"ground", "road"}
 ROAD_ENDPOINT_FIELDS = {"id", "direction", "at", "z"}
+ROAD_PATH_FIELDS = {"id", "from", "to", "waypoints"}
 EDGE_COORDINATES = {
     "north": lambda x, y: y == 0,
     "south": lambda x, y: y == MAP_HEIGHT - 1,
@@ -131,6 +132,7 @@ RECIPE_FIELDS = {
     "levels",
     "connections",
     "road_endpoints",
+    "road_paths",
 }
 
 
@@ -2636,6 +2638,43 @@ def _validate_road_endpoints(
     return validated
 
 
+def _validate_road_paths(
+    road_paths: Any,
+    road_endpoints: list[dict[str, Any]],
+) -> list[dict[str, Any]]:
+    if road_paths is None:
+        return []
+    if not isinstance(road_paths, list):
+        raise RecipeError("road_paths must be an array")
+    endpoint_by_id = {endpoint["id"]: endpoint for endpoint in road_endpoints}
+    validated: list[dict[str, Any]] = []
+    seen_ids: set[str] = set()
+    for index, path in enumerate(road_paths):
+        context = f"road_paths[{index}]"
+        if not isinstance(path, dict) or set(path) != ROAD_PATH_FIELDS:
+            raise RecipeError(f"{context} must define id, from, to, and waypoints")
+        path_id = path["id"]
+        if not isinstance(path_id, str) or not path_id.strip():
+            raise RecipeError(f"{context}.id must be a non-empty string")
+        if path_id in seen_ids:
+            raise RecipeError(f"duplicate road path ID '{path_id}'")
+        seen_ids.add(path_id)
+        from_id, to_id = path["from"], path["to"]
+        if from_id not in endpoint_by_id or to_id not in endpoint_by_id:
+            raise RecipeError(f"{context} must reference existing road endpoint IDs")
+        if from_id == to_id:
+            raise RecipeError(f"{context}.from and to must reference different endpoints")
+        waypoints = path["waypoints"]
+        if not isinstance(waypoints, list):
+            raise RecipeError(f"{context}.waypoints must be an array")
+        points = [endpoint_by_id[from_id]["at"], *waypoints, endpoint_by_id[to_id]["at"]]
+        for point_index, point in enumerate(points):
+            if not isinstance(point, list) or len(point) != 2 or any(type(value) is not int for value in point) or not 0 <= point[0] < MAP_WIDTH or not 0 <= point[1] < MAP_HEIGHT:
+                raise RecipeError(f"{context} point {point_index} must be a map-bounded two-integer coordinate")
+            if point_index and points[point_index][0] != points[point_index - 1][0] and points[point_index][1] != points[point_index - 1][1]:
+                raise RecipeError(f"{context} points must form cardinally aligned segments")
+        validated.append({"id": path_id, "from": from_id, "to": to_id, "waypoints": waypoints})
+    return validated
 def generate_map(
     recipe: dict[str, Any],
     tiles_path: Path,
@@ -2762,6 +2801,7 @@ def generate_map(
     )
     connections = _validate_connections(recipe.get("connections"))
     road_endpoints = _validate_road_endpoints(recipe.get("road_endpoints"), connections, levels)
+    road_paths = _validate_road_paths(recipe.get("road_paths"), road_endpoints)
 
     generated = {
         "id": recipe["id"],
@@ -2792,6 +2832,8 @@ def generate_map(
         generated["building_compositions"] = building_compositions
     if road_endpoints:
         generated["road_endpoints"] = road_endpoints
+    if road_paths:
+        generated["road_paths"] = road_paths
     return generated
 
 

--- a/Tools/map_validator.py
+++ b/Tools/map_validator.py
@@ -11,6 +11,7 @@ POPULATED_LEVEL_TILE_COUNT = MAP_WIDTH * MAP_HEIGHT
 CONNECTION_DIRECTIONS = {'north', 'east', 'south', 'west'}
 CONNECTION_TYPES = {'ground', 'road'}
 ROAD_ENDPOINT_FIELDS = {'id', 'direction', 'at', 'z'}
+ROAD_PATH_FIELDS = {'id', 'from', 'to', 'waypoints'}
 ROOM_KINDS = {'enclosed', 'covered_open', 'ruin'}
 ROOM_BOUNDARY_VALIDATIONS = {'complete'}
 CARDINAL_SIDES = {
@@ -225,7 +226,11 @@ class MapValidator:
         if not isinstance(road_endpoints, list):
             self.add_error(file_path, "top-level road_endpoints must be an array.")
             road_endpoints = []
-        else:
+        road_paths = data.get('road_paths', [])
+        if not isinstance(road_paths, list):
+            self.add_error(file_path, "top-level road_paths must be an array.")
+            road_paths = []
+        if isinstance(road_endpoints, list):
             seen_endpoint_ids: Set[str] = set()
             for idx, endpoint in enumerate(road_endpoints):
                 if not isinstance(endpoint, dict):
@@ -275,6 +280,36 @@ class MapValidator:
                 z = endpoint.get('z')
                 if z is not None and (type(z) is not int or z != 0):
                     self.add_error(file_path, f"{context} z must be 0.")
+
+            endpoint_by_id = {endpoint.get('id'): endpoint for endpoint in road_endpoints if isinstance(endpoint, dict) and isinstance(endpoint.get('id'), str)}
+            seen_path_ids: Set[str] = set()
+            for idx, path in enumerate(road_paths):
+                context = f"road_paths[{idx}]"
+                if not isinstance(path, dict) or set(path) != ROAD_PATH_FIELDS:
+                    self.add_error(file_path, f"{context} must define id, from, to, and waypoints.")
+                    continue
+                path_id = path.get('id')
+                if not isinstance(path_id, str) or not path_id:
+                    self.add_error(file_path, f"{context} id must be a non-empty string.")
+                elif path_id in seen_path_ids:
+                    self.add_error(file_path, f"{context} duplicates road path ID '{path_id}'.")
+                seen_path_ids.add(path_id)
+                from_id, to_id = path.get('from'), path.get('to')
+                if from_id not in endpoint_by_id or to_id not in endpoint_by_id:
+                    self.add_error(file_path, f"{context} must reference existing road endpoint IDs.")
+                if from_id == to_id:
+                    self.add_error(file_path, f"{context} from and to must reference different endpoints.")
+                waypoints = path.get('waypoints')
+                if not isinstance(waypoints, list):
+                    self.add_error(file_path, f"{context} waypoints must be an array.")
+                    continue
+                endpoints = [endpoint_by_id[from_id]['at']] if from_id in endpoint_by_id else []
+                points = endpoints + waypoints + ([endpoint_by_id[to_id]['at']] if to_id in endpoint_by_id else [])
+                for point_index, point in enumerate(points):
+                    if not isinstance(point, list) or len(point) != 2 or not all(type(value) is int for value in point) or not 0 <= point[0] < MAP_WIDTH or not 0 <= point[1] < MAP_HEIGHT:
+                        self.add_error(file_path, f"{context} point {point_index} must be a map-bounded two-integer coordinate.")
+                    elif point_index and points[point_index][0] != points[point_index - 1][0] and points[point_index][1] != points[point_index - 1][1]:
+                        self.add_error(file_path, f"{context} points must form cardinally aligned segments.")
 
         # 3. Enforce the fixed map dimensions used by the loader and editor.
         map_width = data.get('mapwidth', MAP_WIDTH)

--- a/Tools/tests/test_map_generator.py
+++ b/Tools/tests/test_map_generator.py
@@ -2653,6 +2653,20 @@ class MapGeneratorTests(unittest.TestCase):
         self.assertEqual(len(endpoints), 2)
         self.assertEqual(endpoints[0], {"id": "west_entrance", "direction": "west", "at": [0, 16], "z": 0})
         self.assertEqual(endpoints[1], {"id": "east_exit", "direction": "east", "at": [31, 16], "z": 0})
+        self.assertEqual(generated["road_paths"], [{"id": "west_to_east_road", "from": "west_entrance", "to": "east_exit", "waypoints": []}])
+
+    def test_road_paths_require_endpoint_references_and_cardinal_continuity(self):
+        recipe_path = ROOT / "Tools" / "examples" / "map_recipe_road_endpoints.json"
+        recipe = json.loads(recipe_path.read_text(encoding="utf-8"))
+        invalid_reference = json.loads(json.dumps(recipe))
+        invalid_reference["road_paths"][0]["to"] = "missing"
+        with self.assertRaisesRegex(RecipeError, "must reference existing road endpoint IDs"):
+            generate_map(invalid_reference, TILES_PATH)
+        invalid_segment = json.loads(json.dumps(recipe))
+        invalid_segment["road_paths"][0]["waypoints"] = [[2, 17]]
+        with self.assertRaisesRegex(RecipeError, "points must form cardinally aligned segments"):
+            generate_map(invalid_segment, TILES_PATH)
+
 
     def test_road_endpoints_require_road_connection(self):
         recipe = valid_recipe()
@@ -3628,6 +3642,11 @@ class MapValidatorDimensionTests(unittest.TestCase):
         non_array["road_endpoints"] = {}
         errors = self.validate(non_array)
         self.assertTrue(any("top-level road_endpoints must be an array" in error for error in errors))
+
+        invalid_path = json.loads(json.dumps(valid_map))
+        invalid_path["road_paths"][0]["waypoints"] = [[2, 17]]
+        errors = self.validate(invalid_path)
+        self.assertTrue(any("points must form cardinally aligned segments" in error for error in errors))
 
     def test_validates_multi_level_building_foundation_content(self):
         recipe_path = ROOT / "Tools" / "examples" / "map_recipe_multi_level_building_foundation.json"


### PR DESCRIPTION
Add root-level road_paths metadata for authored ground-level routes between validated road endpoints.

Each route declares:
- a unique ID
- different from/to road endpoint IDs
- optional map-bounded waypoints

Validate that all route segments are cardinally aligned, endpoint references exist, IDs are unique, and coordinates remain within the 32x32 map.

Preserve and sanitize road paths through DMap save/load.

Update the maintained road-endpoint example, generator tests, standalone validator coverage, GUT persistence coverage, modding documentation, and the map-generation roadmap.

This remains metadata-only and does not paint road tiles, perform pathfinding, infer walkability, or alter collision/navigation.

Validation:
- 150 Python tests passed
- 89 GUT tests passed
- 15 maintained examples validated