### PR TITLE
feat(map-gen): add template anchors and anchor placement

### DIFF
--- a/Documentation/Game_design/Map_generation_plan.md
+++ b/Documentation/Game_design/Map_generation_plan.md
@@ -746,7 +746,7 @@ Generate a standalone map with one or more road edge connections and a continuou
 
 ## Phase 8 — Templates and compositional generation
 
-**Status: in progress; minimal deterministic unrotated template expansion complete**
+**Status: in progress; deterministic unrotated template expansion and anchor-to-anchor placement complete**
 
 The first Phase 8 slice adds reusable template definitions without creating a second generation pipeline. Templates expand into ordinary root operations before the existing recipe validation and map generation stages.
 
@@ -754,14 +754,15 @@ The first Phase 8 slice adds reusable template definitions without creating a se
 
 * named template definitions with relative `dz` level sections;
 * unrotated placements with translated horizontal origins and `origin.z + dz` resolution;
+* named template anchors with absolute anchor resolution; exterior connection anchors place distinct footprints adjacently while coincident interior anchors intentionally overlap;
+* anchor-to-anchor placement against prior placements;
 * expansion into existing ordinary root operations before normal validation;
 * deterministic maintained `small_cabin` example and regression coverage.
 
 ### Remaining Phase 8 work
 
-* template anchors and anchor-to-anchor placement;
 * parameters and reusable variants;
-* automatic rotation;
+* automatic rotation and facing-aware anchor composition;
 * nested templates;
 * complete three-dimensional footprint validation and richer compositional locations.
 

--- a/Documentation/Modding/map_recipe_generator.md
+++ b/Documentation/Modding/map_recipe_generator.md
@@ -38,8 +38,8 @@ The root must be a JSON object with these fields:
 | `connections` | object | Authored map-edge connection metadata. Optional; defaults to all `"ground"`. |
 | `road_endpoints` | array | Authored road endpoint anchors at map edges. Optional; defaults to `[]`. |
 | `road_paths` | array | Authored cardinal routes between road endpoints. Optional; defaults to `[]`; a path may paint a map-local route with `tile`. |
-| `templates` | object | Minimal reusable template definitions with relative `levels`. Optional; requires `placements` when present. |
-| `placements` | array | Unrotated template placements with an origin and relative-level expansion. Optional; requires `templates` when present. |
+| `templates` | object | Reusable template definitions with relative `levels` and optional named `anchors`. Optional; requires `placements` when present. |
+| `placements` | array | Template placements with a literal `origin` or anchor-to-anchor alignment through `anchor_to` and `at_anchor`. |
 | `building_surfaces` | array | Authored per-building floor, ceiling, and roof surface semantics. Optional; defaults to `[]`. |
 | `building_supports` | array | Authored multi-level structural support paths. Optional; defaults to `[]`. |
 
@@ -133,31 +133,40 @@ Each path requires `id`, `from`, `to`, and `waypoints`; `tile` is optional for b
 
 ## Minimal template expansion
 
-Templates are expanded before ordinary recipe validation and generation. The first supported form is intentionally small: a template defines relative `levels`, each placement supplies an origin and `rotation: 0`, and every template operation is translated into an ordinary root operation. Template operations omit `z`; the generator resolves `absolute z = placement.origin.z + level.dz`. Horizontal coordinates are translated by `placement.origin.at` without rotation.
+Templates are expanded before ordinary recipe validation and generation. A template defines relative `levels` and may define named anchors as `{ "at": [x, y], "z": dz, "facing": "north" }`. Anchors are relative to the placement origin and are not serialized into the generated map. A placement may use a literal `origin`, or align its `at_anchor` to an anchor on a prior placement using `anchor_to`.
 
 ```json
 {
   "templates": {
     "small_cabin": {
+      "anchors": {
+        "entrance": {"at": [0, 1], "z": 0, "facing": "west"},
+        "exit": {"at": [4, 1], "z": 0, "facing": "east"}
+      },
       "levels": [
         {"dz": 0, "operations": [
-          {"type": "rectangle", "x": 0, "y": 0, "width": 4, "height": 4, "tile": {"id": "concrete_00"}}
-        ]},
-        {"dz": 2, "operations": [
           {"type": "rectangle", "x": 0, "y": 0, "width": 4, "height": 4, "tile": {"id": "concrete_00"}}
         ]}
       ]
     }
   },
   "placements": [
-    {"template": "small_cabin", "origin": {"at": [10, 10], "z": 0}, "rotation": 0}
+    {"template": "small_cabin", "origin": {"at": [10, 10], "z": 0}, "rotation": 0},
+    {
+      "template": "small_cabin",
+      "anchor_to": {"placement": 0, "anchor": "exit"},
+      "at_anchor": "entrance",
+      "rotation": 0
+    }
   ]
 }
 ```
 
-The minimal expansion supports existing `set`, rectangle, outline, line, pattern, scatter, furniture, area-rectangle, room-rectangle, and furniture-scatter operation shapes. It rejects nested operation `z` values, non-zero rotations, unknown templates, duplicate relative `dz` levels, and placements outside the logical z range. Templates cannot yet be combined with the grouped root `levels` layout, nested templates, parameters, anchor-to-anchor composition, or automatic rotation. The generated map contains only the expanded ordinary recipe output; `templates` and `placements` are not serialized.
+For anchor-to-anchor placement, the referenced placement must appear earlier in the `placements` array. The generator computes the new origin so the placed template's `at_anchor` has the same absolute `[x, y, z]` as the referenced anchor. To place separate structures side by side, author connection anchors on the exterior edge immediately beyond each footprint (for example, a 4×4 template can use west `[0, 1]` and east `[4, 1]` anchors); interior anchors intentionally produce overlapping geometry when coincident. Anchor `facing` is preserved as metadata for future rotation-aware composition; it does not yet rotate or enforce a facing relationship.
 
-`Tools/examples/map_recipe_small_cabin_template.json` is the maintained example. Its tests verify deterministic expansion and relative `dz` placement.
+The minimal expansion supports existing `set`, rectangle, outline, line, pattern, scatter, furniture, area-rectangle, room-rectangle, and furniture-scatter operation shapes. It rejects nested operation `z` values, non-zero rotations, unknown templates or anchors, duplicate relative `dz` levels, forward anchor references, and placements outside the logical z range. Templates cannot yet be combined with the grouped root `levels` layout, nested templates, parameters, or automatic rotation. The generated map contains only expanded ordinary recipe output; `templates` and `placements` are not serialized.
+
+`Tools/examples/map_recipe_small_cabin_template.json` is the maintained example. Its tests verify deterministic expansion, relative `dz` placement, and anchor-to-anchor alignment.
 ## Logical levels
 
 Map level-array index `10` is logical ground level `z: 0`. The conversion is:

--- a/Tools/examples/map_recipe_small_cabin_template.json
+++ b/Tools/examples/map_recipe_small_cabin_template.json
@@ -6,6 +6,10 @@
 	"base_tile": {"id": "grass_plain_01"},
 	"templates": {
 		"small_cabin": {
+			"anchors": {
+				"entrance": {"at": [0, 1], "z": 0, "facing": "west"},
+				"exit": {"at": [4, 1], "z": 0, "facing": "east"}
+			},
 			"levels": [
 				{
 					"dz": 0,
@@ -33,6 +37,12 @@
 		{
 			"template": "small_cabin",
 			"origin": {"at": [10, 10], "z": 0},
+			"rotation": 0
+		},
+		{
+			"template": "small_cabin",
+			"anchor_to": {"placement": 0, "anchor": "exit"},
+			"at_anchor": "entrance",
 			"rotation": 0
 		}
 	]

--- a/Tools/map_generator.py
+++ b/Tools/map_generator.py
@@ -168,8 +168,8 @@ def _expand_templates(recipe: dict[str, Any]) -> dict[str, Any]:
         context = f"templates.{template_id}"
         if not isinstance(template_id, str) or DEFINITION_NAME_PATTERN.fullmatch(template_id) is None:
             raise RecipeError(f"{context} must use a valid template ID")
-        if not isinstance(template, dict) or set(template) != {"levels"}:
-            raise RecipeError(f"{context} must define only levels")
+        if not isinstance(template, dict) or set(template) - {"levels", "anchors"} or "levels" not in template:
+            raise RecipeError(f"{context} must define levels and may define anchors")
         levels = template["levels"]
         if not isinstance(levels, list) or not levels:
             raise RecipeError(f"{context}.levels must be a non-empty array")
@@ -186,28 +186,67 @@ def _expand_templates(recipe: dict[str, Any]) -> dict[str, Any]:
             seen_dz.add(dz)
             if not isinstance(level["operations"], list):
                 raise RecipeError(f"{level_context}.operations must be an array")
+        anchors = template.get("anchors", {})
+        if not isinstance(anchors, dict):
+            raise RecipeError(f"{context}.anchors must be an object")
+        for anchor_id, anchor in anchors.items():
+            anchor_context = f"{context}.anchors.{anchor_id}"
+            if not isinstance(anchor_id, str) or DEFINITION_NAME_PATTERN.fullmatch(anchor_id) is None:
+                raise RecipeError(f"{anchor_context} must use a valid anchor ID")
+            if not isinstance(anchor, dict) or set(anchor) - {"at", "z", "facing"} or not {"at", "z"}.issubset(anchor):
+                raise RecipeError(f"{anchor_context} must define at and z, with optional facing")
+            if not isinstance(anchor["at"], list) or len(anchor["at"]) != 2 or any(type(value) is not int for value in anchor["at"]):
+                raise RecipeError(f"{anchor_context}.at must be a two-integer coordinate")
+            if type(anchor["z"]) is not int or not MIN_LOGICAL_Z <= anchor["z"] <= MAX_LOGICAL_Z:
+                raise RecipeError(f"{anchor_context}.z must be an integer between -10 and 10")
+            if "facing" in anchor and anchor["facing"] not in CONNECTION_DIRECTIONS:
+                raise RecipeError(f"{anchor_context}.facing must be a cardinal direction")
 
+    resolved_anchors: list[dict[str, dict[str, Any]]] = []
     for placement_index, placement in enumerate(placements):
         context = f"placements[{placement_index}]"
-        if not isinstance(placement, dict) or set(placement) != {"template", "origin", "rotation"}:
-            raise RecipeError(f"{context} must define template, origin, and rotation")
+        if not isinstance(placement, dict) or set(placement) - {"template", "origin", "anchor_to", "at_anchor", "rotation"}:
+            raise RecipeError(f"{context} contains unknown placement fields")
+        if set(placement) & {"origin", "anchor_to", "at_anchor"} not in ({"origin"}, {"anchor_to", "at_anchor"}):
+            raise RecipeError(f"{context} must define either origin or anchor_to with at_anchor")
         template_id = placement["template"]
         if not isinstance(template_id, str) or template_id not in templates:
             raise RecipeError(f"{context}.template references unknown template '{template_id}'")
-        origin = placement["origin"]
-        if (
-            not isinstance(origin, dict)
-            or set(origin) != {"at", "z"}
-            or not isinstance(origin.get("at"), list)
-            or len(origin["at"]) != 2
-            or any(type(value) is not int for value in origin["at"])
-            or type(origin.get("z")) is not int
-        ):
-            raise RecipeError(f"{context}.origin must define a two-integer at and integer z")
+        if "template" not in placement or "rotation" not in placement:
+            raise RecipeError(f"{context} must define template and rotation")
         if placement["rotation"] != 0:
             raise RecipeError(f"{context}.rotation only supports 0 in the minimal template expansion")
+        template_anchors = templates[template_id].get("anchors", {})
+        if "origin" in placement:
+            origin = placement["origin"]
+            if (
+                not isinstance(origin, dict)
+                or set(origin) != {"at", "z"}
+                or not isinstance(origin.get("at"), list)
+                or len(origin["at"]) != 2
+                or any(type(value) is not int for value in origin["at"])
+                or type(origin.get("z")) is not int
+            ):
+                raise RecipeError(f"{context}.origin must define a two-integer at and integer z")
+            origin_at = origin["at"]
+            origin_z = origin["z"]
+        else:
+            anchor_to = placement["anchor_to"]
+            at_anchor = placement["at_anchor"]
+            if not isinstance(anchor_to, dict) or set(anchor_to) != {"placement", "anchor"}:
+                raise RecipeError(f"{context}.anchor_to must define placement and anchor")
+            if type(anchor_to["placement"]) is not int or not 0 <= anchor_to["placement"] < placement_index:
+                raise RecipeError(f"{context}.anchor_to.placement must reference a prior placement")
+            if not isinstance(anchor_to["anchor"], str) or anchor_to["anchor"] not in resolved_anchors[anchor_to["placement"]]:
+                raise RecipeError(f"{context}.anchor_to.anchor must reference an anchor on the prior placement")
+            if not isinstance(at_anchor, str) or at_anchor not in template_anchors:
+                raise RecipeError(f"{context}.at_anchor must reference an anchor on the placed template")
+            target = resolved_anchors[anchor_to["placement"]][anchor_to["anchor"]]
+            local = template_anchors[at_anchor]
+            origin_at = [target["at"][0] - local["at"][0], target["at"][1] - local["at"][1]]
+            origin_z = target["z"] - local["z"]
         for level in templates[template_id]["levels"]:
-            absolute_z = origin["z"] + level["dz"]
+            absolute_z = origin_z + level["dz"]
             if not MIN_LOGICAL_Z <= absolute_z <= MAX_LOGICAL_Z:
                 raise RecipeError(f"{context} places relative level dz {level['dz']} outside logical z bounds")
             for operation_index, operation in enumerate(level["operations"]):
@@ -221,31 +260,44 @@ def _expand_templates(recipe: dict[str, Any]) -> dict[str, Any]:
                 if operation_type in {"set", "rectangle", "rectangle_outline", "furniture", "area_rectangle", "room_rectangle"}:
                     if not isinstance(translated.get("x"), int) or not isinstance(translated.get("y"), int):
                         raise RecipeError(f"{operation_context} requires integer x and y")
-                    translated["x"] += origin["at"][0]
-                    translated["y"] += origin["at"][1]
+                    translated["x"] += origin_at[0]
+                    translated["y"] += origin_at[1]
                 elif operation_type in {"scatter", "furniture_scatter"}:
                     region = translated.get("region")
                     if not isinstance(region, dict) or not isinstance(region.get("x"), int) or not isinstance(region.get("y"), int):
                         raise RecipeError(f"{operation_context}.region requires integer x and y")
-                    region["x"] += origin["at"][0]
-                    region["y"] += origin["at"][1]
+                    region["x"] += origin_at[0]
+                    region["y"] += origin_at[1]
                 elif operation_type == "line":
                     for endpoint in ("from", "to"):
                         point = translated.get(endpoint)
                         if not isinstance(point, list) or len(point) != 2 or any(type(value) is not int for value in point):
                             raise RecipeError(f"{operation_context}.{endpoint} must be a two-integer coordinate")
-                        point[0] += origin["at"][0]
-                        point[1] += origin["at"][1]
+                        point[0] += origin_at[0]
+                        point[1] += origin_at[1]
                 elif operation_type == "pattern":
                     point = translated.get("at")
                     if not isinstance(point, list) or len(point) != 2 or any(type(value) is not int for value in point):
                         raise RecipeError(f"{operation_context}.at must be a two-integer coordinate")
-                    point[0] += origin["at"][0]
-                    point[1] += origin["at"][1]
+                    point[0] += origin_at[0]
+                    point[1] += origin_at[1]
                 else:
                     raise RecipeError(f"{operation_context}.type '{operation_type}' is not supported by minimal templates")
                 translated["z"] = absolute_z
                 expanded_operations.append(translated)
+        resolved_template_anchors: dict[str, dict[str, Any]] = {}
+        for anchor_id, anchor in template_anchors.items():
+            resolved_anchor = {
+                "at": [origin_at[0] + anchor["at"][0], origin_at[1] + anchor["at"][1]],
+                "z": origin_z + anchor["z"],
+                **({"facing": anchor["facing"]} if "facing" in anchor else {}),
+            }
+            if not (0 <= resolved_anchor["at"][0] < MAP_WIDTH and 0 <= resolved_anchor["at"][1] < MAP_HEIGHT):
+                raise RecipeError(f"{context}.{anchor_id} resolves outside map bounds")
+            if not MIN_LOGICAL_Z <= resolved_anchor["z"] <= MAX_LOGICAL_Z:
+                raise RecipeError(f"{context}.{anchor_id} resolves outside logical z bounds")
+            resolved_template_anchors[anchor_id] = resolved_anchor
+        resolved_anchors.append(resolved_template_anchors)
     return expanded
 
 

--- a/Tools/tests/test_map_generator.py
+++ b/Tools/tests/test_map_generator.py
@@ -82,6 +82,40 @@ class MapGeneratorTests(unittest.TestCase):
         self.assertEqual(first["levels"][13][13 * 32 + 11], {"id": "concrete_00"})
         self.assertEqual(first["levels"][12], [])
 
+    def test_template_anchors_align_a_later_placement_to_a_prior_placement(self):
+        recipe = valid_recipe()
+        recipe["templates"] = {
+            "segment": {
+                "anchors": {
+                    "entry": {"at": [0, 0], "z": 0, "facing": "east"},
+                    "exit": {"at": [2, 0], "z": 1},
+                },
+                "levels": [
+                    {"dz": 0, "operations": [{"type": "set", "x": 0, "y": 0, "tile": {"id": "dirt_light_00"}}]},
+                    {"dz": 1, "operations": [{"type": "set", "x": 2, "y": 0, "tile": {"id": "concrete_00"}}]},
+                ],
+            }
+        }
+        recipe["placements"] = [
+            {"template": "segment", "origin": {"at": [10, 10], "z": 0}, "rotation": 0},
+            {"template": "segment", "anchor_to": {"placement": 0, "anchor": "exit"}, "at_anchor": "entry", "rotation": 0},
+        ]
+
+        generated = generate_map(recipe, TILES_PATH)
+
+        self.assertEqual(generated["levels"][10][10 * 32 + 10], {"id": "dirt_light_00"})
+        self.assertEqual(generated["levels"][11][10 * 32 + 12], {"id": "dirt_light_00"})
+        self.assertEqual(generated["levels"][10][10 * 32 + 12], {"id": "grass_plain_01"})
+        self.assertEqual(generated["levels"][12][10 * 32 + 14], {"id": "concrete_00"})
+
+    def test_template_anchor_placement_requires_a_prior_anchor(self):
+        recipe = valid_recipe()
+        recipe["templates"] = {"segment": {"anchors": {"entry": {"at": [0, 0], "z": 0}}, "levels": [{"dz": 0, "operations": []}]}}
+        recipe["placements"] = [{"template": "segment", "anchor_to": {"placement": 0, "anchor": "entry"}, "at_anchor": "entry", "rotation": 0}]
+
+        with self.assertRaisesRegex(RecipeError, "must reference a prior placement"):
+            generate_map(recipe, TILES_PATH)
+
     def test_small_cabin_template_example_generates(self):
         recipe_path = ROOT / "Tools" / "examples" / "map_recipe_small_cabin_template.json"
         first = generate_map(json.loads(recipe_path.read_text(encoding="utf-8")), TILES_PATH)
@@ -91,6 +125,10 @@ class MapGeneratorTests(unittest.TestCase):
         self.assertEqual(first["levels"][10][10 * 32 + 10]["id"], "dirt_light_00")
         self.assertEqual(first["levels"][11][10 * 32 + 10]["id"], "brick_wall_00")
         self.assertEqual(first["levels"][12][10 * 32 + 10]["id"], "concrete_00")
+        self.assertEqual(first["levels"][12][10 * 32 + 13]["id"], "concrete_00")
+        self.assertEqual(first["levels"][12][10 * 32 + 14]["id"], "concrete_00")
+        self.assertEqual(first["levels"][12][10 * 32 + 17]["id"], "concrete_00")
+        self.assertEqual(first["levels"][12][10 * 32 + 18], {})
 
     def test_legacy_regions_and_every_operation_can_target_logical_z(self):
         recipe = valid_recipe()


### PR DESCRIPTION
## Summary

- add named relative anchors to template definitions
- support anchor-to-anchor placement against prior placements
- preserve literal-origin placement compatibility
- validate anchor references, placement order, and resolved bounds
- update the maintained small cabin example
- document the new Phase 8 template composition capability

## Validation

- 161 Python tests passing
- maintained generated template map validates successfully
- Python compilation checks pass
- git diff --check passes

## Current limitations

- only rotation 0 is supported
- anchor facing is preserved as metadata but does not yet rotate placement
- parameters, nested templates, and richer footprint validation remain future Phase 8 work