### PR TITLE
feat(mapgen): paint deterministic local road paths

### DIFF
--- a/Documentation/Game_design/Map_generation_plan.md
+++ b/Documentation/Game_design/Map_generation_plan.md
@@ -711,7 +711,7 @@ Generate one small, enterable building that loads correctly and has a reachable 
 
 ## Phase 7 — Roads and map connections
 
-**Status: in progress; authored map-edge connections, road endpoints, and route polylines complete**
+**Status: in progress; authored map-edge connections, road endpoints, route polylines, and map-local road painting complete**
 
 The prototype previously hardcoded all four edge connections as `"ground"`. These are now authored recipe-level metadata, with named endpoint anchors identifying the exact map-edge cells where roads enter or exit.
 
@@ -721,27 +721,27 @@ The recipe generator supports a root-level `connections` field. It accepts up to
 
 The recipe generator now also supports root-level `road_endpoints`. Each endpoint has a unique `id`, a cardinal `direction`, an edge coordinate `at`, and ground-level `z: 0`. Its direction must be declared as `"road"` in `connections`, and its coordinate must lie on the corresponding map edge. The generator, standalone validator, and DMap save/load path validate or preserve these authored references. `Tools/examples/map_recipe_road_endpoints.json` is the maintained evidence: a simple outdoor map with west and east road endpoints and a deterministic connecting dirt path.
 
-`road_paths` now authors a named ground-level cardinal polyline between two validated `road_endpoints`. The generator and standalone validator require different existing endpoint IDs, optional map-bounded waypoints, and cardinal continuity across the complete endpoint-to-endpoint sequence. The maintained `map_recipe_road_endpoints.json` demonstrates a direct west-to-east route. This remains metadata-only: it does not paint road tiles, perform pathfinding, infer walkability, or alter collision/navigation.
+`road_paths` now authors a named ground-level cardinal polyline between two validated `road_endpoints`. The generator and standalone validator require different existing endpoint IDs, optional map-bounded waypoints, and cardinal continuity across the complete endpoint-to-endpoint sequence. A path may now provide a known `tile`; the generator rasterizes and paints the complete route after validating supporting terrain and rejecting feature overwrites. The maintained `map_recipe_road_endpoints.json` demonstrates a generated west-to-east dirt route. This remains map-local geometry: it does not run pathfinding, infer walkability from arbitrary terrain, alter collision/navigation, or integrate multiple maps.
 
 Capabilities:
 
 * entrances on map edges;
 * road endpoints;
-* path routing between anchors;
+* path routing and deterministic road painting between anchors;
 * north/east/south/west connection metadata;
-* guaranteed connection between entry points and important locations;
-* bridge or obstacle handling where supported.
+* guaranteed map-local terrain continuity between declared entry points;
+* bridge or obstacle handling remains future work beyond this narrow map-local slice.
 
 Validation should determine:
 
-* whether every declared connection has a corresponding traversable edge;
-* whether important map areas are reachable;
-* whether roads terminate correctly;
+* whether every declared connection has a corresponding terrain edge;
+* whether every generated route has continuous supporting terrain;
+* whether road paths terminate at their declared endpoints;
 * whether edge tiles match adjacent-map expectations.
 
 ### Success criterion
 
-Generate a map with one or more working edge connections and a traversable road to its main feature.
+Generate a standalone map with one or more road edge connections and a continuous, deterministically painted ground-level route between declared endpoints. Full walkability/pathfinding and multi-map route integration remain later validation or overmap concerns.
 
 ## Phase 8 — Templates and compositional generation
 
@@ -817,55 +817,7 @@ Placement resolves each section with `absolute z = origin z + dz`. Rotation must
 
 ### Success criterion
 
-Create a small settlement by composing templates rather than manually specifying every wall, road, object, and populated level. Templates can include validated multi-level structures and expose usable horizontal and vertical anchors.
-
-## Phase 9 — Semantic map recipes
-
-**Status: long-term target**
-
-At this point the agent should be able to write recipes in terms of design intent:
-
-```json
-{
-  "biome": "temperate_forest",
-  "layout": {
-    "type": "small_settlement",
-    "entry": "west",
-    "center": "village_square"
-  },
-  "requirements": [
-    "three houses",
-    "one workshop",
-    "a pond southeast of the square",
-    "a road connecting west and east",
-    "dense trees around the outer border"
-  ]
-}
-```
-
-The generator or a planning layer would translate those requirements into:
-
-* anchors;
-* templates;
-* primitives;
-* logical levels and vertical transitions;
-* placement constraints;
-* routing;
-* validation.
-
-This may eventually involve two distinct stages:
-
-```text
-High-level design
-       ↓
-Expanded concrete recipe
-       ↓
-Map generator
-       ↓
-Map JSON
-```
-
-Keeping planning separate from final generation would make failures easier to inspect.
+Generate a complete map-local location, such as a house, workshop, crossroads, or village-square map, by composing reusable templates rather than manually specifying every wall, road, object, and populated level. Templates can include validated multi-level structures and expose usable horizontal and vertical anchors. The resulting map remains an individual map asset that can be registered in a tactical map or overmap area by the existing game systems.
 
 ## Phase 10 — Quality and gameplay validation
 
@@ -902,9 +854,9 @@ An agent can create a new playable, potentially multi-level map from a concise d
 
 # Recommended immediate next task
 
-**Phase 6 is in progress.** Its runtime-compatible area foundation, catalog-validated per-instance entity variation, authored room semantics, explicit door-link metadata, partial physical boundary references, opt-in enclosed-room completeness validation, first single-level authored footprint, narrow authored roof/ceiling metadata, opt-in building-level composition constraints, authored building access-completeness validation, authored interior classification constraints, authored exterior/open-space classification constraints, validated building-level room partition constraints, validated building overhead-classification constraints, authored external footprint context, validated exterior-access context, authored building-level entrance semantics, validated building-level entrance orientation and approach alignment, authored multi-entrance building semantics with per-entrance validation, authored furniture anchor metadata, the multi-level building footprint foundation, per-floor room/furniture ownership metadata, two-slope staircase physical semantics, per-floor floor/ceiling surface semantics, and multi-level roof/support semantics are complete. **Phase 7 is in progress** with authored map-edge connection metadata and road endpoint anchoring. The next contribution should implement road path routing without introducing generated geometry or generalized templates.
+**Phase 6 is in progress.** Its runtime-compatible area foundation, catalog-validated per-instance entity variation, authored room semantics, explicit door-link metadata, partial physical boundary references, opt-in enclosed-room completeness validation, first single-level authored footprint, narrow authored roof/ceiling metadata, opt-in building-level composition constraints, authored building access-completeness validation, authored interior classification constraints, authored exterior/open-space classification constraints, validated building-level room partition constraints, validated building overhead-classification constraints, authored external footprint context, validated exterior-access context, authored building-level entrance semantics, validated building-level entrance orientation and approach alignment, authored multi-entrance building semantics with per-entrance validation, authored furniture anchor metadata, the multi-level building footprint foundation, per-floor room/furniture ownership metadata, two-slope staircase physical semantics, per-floor floor/ceiling surface semantics, and multi-level roof/support semantics are complete. **Phase 7 remains in progress** after completing authored map-edge metadata, endpoint anchoring, route metadata, and deterministic map-local route painting. The next contribution should validate route cells against actual runtime walkability or implement a concrete map-to-map compatibility contract, but should not introduce a second overmap settlement or city-routing system.
 
-Do not yet generate walls, doors, roofs, multi-level building geometry, road geometry, towns, or generalized building templates. Preserve the established map-level `areas` plus per-tile area membership representation, keep room semantics independent from runtime areas, and validate any physical semantics in the editor and runtime.
+Do not yet generate walls, doors, roofs, multi-level building geometry, towns, or generalized building templates. Preserve the established map-level `areas` plus per-tile area membership representation, keep room semantics independent from runtime areas, and treat overmap areas as the authority for settlement composition and multi-map roads.
 
 Run the complete Python suite, relevant Godot tests or smoke checks, all maintained example generations through `Tools/map_validator.py`, and `git diff --check`.
 
@@ -966,11 +918,11 @@ Do not commit or push unless explicitly requested.
 [Complete] Straight and corner staircase formations with no slope stacking
 [Complete] Per-floor ceiling/floor surface semantics (top-down)
 [Complete] Multi-level roof/support semantics
-[Next]     Road feature connectivity or map-to-map route integration
+[Complete] Map-local road route painting between declared endpoints
+[Next]     Runtime walkability validation or explicit map-to-map edge compatibility
 [In Progress]  Rooms and buildings
 [In Progress]  Roads and map connections
 [Planned]  Multi-level reusable templates and richer composition
-[Planned]  Semantic map planning
 [Planned]  3D connectivity and gameplay validation
 [Target]   Agent-generated playable maps
 ```

--- a/Documentation/Modding/map_recipe_generator.md
+++ b/Documentation/Modding/map_recipe_generator.md
@@ -37,6 +37,7 @@ The root must be a JSON object with these fields:
 | `levels` | non-empty array | Explicit grouped level definitions. Cannot be combined with root `base_tile`, `regions`, or `operations`. |
 | `connections` | object | Authored map-edge connection metadata. Optional; defaults to all `"ground"`. |
 | `road_endpoints` | array | Authored road endpoint anchors at map edges. Optional; defaults to `[]`. |
+| `road_paths` | array | Authored cardinal routes between road endpoints. Optional; defaults to `[]`; a path may paint a map-local route with `tile`. |
 | `building_surfaces` | array | Authored per-building floor, ceiling, and roof surface semantics. Optional; defaults to `[]`. |
 | `building_supports` | array | Authored multi-level structural support paths. Optional; defaults to `[]`. |
 
@@ -108,7 +109,7 @@ Each entry has exactly `id`, `direction`, `at`, and `z`. `id` is unique within t
 
 The standalone validator independently checks the same content: it rejects unknown directions, duplicate IDs, coordinates not on the correct edge, and non-zero `z` values. `DMap` preserves valid road endpoints through editor save/load and removes entries with missing fields, invalid directions, duplicate IDs, or malformed coordinates.
 
-`road_paths` authors a named cardinal polyline between two road endpoints:
+`road_paths` authors a named cardinal polyline between two road endpoints. For a map-local physical route, add a `tile` field; the generator rasterizes every cell in the route and replaces its terrain with that tile. This keeps route geometry explicit and deterministic while avoiding a second pathfinding system.
 
 ```json
 {
@@ -117,13 +118,14 @@ The standalone validator independently checks the same content: it rejects unkno
       "id": "west_to_east_road",
       "from": "west_entrance",
       "to": "east_exit",
-      "waypoints": []
+      "waypoints": [],
+      "tile": {"id": "dirt_light_00"}
     }
   ]
 }
 ```
 
-Each path has exactly `id`, `from`, `to`, and `waypoints`. Both endpoint IDs must exist and be different. `waypoints` is an optional array of map-bounded `[x, y]` coordinates; the complete sequence from the `from` endpoint through the waypoints to the `to` endpoint must form cardinally aligned segments. Paths are ground-level metadata only: they do not paint road tiles, run pathfinding, infer walkability, or alter collision/navigation. `DMap` preserves valid paths and removes paths with stale endpoints, malformed points, duplicate IDs, or non-cardinal segments.
+Each path requires `id`, `from`, `to`, and `waypoints`; `tile` is optional for backwards-compatible metadata-only paths. Both endpoint IDs must exist and be different. `waypoints` is an optional array of map-bounded `[x, y]` coordinates; the complete sequence from the `from` endpoint through the waypoints to the `to` endpoint must form cardinally aligned segments. When `tile` is present, it must reference a known non-empty tile, every route cell must contain supporting terrain, route cells may not contain features, and the generator paints the complete ground-level route. This validates and generates map-local road geometry only; it does not run pathfinding, infer walkability from arbitrary terrain, alter collision/navigation, or integrate multiple maps. `DMap` preserves valid paths with or without `tile` and removes paths with stale endpoints, malformed points, duplicate IDs, invalid tile objects, or non-cardinal segments.
 
 `Tools/examples/map_recipe_road_endpoints.json` demonstrates the maintained example with two road endpoints: `west_entrance` at the west edge and `east_exit` at the east edge.
 

--- a/Scripts/Gamedata/DMap.gd
+++ b/Scripts/Gamedata/DMap.gd
@@ -686,7 +686,12 @@ func _sanitize_road_paths(data: Dictionary) -> void:
 		if endpoint is Dictionary and endpoint.get("id") is String:
 			endpoint_ids.append(endpoint["id"])
 	data["road_paths"] = data["road_paths"].filter(func(path):
-		if not path is Dictionary or path.keys().size() != 4 or not path.has("id") or not path["id"] is String or path["id"].is_empty() or path["id"] in seen_path_ids or not path.has("from") or not path["from"] in endpoint_ids or not path.has("to") or not path["to"] in endpoint_ids or path["from"] == path["to"] or not path.has("waypoints") or not path["waypoints"] is Array:
+		if not path is Dictionary or path.keys().size() < 4 or path.keys().size() > 5 or not path.has("id") or not path["id"] is String or path["id"].is_empty() or path["id"] in seen_path_ids or not path.has("from") or not path["from"] in endpoint_ids or not path.has("to") or not path["to"] in endpoint_ids or path["from"] == path["to"] or not path.has("waypoints") or not path["waypoints"] is Array:
+			return false
+		for key in path.keys():
+			if key not in ["id", "from", "to", "waypoints", "tile"]:
+				return false
+		if path.has("tile") and (not path["tile"] is Dictionary or not path["tile"].has("id") or not path["tile"]["id"] is String or path["tile"]["id"].is_empty()):
 			return false
 		var points: Array = []
 		for endpoint in data["road_endpoints"]:

--- a/Tests/Unit/test_dmap_sanitization.gd
+++ b/Tests/Unit/test_dmap_sanitization.gd
@@ -370,12 +370,12 @@ func test_dmap_road_paths_roundtrip_and_sanitization():
 			{"id": "east", "direction": "east", "at": [31, 16], "z": 0},
 		],
 		"road_paths": [
-			{"id": "valid_route", "from": "west", "to": "east", "waypoints": []},
+			{"id": "valid_route", "from": "west", "to": "east", "waypoints": [], "tile": {"id": "dirt_light_00"}},
 			{"id": "bad_route", "from": "west", "to": "missing", "waypoints": []},
 		],
 	})
 	var data = map.get_data()
-	assert_eq(data["road_paths"], [{"id": "valid_route", "from": "west", "to": "east", "waypoints": []}])
+	assert_eq(data["road_paths"], [{"id": "valid_route", "from": "west", "to": "east", "waypoints": [], "tile": {"id": "dirt_light_00"}}])
 
 
 func test_dmap_building_compositions_roundtrip_and_sanitization():

--- a/Tools/examples/map_recipe_road_endpoints.json
+++ b/Tools/examples/map_recipe_road_endpoints.json
@@ -15,9 +15,6 @@
 		{"id": "east_exit", "direction": "east", "at": [31, 16], "z": 0}
 	],
 	"road_paths": [
-		{"id": "west_to_east_road", "from": "west_entrance", "to": "east_exit", "waypoints": []}
-	],
-	"operations": [
-		{"type": "line", "from": [0, 16], "to": [31, 16], "tile": {"id": "dirt_light_00"}}
+		{"id": "west_to_east_road", "from": "west_entrance", "to": "east_exit", "waypoints": [], "tile": {"id": "dirt_light_00"}}
 	]
 }

--- a/Tools/map_generator.py
+++ b/Tools/map_generator.py
@@ -35,6 +35,7 @@ CONNECTION_DIRECTIONS = {"north", "east", "south", "west"}
 CONNECTION_TYPES = {"ground", "road"}
 ROAD_ENDPOINT_FIELDS = {"id", "direction", "at", "z"}
 ROAD_PATH_FIELDS = {"id", "from", "to", "waypoints"}
+ROAD_PATH_OPTIONAL_FIELDS = {"tile"}
 EDGE_COORDINATES = {
     "north": lambda x, y: y == 0,
     "south": lambda x, y: y == MAP_HEIGHT - 1,
@@ -2641,6 +2642,8 @@ def _validate_road_endpoints(
 def _validate_road_paths(
     road_paths: Any,
     road_endpoints: list[dict[str, Any]],
+    known_tiles: set[str],
+    palette: dict[str, list[dict[str, Any]]],
 ) -> list[dict[str, Any]]:
     if road_paths is None:
         return []
@@ -2651,8 +2654,8 @@ def _validate_road_paths(
     seen_ids: set[str] = set()
     for index, path in enumerate(road_paths):
         context = f"road_paths[{index}]"
-        if not isinstance(path, dict) or set(path) != ROAD_PATH_FIELDS:
-            raise RecipeError(f"{context} must define id, from, to, and waypoints")
+        if not isinstance(path, dict) or not ROAD_PATH_FIELDS.issubset(path) or set(path) - ROAD_PATH_FIELDS - ROAD_PATH_OPTIONAL_FIELDS:
+            raise RecipeError(f"{context} must define id, from, to, and waypoints, with optional tile")
         path_id = path["id"]
         if not isinstance(path_id, str) or not path_id.strip():
             raise RecipeError(f"{context}.id must be a non-empty string")
@@ -2673,8 +2676,59 @@ def _validate_road_paths(
                 raise RecipeError(f"{context} point {point_index} must be a map-bounded two-integer coordinate")
             if point_index and points[point_index][0] != points[point_index - 1][0] and points[point_index][1] != points[point_index - 1][1]:
                 raise RecipeError(f"{context} points must form cardinally aligned segments")
-        validated.append({"id": path_id, "from": from_id, "to": to_id, "waypoints": waypoints})
+        validated_path = {"id": path_id, "from": from_id, "to": to_id, "waypoints": waypoints}
+        if "tile" in path:
+            _validate_tile_spec(path["tile"], known_tiles, f"{context}.tile", palette=palette)
+            validated_path["tile"] = path["tile"]
+        validated.append(validated_path)
     return validated
+
+
+def _rasterize_cardinal_path(points: list[list[int]]) -> list[tuple[int, int]]:
+    cells: list[tuple[int, int]] = []
+    for point_index in range(len(points) - 1):
+        start_x, start_y = points[point_index]
+        end_x, end_y = points[point_index + 1]
+        if start_x == end_x:
+            step = 1 if end_y >= start_y else -1
+            segment = [(start_x, y) for y in range(start_y, end_y + step, step)]
+        else:
+            step = 1 if end_x >= start_x else -1
+            segment = [(x, start_y) for x in range(start_x, end_x + step, step)]
+        for cell in segment:
+            if not cells or cells[-1] != cell:
+                cells.append(cell)
+    return cells
+
+
+def _apply_road_paths(
+    road_paths: list[dict[str, Any]],
+    road_endpoints: list[dict[str, Any]],
+    levels: list[list[dict[str, Any]]],
+    rng: random.Random,
+    known_tiles: set[str],
+    palette: dict[str, list[dict[str, Any]]],
+) -> None:
+    endpoint_by_id = {endpoint["id"]: endpoint for endpoint in road_endpoints}
+    level = levels[POPULATED_LEVEL_INDEX]
+    for path in road_paths:
+        if "tile" not in path:
+            continue
+        points = [endpoint_by_id[path["from"]]["at"], *path["waypoints"], endpoint_by_id[path["to"]]["at"]]
+        road_cells = _rasterize_cardinal_path(points)
+        road_tile = _make_tile(path["tile"], rng, known_tiles, f"road_paths.{path['id']}.tile", palette=palette)
+        if not road_tile:
+            raise RecipeError(f"road_paths.{path['id']}.tile must define a non-empty terrain tile")
+        for x, y in road_cells:
+            index = y * MAP_WIDTH + x
+            existing = level[index]
+            if not isinstance(existing, dict) or not existing.get("id"):
+                raise RecipeError(f"road_paths.{path['id']} requires supporting terrain at [{x}, {y}]")
+            if "feature" in existing:
+                raise RecipeError(f"road_paths.{path['id']} cannot overwrite a feature at [{x}, {y}]")
+        for x, y in road_cells:
+            level[y * MAP_WIDTH + x] = road_tile.copy()
+        path["tile"] = road_tile
 def generate_map(
     recipe: dict[str, Any],
     tiles_path: Path,
@@ -2801,7 +2855,8 @@ def generate_map(
     )
     connections = _validate_connections(recipe.get("connections"))
     road_endpoints = _validate_road_endpoints(recipe.get("road_endpoints"), connections, levels)
-    road_paths = _validate_road_paths(recipe.get("road_paths"), road_endpoints)
+    road_paths = _validate_road_paths(recipe.get("road_paths"), road_endpoints, known_tiles, palette)
+    _apply_road_paths(road_paths, road_endpoints, levels, rng, known_tiles, palette)
 
     generated = {
         "id": recipe["id"],

--- a/Tools/map_validator.py
+++ b/Tools/map_validator.py
@@ -12,6 +12,7 @@ CONNECTION_DIRECTIONS = {'north', 'east', 'south', 'west'}
 CONNECTION_TYPES = {'ground', 'road'}
 ROAD_ENDPOINT_FIELDS = {'id', 'direction', 'at', 'z'}
 ROAD_PATH_FIELDS = {'id', 'from', 'to', 'waypoints'}
+ROAD_PATH_OPTIONAL_FIELDS = {'tile'}
 ROOM_KINDS = {'enclosed', 'covered_open', 'ruin'}
 ROOM_BOUNDARY_VALIDATIONS = {'complete'}
 CARDINAL_SIDES = {
@@ -285,8 +286,8 @@ class MapValidator:
             seen_path_ids: Set[str] = set()
             for idx, path in enumerate(road_paths):
                 context = f"road_paths[{idx}]"
-                if not isinstance(path, dict) or set(path) != ROAD_PATH_FIELDS:
-                    self.add_error(file_path, f"{context} must define id, from, to, and waypoints.")
+                if not isinstance(path, dict) or not ROAD_PATH_FIELDS.issubset(path) or set(path) - ROAD_PATH_FIELDS - ROAD_PATH_OPTIONAL_FIELDS:
+                    self.add_error(file_path, f"{context} must define id, from, to, and waypoints, with optional tile.")
                     continue
                 path_id = path.get('id')
                 if not isinstance(path_id, str) or not path_id:
@@ -310,6 +311,10 @@ class MapValidator:
                         self.add_error(file_path, f"{context} point {point_index} must be a map-bounded two-integer coordinate.")
                     elif point_index and points[point_index][0] != points[point_index - 1][0] and points[point_index][1] != points[point_index - 1][1]:
                         self.add_error(file_path, f"{context} points must form cardinally aligned segments.")
+                if 'tile' in path:
+                    tile = path['tile']
+                    if not isinstance(tile, dict) or set(tile) - {'id', 'rotation'} or not isinstance(tile.get('id'), str) or not tile.get('id'):
+                        self.add_error(file_path, f"{context}.tile must be a non-empty tile object.")
 
         # 3. Enforce the fixed map dimensions used by the loader and editor.
         map_width = data.get('mapwidth', MAP_WIDTH)

--- a/Tools/tests/test_map_generator.py
+++ b/Tools/tests/test_map_generator.py
@@ -2653,7 +2653,36 @@ class MapGeneratorTests(unittest.TestCase):
         self.assertEqual(len(endpoints), 2)
         self.assertEqual(endpoints[0], {"id": "west_entrance", "direction": "west", "at": [0, 16], "z": 0})
         self.assertEqual(endpoints[1], {"id": "east_exit", "direction": "east", "at": [31, 16], "z": 0})
-        self.assertEqual(generated["road_paths"], [{"id": "west_to_east_road", "from": "west_entrance", "to": "east_exit", "waypoints": []}])
+        self.assertEqual(generated["road_paths"], [{"id": "west_to_east_road", "from": "west_entrance", "to": "east_exit", "waypoints": [], "tile": {"id": "dirt_light_00"}}])
+        self.assertTrue(all(tile == {"id": "dirt_light_00"} for tile in generated["levels"][10][16 * 32:17 * 32]))
+
+    def test_metadata_only_road_path_does_not_change_terrain(self):
+        recipe = valid_recipe()
+        recipe["base_tile"] = {"id": "grass_plain_01"}
+        recipe["connections"] = {"west": "road", "east": "road"}
+        recipe["road_endpoints"] = [
+            {"id": "west_entrance", "direction": "west", "at": [0, 16], "z": 0},
+            {"id": "east_exit", "direction": "east", "at": [31, 16], "z": 0},
+        ]
+        recipe["road_paths"] = [{"id": "metadata_route", "from": "west_entrance", "to": "east_exit", "waypoints": []}]
+
+        generated = generate_map(recipe, TILES_PATH)
+
+        self.assertTrue(all(tile == {"id": "grass_plain_01"} for tile in generated["levels"][10][16 * 32:17 * 32]))
+
+    def test_road_path_rejects_feature_overwrite(self):
+        recipe = valid_recipe()
+        recipe["base_tile"] = {"id": "grass_plain_01"}
+        recipe["connections"] = {"west": "road", "east": "road"}
+        recipe["road_endpoints"] = [
+            {"id": "west_entrance", "direction": "west", "at": [0, 16], "z": 0},
+            {"id": "east_exit", "direction": "east", "at": [31, 16], "z": 0},
+        ]
+        recipe["operations"] = [{"type": "furniture", "id": "door_wood", "x": 10, "y": 16, "rotation": 0}]
+        recipe["road_paths"] = [{"id": "blocked_route", "from": "west_entrance", "to": "east_exit", "waypoints": [], "tile": {"id": "dirt_light_00"}}]
+
+        with self.assertRaisesRegex(RecipeError, r"cannot overwrite a feature at \[10, 16\]"):
+            generate_map(recipe, TILES_PATH, furnitures_path=FURNITURES_PATH)
 
     def test_road_paths_require_endpoint_references_and_cardinal_continuity(self):
         recipe_path = ROOT / "Tools" / "examples" / "map_recipe_road_endpoints.json"


### PR DESCRIPTION

#### Summary

- Add optional tiled map-local road paths between authored endpoints.
- Rasterize and validate complete cardinal routes during generation.
- Reject routes that lack supporting terrain or overwrite features.
- Preserve metadata-only road paths for backwards compatibility.
- Update DMap sanitization, validators, tests, examples, and Phase 7 documentation.

#### Validation

- `PYTHONPATH=. python3 -m unittest discover -s Tools/tests -p "test_*.py"`
- `/usr/local/bin/godot --headless -s addons/gut/gut_cmdln.gd -gdir=Tests/Unit -gexit`
- `python3 Tools/map_generator.py Tools/examples/map_recipe_road_endpoints.json /tmp/generated_road_endpoints.json --overwrite`
- `python3 Tools/map_validator.py /tmp/generated_road_endpoints.json`
- `git diff --check`

All checks passed.