### PR TITLE
feat(map-gen): add minimal template expansion with relative dz

### DIFF
--- a/Documentation/Game_design/Map_generation_plan.md
+++ b/Documentation/Game_design/Map_generation_plan.md
@@ -711,7 +711,7 @@ Generate one small, enterable building that loads correctly and has a reachable 
 
 ## Phase 7 — Roads and map connections
 
-**Status: in progress; authored map-edge connections, road endpoints, map-local road painting, and runtime walkability validation complete**
+**Status: complete; authored map-edge connections, road endpoints, map-local road painting, and runtime walkability validation complete**
 
 The prototype previously hardcoded all four edge connections as `"ground"`. These are now authored recipe-level metadata, with named endpoint anchors identifying the exact map-edge cells where roads enter or exit.
 
@@ -738,7 +738,7 @@ Validation should determine:
 * whether every generated route has continuous supporting terrain;
 * whether road paths terminate at their declared endpoints;
 * whether generated Ground cube routes are connected by runtime navigation;
-* whether edge tiles match adjacent-map expectations.
+* whether edge tiles match adjacent-map expectations; this map-to-map compatibility contract is intentionally deferred and may be resumed later.
 
 ### Success criterion
 
@@ -746,13 +746,26 @@ Generate a standalone map with one or more road edge connections and a continuou
 
 ## Phase 8 — Templates and compositional generation
 
-**Status: planned**
+**Status: in progress; minimal deterministic unrotated template expansion complete**
 
-Once primitives and object placement work, add reusable templates.
+The first Phase 8 slice adds reusable template definitions without creating a second generation pipeline. Templates expand into ordinary root operations before the existing recipe validation and map generation stages.
 
-This phase owns richer composition deferred from Phase 4B, including nested patterns, shape-based definitions, complex automatic rotation, and multi-level template composition.
+### Completed foundation
 
-Possible templates:
+* named template definitions with relative `dz` level sections;
+* unrotated placements with translated horizontal origins and `origin.z + dz` resolution;
+* expansion into existing ordinary root operations before normal validation;
+* deterministic maintained `small_cabin` example and regression coverage.
+
+### Remaining Phase 8 work
+
+* template anchors and anchor-to-anchor placement;
+* parameters and reusable variants;
+* automatic rotation;
+* nested templates;
+* complete three-dimensional footprint validation and richer compositional locations.
+
+Candidate templates include:
 
 ```text
 small cabin
@@ -855,9 +868,9 @@ An agent can create a new playable, potentially multi-level map from a concise d
 
 # Recommended immediate next task
 
-**Phase 6 is complete.** Its runtime-compatible area foundation, room semantics, authored building constraints, multi-level footprint metadata, physical floor/wall/support generation, standable roof generation, authored staircase evidence, enclosed maintained building geometry, and manual player traversal verification are complete for the first narrow building slice. **Phase 7 remains in progress** after completing authored map-edge metadata, endpoint anchoring, route metadata, deterministic map-local route painting, and runtime walkability validation. Its next optional contribution is a concrete map-to-map compatibility contract, but it should not introduce a second overmap settlement or city-routing system.
+**Phase 6 is complete.** Its runtime-compatible area foundation, room semantics, authored building constraints, multi-level footprint metadata, physical floor/wall/support generation, standable roof generation, authored staircase evidence, enclosed maintained building geometry, and manual player traversal verification are complete for the first narrow building slice. **Phase 7 is complete** with authored map-edge metadata, endpoint anchoring, route metadata, deterministic map-local route painting, and runtime walkability validation. Explicit map-to-map edge compatibility is intentionally deferred as an optional future follow-up. The next planned area is **Phase 8: Templates and compositional generation**. Its first minimal slice is now implemented: deterministic unrotated `small_cabin` expansion with relative `dz`; remaining work is anchors, parameters, rotation, nesting, and richer composition.
 
-Do not yet generate doors, towns, or generalized building templates. Preserve the established map-level `areas` plus per-tile area membership representation, keep room semantics independent from runtime areas, and treat overmap areas as the authority for settlement composition and multi-map roads.
+Do not yet generate towns or generalized compositional locations. Preserve the established map-level `areas` plus per-tile area membership representation, keep room semantics independent from runtime areas, and treat overmap areas as the authority for settlement composition and multi-map roads. Explicit map-to-map edge compatibility remains deferred until it becomes useful.
 
 Run the complete Python suite, relevant Godot tests or smoke checks, all maintained example generations through `Tools/map_validator.py`, and `git diff --check`.
 
@@ -927,10 +940,10 @@ Do not commit or push unless explicitly requested.
 [Complete] Wall and door placement decoupling via `target_at`/`room_at`
 [Complete] Map-local road route painting between declared endpoints
 [Complete] Runtime navigation validation for a painted local road route
-[Next]     Explicit map-to-map edge compatibility
+[Deferred] Explicit map-to-map edge compatibility (resume if needed)
 [Complete] Rooms and buildings
-[In Progress] Roads and map connections
-[Planned]  Multi-level reusable templates and richer composition
+[Complete] Roads and map connections
+[In Progress] Multi-level reusable templates and richer composition
 [Planned]  3D connectivity and gameplay validation
 [Target]   Agent-generated playable maps
 ```

--- a/Documentation/Modding/map_recipe_generator.md
+++ b/Documentation/Modding/map_recipe_generator.md
@@ -38,6 +38,8 @@ The root must be a JSON object with these fields:
 | `connections` | object | Authored map-edge connection metadata. Optional; defaults to all `"ground"`. |
 | `road_endpoints` | array | Authored road endpoint anchors at map edges. Optional; defaults to `[]`. |
 | `road_paths` | array | Authored cardinal routes between road endpoints. Optional; defaults to `[]`; a path may paint a map-local route with `tile`. |
+| `templates` | object | Minimal reusable template definitions with relative `levels`. Optional; requires `placements` when present. |
+| `placements` | array | Unrotated template placements with an origin and relative-level expansion. Optional; requires `templates` when present. |
 | `building_surfaces` | array | Authored per-building floor, ceiling, and roof surface semantics. Optional; defaults to `[]`. |
 | `building_supports` | array | Authored multi-level structural support paths. Optional; defaults to `[]`. |
 
@@ -129,6 +131,33 @@ Each path requires `id`, `from`, `to`, and `waypoints`; `tile` is optional for b
 
 `Tools/examples/map_recipe_road_endpoints.json` demonstrates the maintained example with two road endpoints: `west_entrance` at the west edge and `east_exit` at the east edge.
 
+## Minimal template expansion
+
+Templates are expanded before ordinary recipe validation and generation. The first supported form is intentionally small: a template defines relative `levels`, each placement supplies an origin and `rotation: 0`, and every template operation is translated into an ordinary root operation. Template operations omit `z`; the generator resolves `absolute z = placement.origin.z + level.dz`. Horizontal coordinates are translated by `placement.origin.at` without rotation.
+
+```json
+{
+  "templates": {
+    "small_cabin": {
+      "levels": [
+        {"dz": 0, "operations": [
+          {"type": "rectangle", "x": 0, "y": 0, "width": 4, "height": 4, "tile": {"id": "concrete_00"}}
+        ]},
+        {"dz": 2, "operations": [
+          {"type": "rectangle", "x": 0, "y": 0, "width": 4, "height": 4, "tile": {"id": "concrete_00"}}
+        ]}
+      ]
+    }
+  },
+  "placements": [
+    {"template": "small_cabin", "origin": {"at": [10, 10], "z": 0}, "rotation": 0}
+  ]
+}
+```
+
+The minimal expansion supports existing `set`, rectangle, outline, line, pattern, scatter, furniture, area-rectangle, room-rectangle, and furniture-scatter operation shapes. It rejects nested operation `z` values, non-zero rotations, unknown templates, duplicate relative `dz` levels, and placements outside the logical z range. Templates cannot yet be combined with the grouped root `levels` layout, nested templates, parameters, anchor-to-anchor composition, or automatic rotation. The generated map contains only the expanded ordinary recipe output; `templates` and `placements` are not serialized.
+
+`Tools/examples/map_recipe_small_cabin_template.json` is the maintained example. Its tests verify deterministic expansion and relative `dz` placement.
 ## Logical levels
 
 Map level-array index `10` is logical ground level `z: 0`. The conversion is:

--- a/Tools/examples/map_recipe_small_cabin_template.json
+++ b/Tools/examples/map_recipe_small_cabin_template.json
@@ -1,0 +1,39 @@
+{
+	"id": "generated_small_cabin_template",
+	"name": "Generated Small Cabin Template",
+	"description": "A minimal unrotated small cabin template expanded into ordinary map operations.",
+	"seed": 20260824,
+	"base_tile": {"id": "grass_plain_01"},
+	"templates": {
+		"small_cabin": {
+			"levels": [
+				{
+					"dz": 0,
+					"operations": [
+						{"type": "rectangle", "x": 0, "y": 0, "width": 4, "height": 4, "tile": {"id": "concrete_00"}},
+						{"type": "rectangle_outline", "x": 0, "y": 0, "width": 4, "height": 4, "tile": {"id": "dirt_light_00"}}
+					]
+				},
+				{
+					"dz": 1,
+					"operations": [
+						{"type": "rectangle_outline", "x": 0, "y": 0, "width": 4, "height": 4, "tile": {"id": "brick_wall_00"}}
+					]
+				},
+				{
+					"dz": 2,
+					"operations": [
+						{"type": "rectangle", "x": 0, "y": 0, "width": 4, "height": 4, "tile": {"id": "concrete_00"}}
+					]
+				}
+			]
+		}
+	},
+	"placements": [
+		{
+			"template": "small_cabin",
+			"origin": {"at": [10, 10], "z": 0},
+			"rotation": 0
+		}
+	]
+}

--- a/Tools/map_generator.py
+++ b/Tools/map_generator.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import argparse
+import copy
 import json
 import os
 import random
@@ -135,11 +136,117 @@ RECIPE_FIELDS = {
     "connections",
     "road_endpoints",
     "road_paths",
+    "templates",
+    "placements",
 }
 
 
 class RecipeError(ValueError):
     """Raised when a map recipe is invalid."""
+
+
+def _expand_templates(recipe: dict[str, Any]) -> dict[str, Any]:
+    templates = recipe.get("templates")
+    placements = recipe.get("placements")
+    if templates is None and placements is None:
+        return recipe
+    if not isinstance(templates, dict) or not templates:
+        raise RecipeError("templates must be a non-empty object")
+    if not isinstance(placements, list) or not placements:
+        raise RecipeError("placements must be a non-empty array")
+    if "levels" in recipe:
+        raise RecipeError("templates cannot be combined with recipe.levels in the minimal template expansion")
+
+    expanded = copy.deepcopy(recipe)
+    expanded.pop("templates", None)
+    expanded.pop("placements", None)
+    expanded_operations = expanded.setdefault("operations", [])
+    if not isinstance(expanded_operations, list):
+        raise RecipeError("operations must be an array when templates are used")
+
+    for template_id, template in templates.items():
+        context = f"templates.{template_id}"
+        if not isinstance(template_id, str) or DEFINITION_NAME_PATTERN.fullmatch(template_id) is None:
+            raise RecipeError(f"{context} must use a valid template ID")
+        if not isinstance(template, dict) or set(template) != {"levels"}:
+            raise RecipeError(f"{context} must define only levels")
+        levels = template["levels"]
+        if not isinstance(levels, list) or not levels:
+            raise RecipeError(f"{context}.levels must be a non-empty array")
+        seen_dz: set[int] = set()
+        for level_index, level in enumerate(levels):
+            level_context = f"{context}.levels[{level_index}]"
+            if not isinstance(level, dict) or set(level) != {"dz", "operations"}:
+                raise RecipeError(f"{level_context} must define dz and operations")
+            dz = level["dz"]
+            if type(dz) is not int or not MIN_LOGICAL_Z <= dz <= MAX_LOGICAL_Z:
+                raise RecipeError(f"{level_context}.dz must be an integer between -10 and 10")
+            if dz in seen_dz:
+                raise RecipeError(f"{level_context}.dz duplicates relative level {dz}")
+            seen_dz.add(dz)
+            if not isinstance(level["operations"], list):
+                raise RecipeError(f"{level_context}.operations must be an array")
+
+    for placement_index, placement in enumerate(placements):
+        context = f"placements[{placement_index}]"
+        if not isinstance(placement, dict) or set(placement) != {"template", "origin", "rotation"}:
+            raise RecipeError(f"{context} must define template, origin, and rotation")
+        template_id = placement["template"]
+        if not isinstance(template_id, str) or template_id not in templates:
+            raise RecipeError(f"{context}.template references unknown template '{template_id}'")
+        origin = placement["origin"]
+        if (
+            not isinstance(origin, dict)
+            or set(origin) != {"at", "z"}
+            or not isinstance(origin.get("at"), list)
+            or len(origin["at"]) != 2
+            or any(type(value) is not int for value in origin["at"])
+            or type(origin.get("z")) is not int
+        ):
+            raise RecipeError(f"{context}.origin must define a two-integer at and integer z")
+        if placement["rotation"] != 0:
+            raise RecipeError(f"{context}.rotation only supports 0 in the minimal template expansion")
+        for level in templates[template_id]["levels"]:
+            absolute_z = origin["z"] + level["dz"]
+            if not MIN_LOGICAL_Z <= absolute_z <= MAX_LOGICAL_Z:
+                raise RecipeError(f"{context} places relative level dz {level['dz']} outside logical z bounds")
+            for operation_index, operation in enumerate(level["operations"]):
+                operation_context = f"{context}.{template_id}.levels[{level['dz']}].operations[{operation_index}]"
+                if not isinstance(operation, dict) or "type" not in operation:
+                    raise RecipeError(f"{operation_context} must be an operation object")
+                if "z" in operation:
+                    raise RecipeError(f"{operation_context}.z must be omitted; use the enclosing relative level dz")
+                translated = copy.deepcopy(operation)
+                operation_type = translated["type"]
+                if operation_type in {"set", "rectangle", "rectangle_outline", "furniture", "area_rectangle", "room_rectangle"}:
+                    if not isinstance(translated.get("x"), int) or not isinstance(translated.get("y"), int):
+                        raise RecipeError(f"{operation_context} requires integer x and y")
+                    translated["x"] += origin["at"][0]
+                    translated["y"] += origin["at"][1]
+                elif operation_type in {"scatter", "furniture_scatter"}:
+                    region = translated.get("region")
+                    if not isinstance(region, dict) or not isinstance(region.get("x"), int) or not isinstance(region.get("y"), int):
+                        raise RecipeError(f"{operation_context}.region requires integer x and y")
+                    region["x"] += origin["at"][0]
+                    region["y"] += origin["at"][1]
+                elif operation_type == "line":
+                    for endpoint in ("from", "to"):
+                        point = translated.get(endpoint)
+                        if not isinstance(point, list) or len(point) != 2 or any(type(value) is not int for value in point):
+                            raise RecipeError(f"{operation_context}.{endpoint} must be a two-integer coordinate")
+                        point[0] += origin["at"][0]
+                        point[1] += origin["at"][1]
+                elif operation_type == "pattern":
+                    point = translated.get("at")
+                    if not isinstance(point, list) or len(point) != 2 or any(type(value) is not int for value in point):
+                        raise RecipeError(f"{operation_context}.at must be a two-integer coordinate")
+                    point[0] += origin["at"][0]
+                    point[1] += origin["at"][1]
+                else:
+                    raise RecipeError(f"{operation_context}.type '{operation_type}' is not supported by minimal templates")
+                translated["z"] = absolute_z
+                expanded_operations.append(translated)
+    return expanded
 
 
 def _validate_unicode(value: str, context: str) -> None:
@@ -2980,6 +3087,7 @@ def generate_map(
     """Validate a recipe and return map data matching DMap's saved format."""
     if not isinstance(recipe, dict):
         raise RecipeError("recipe must be a JSON object")
+    recipe = _expand_templates(recipe)
     unknown_fields = sorted(set(recipe) - RECIPE_FIELDS)
     if unknown_fields:
         raise RecipeError(f"unknown recipe field '{unknown_fields[0]}'")

--- a/Tools/tests/test_map_generator.py
+++ b/Tools/tests/test_map_generator.py
@@ -60,6 +60,38 @@ class MapGeneratorTests(unittest.TestCase):
             [270, 0, 180, 180, 90, 180, 270, 90, 180, 0, 270, 180],
         )
 
+    def test_template_expansion_is_deterministic_and_uses_relative_dz(self):
+        recipe = valid_recipe()
+        recipe["templates"] = {
+            "small_cabin": {
+                "levels": [
+                    {"dz": 0, "operations": [{"type": "set", "x": 1, "y": 2, "tile": {"id": "dirt_light_00"}}]},
+                    {"dz": 2, "operations": [{"type": "set", "x": 1, "y": 2, "tile": {"id": "concrete_00"}}]},
+                ]
+            }
+        }
+        recipe["placements"] = [{"template": "small_cabin", "origin": {"at": [10, 11], "z": 1}, "rotation": 0}]
+
+        first = generate_map(recipe, TILES_PATH)
+        second = generate_map(recipe, TILES_PATH)
+
+        self.assertEqual(first, second)
+        self.assertNotIn("templates", first)
+        self.assertNotIn("placements", first)
+        self.assertEqual(first["levels"][11][13 * 32 + 11], {"id": "dirt_light_00"})
+        self.assertEqual(first["levels"][13][13 * 32 + 11], {"id": "concrete_00"})
+        self.assertEqual(first["levels"][12], [])
+
+    def test_small_cabin_template_example_generates(self):
+        recipe_path = ROOT / "Tools" / "examples" / "map_recipe_small_cabin_template.json"
+        first = generate_map(json.loads(recipe_path.read_text(encoding="utf-8")), TILES_PATH)
+        second = generate_map(json.loads(recipe_path.read_text(encoding="utf-8")), TILES_PATH)
+
+        self.assertEqual(first, second)
+        self.assertEqual(first["levels"][10][10 * 32 + 10]["id"], "dirt_light_00")
+        self.assertEqual(first["levels"][11][10 * 32 + 10]["id"], "brick_wall_00")
+        self.assertEqual(first["levels"][12][10 * 32 + 10]["id"], "concrete_00")
+
     def test_legacy_regions_and_every_operation_can_target_logical_z(self):
         recipe = valid_recipe()
         recipe["base_tile"] = {"id": "grass_plain_01"}


### PR DESCRIPTION
## Summary

- add minimal `templates` and `placements` recipe fields
- expand unrotated templates into existing root operations
- support relative template levels through `origin.z + dz`
- add a maintained `small_cabin` template example
- document the initial Phase 8 schema and remaining limitations

## Validation

- 159 Python tests passing
- maintained generated template map validates successfully
- Python compilation checks pass
- `git diff --check` passes

## Scope

This initial slice intentionally excludes:

- template parameters
- anchors
- automatic rotation
- nested templates
- anchor-to-anchor composition
- grouped root-level `levels` combined with templates