### PR TITLE
feat(map-gen): add template parameters and cabin variants

### DIFF
--- a/Documentation/Game_design/Map_generation_plan.md
+++ b/Documentation/Game_design/Map_generation_plan.md
@@ -746,7 +746,7 @@ Generate a standalone map with one or more road edge connections and a continuou
 
 ## Phase 8 — Templates and compositional generation
 
-**Status: in progress; deterministic unrotated template expansion and anchor-to-anchor placement complete**
+**Status: in progress; deterministic unrotated template expansion, anchors, and tile parameter variants complete**
 
 The first Phase 8 slice adds reusable template definitions without creating a second generation pipeline. Templates expand into ordinary root operations before the existing recipe validation and map generation stages.
 
@@ -756,12 +756,13 @@ The first Phase 8 slice adds reusable template definitions without creating a se
 * unrotated placements with translated horizontal origins and `origin.z + dz` resolution;
 * named template anchors with absolute anchor resolution; exterior connection anchors place distinct footprints adjacently while coincident interior anchors intentionally overlap;
 * anchor-to-anchor placement against prior placements;
+* `tile_id` template parameter declarations with required/default resolution and placement-level overrides;
+* deterministic reusable variants in the maintained `small_cabin` example;
 * expansion into existing ordinary root operations before normal validation;
-* deterministic maintained `small_cabin` example and regression coverage.
 
 ### Remaining Phase 8 work
 
-* parameters and reusable variants;
+* additional parameter types and semantic variants;
 * automatic rotation and facing-aware anchor composition;
 * nested templates;
 * complete three-dimensional footprint validation and richer compositional locations.

--- a/Documentation/Modding/map_recipe_generator.md
+++ b/Documentation/Modding/map_recipe_generator.md
@@ -38,8 +38,8 @@ The root must be a JSON object with these fields:
 | `connections` | object | Authored map-edge connection metadata. Optional; defaults to all `"ground"`. |
 | `road_endpoints` | array | Authored road endpoint anchors at map edges. Optional; defaults to `[]`. |
 | `road_paths` | array | Authored cardinal routes between road endpoints. Optional; defaults to `[]`; a path may paint a map-local route with `tile`. |
-| `templates` | object | Reusable template definitions with relative `levels` and optional named `anchors`. Optional; requires `placements` when present. |
-| `placements` | array | Template placements with a literal `origin` or anchor-to-anchor alignment through `anchor_to` and `at_anchor`. |
+| `templates` | object | Reusable template definitions with relative `levels`, optional named `anchors`, and declared parameter definitions. Optional; requires `placements` when present. |
+| `placements` | array | Template placements with a literal `origin` or anchor-to-anchor alignment through `anchor_to` and `at_anchor`, plus optional parameter overrides. |
 | `building_surfaces` | array | Authored per-building floor, ceiling, and roof surface semantics. Optional; defaults to `[]`. |
 | `building_supports` | array | Authored multi-level structural support paths. Optional; defaults to `[]`. |
 
@@ -139,6 +139,10 @@ Templates are expanded before ordinary recipe validation and generation. A templ
 {
   "templates": {
     "small_cabin": {
+      "parameters": {
+        "floor_tile": {"type": "tile_id", "default": "concrete_00"},
+        "wall_tile": {"type": "tile_id", "default": "brick_wall_00"}
+      },
       "anchors": {
         "entrance": {"at": [0, 1], "z": 0, "facing": "west"},
         "exit": {"at": [4, 1], "z": 0, "facing": "east"}
@@ -156,6 +160,7 @@ Templates are expanded before ordinary recipe validation and generation. A templ
       "template": "small_cabin",
       "anchor_to": {"placement": 0, "anchor": "exit"},
       "at_anchor": "entrance",
+      "parameters": {"wall_tile": "brick_wall_01"},
       "rotation": 0
     }
   ]
@@ -164,9 +169,11 @@ Templates are expanded before ordinary recipe validation and generation. A templ
 
 For anchor-to-anchor placement, the referenced placement must appear earlier in the `placements` array. The generator computes the new origin so the placed template's `at_anchor` has the same absolute `[x, y, z]` as the referenced anchor. To place separate structures side by side, author connection anchors on the exterior edge immediately beyond each footprint (for example, a 4×4 template can use west `[0, 1]` and east `[4, 1]` anchors); interior anchors intentionally produce overlapping geometry when coincident. Anchor `facing` is preserved as metadata for future rotation-aware composition; it does not yet rotate or enforce a facing relationship.
 
-The minimal expansion supports existing `set`, rectangle, outline, line, pattern, scatter, furniture, area-rectangle, room-rectangle, and furniture-scatter operation shapes. It rejects nested operation `z` values, non-zero rotations, unknown templates or anchors, duplicate relative `dz` levels, forward anchor references, and placements outside the logical z range. Templates cannot yet be combined with the grouped root `levels` layout, nested templates, parameters, or automatic rotation. The generated map contains only expanded ordinary recipe output; `templates` and `placements` are not serialized.
+Templates may declare `parameters`; this first parameter slice supports only `tile_id` values. Each declaration has `type: "tile_id"` and may provide a string `default`. A declaration without a default is required on every placement. Placements may override declared values through `parameters`, and template operation strings of the exact form `$parameter_name` are replaced before normal operation validation. Unknown overrides, missing required values, malformed parameter declarations, and unresolved `$` references are rejected. The substituted ID then follows the same tile-database validation as a literal tile ID.
 
-`Tools/examples/map_recipe_small_cabin_template.json` is the maintained example. Its tests verify deterministic expansion, relative `dz` placement, and anchor-to-anchor alignment.
+The expansion supports existing `set`, rectangle, outline, line, pattern, scatter, furniture, area-rectangle, room-rectangle, and furniture-scatter operation shapes. It rejects nested operation `z` values, non-zero rotations, unknown templates or anchors, duplicate relative `dz` levels, forward anchor references, and placements outside the logical z range. Templates cannot yet be combined with the grouped root `levels` layout, nested templates, non-`tile_id` parameter types, or automatic rotation. The generated map contains only expanded ordinary recipe output; `templates` and `placements` are not serialized.
+
+`Tools/examples/map_recipe_small_cabin_template.json` is the maintained example. Its tests verify deterministic expansion, relative `dz` placement, anchor-to-anchor alignment, and two cabin tile variants.
 ## Logical levels
 
 Map level-array index `10` is logical ground level `z: 0`. The conversion is:

--- a/Tools/examples/map_recipe_small_cabin_template.json
+++ b/Tools/examples/map_recipe_small_cabin_template.json
@@ -6,6 +6,12 @@
 	"base_tile": {"id": "grass_plain_01"},
 	"templates": {
 		"small_cabin": {
+			"parameters": {
+				"floor_tile": {"type": "tile_id", "default": "concrete_00"},
+				"support_tile": {"type": "tile_id", "default": "dirt_light_00"},
+				"wall_tile": {"type": "tile_id", "default": "brick_wall_00"},
+				"roof_tile": {"type": "tile_id", "default": "concrete_00"}
+			},
 			"anchors": {
 				"entrance": {"at": [0, 1], "z": 0, "facing": "west"},
 				"exit": {"at": [4, 1], "z": 0, "facing": "east"}
@@ -14,20 +20,20 @@
 				{
 					"dz": 0,
 					"operations": [
-						{"type": "rectangle", "x": 0, "y": 0, "width": 4, "height": 4, "tile": {"id": "concrete_00"}},
-						{"type": "rectangle_outline", "x": 0, "y": 0, "width": 4, "height": 4, "tile": {"id": "dirt_light_00"}}
+						{"type": "rectangle", "x": 0, "y": 0, "width": 4, "height": 4, "tile": {"id": "$floor_tile"}},
+						{"type": "rectangle_outline", "x": 0, "y": 0, "width": 4, "height": 4, "tile": {"id": "$support_tile"}}
 					]
 				},
 				{
 					"dz": 1,
 					"operations": [
-						{"type": "rectangle_outline", "x": 0, "y": 0, "width": 4, "height": 4, "tile": {"id": "brick_wall_00"}}
+						{"type": "rectangle_outline", "x": 0, "y": 0, "width": 4, "height": 4, "tile": {"id": "$wall_tile"}}
 					]
 				},
 				{
 					"dz": 2,
 					"operations": [
-						{"type": "rectangle", "x": 0, "y": 0, "width": 4, "height": 4, "tile": {"id": "concrete_00"}}
+						{"type": "rectangle", "x": 0, "y": 0, "width": 4, "height": 4, "tile": {"id": "$roof_tile"}}
 					]
 				}
 			]
@@ -43,6 +49,7 @@
 			"template": "small_cabin",
 			"anchor_to": {"placement": 0, "anchor": "exit"},
 			"at_anchor": "entrance",
+			"parameters": {"support_tile": "dirt_light_01", "wall_tile": "brick_wall_01"},
 			"rotation": 0
 		}
 	]

--- a/Tools/map_generator.py
+++ b/Tools/map_generator.py
@@ -145,6 +145,55 @@ class RecipeError(ValueError):
     """Raised when a map recipe is invalid."""
 
 
+def _resolve_template_parameters(
+    definitions: Any, overrides: Any, context: str, require_values: bool = True
+) -> dict[str, str]:
+    if definitions is None:
+        definitions = {}
+    if not isinstance(definitions, dict):
+        raise RecipeError(f"{context}.parameters must be an object")
+    if overrides is None:
+        overrides = {}
+    if not isinstance(overrides, dict):
+        raise RecipeError(f"{context}.parameters must be an object")
+
+    unknown_overrides = sorted(set(overrides) - set(definitions))
+    if unknown_overrides:
+        raise RecipeError(f"{context}.parameters contains unknown parameter '{unknown_overrides[0]}'")
+
+    resolved: dict[str, str] = {}
+    for parameter_id, definition in definitions.items():
+        parameter_context = f"{context}.parameters.{parameter_id}"
+        if not isinstance(parameter_id, str) or DEFINITION_NAME_PATTERN.fullmatch(parameter_id) is None:
+            raise RecipeError(f"{parameter_context} must use a valid parameter ID")
+        if not isinstance(definition, dict) or set(definition) - {"type", "default"} or definition.get("type") != "tile_id":
+            raise RecipeError(f"{parameter_context} must define type 'tile_id' with optional default")
+        value = overrides.get(parameter_id, definition.get("default"))
+        if value is None and not require_values:
+            continue
+        if not isinstance(value, str) or not value:
+            raise RecipeError(f"{parameter_context} requires a non-empty tile_id value")
+        resolved[parameter_id] = value
+
+    return resolved
+
+
+def _substitute_template_parameters(value: Any, parameters: dict[str, str], context: str) -> Any:
+    if isinstance(value, str) and value.startswith("$"):
+        parameter_id = value[1:]
+        if parameter_id not in parameters:
+            raise RecipeError(f"{context} references unknown template parameter '{parameter_id}'")
+        return parameters[parameter_id]
+    if isinstance(value, list):
+        return [_substitute_template_parameters(entry, parameters, context) for entry in value]
+    if isinstance(value, dict):
+        return {
+            key: _substitute_template_parameters(entry, parameters, context)
+            for key, entry in value.items()
+        }
+    return value
+
+
 def _expand_templates(recipe: dict[str, Any]) -> dict[str, Any]:
     templates = recipe.get("templates")
     placements = recipe.get("placements")
@@ -168,8 +217,9 @@ def _expand_templates(recipe: dict[str, Any]) -> dict[str, Any]:
         context = f"templates.{template_id}"
         if not isinstance(template_id, str) or DEFINITION_NAME_PATTERN.fullmatch(template_id) is None:
             raise RecipeError(f"{context} must use a valid template ID")
-        if not isinstance(template, dict) or set(template) - {"levels", "anchors"} or "levels" not in template:
-            raise RecipeError(f"{context} must define levels and may define anchors")
+        if not isinstance(template, dict) or set(template) - {"levels", "anchors", "parameters"} or "levels" not in template:
+            raise RecipeError(f"{context} must define levels and may define anchors or parameters")
+        _resolve_template_parameters(template.get("parameters"), {}, context, require_values=False)
         levels = template["levels"]
         if not isinstance(levels, list) or not levels:
             raise RecipeError(f"{context}.levels must be a non-empty array")
@@ -205,17 +255,20 @@ def _expand_templates(recipe: dict[str, Any]) -> dict[str, Any]:
     resolved_anchors: list[dict[str, dict[str, Any]]] = []
     for placement_index, placement in enumerate(placements):
         context = f"placements[{placement_index}]"
-        if not isinstance(placement, dict) or set(placement) - {"template", "origin", "anchor_to", "at_anchor", "rotation"}:
+        if not isinstance(placement, dict) or set(placement) - {"template", "origin", "anchor_to", "at_anchor", "rotation", "parameters"}:
             raise RecipeError(f"{context} contains unknown placement fields")
+        if "template" not in placement or "rotation" not in placement:
+            raise RecipeError(f"{context} must define template and rotation")
         if set(placement) & {"origin", "anchor_to", "at_anchor"} not in ({"origin"}, {"anchor_to", "at_anchor"}):
             raise RecipeError(f"{context} must define either origin or anchor_to with at_anchor")
         template_id = placement["template"]
         if not isinstance(template_id, str) or template_id not in templates:
             raise RecipeError(f"{context}.template references unknown template '{template_id}'")
-        if "template" not in placement or "rotation" not in placement:
-            raise RecipeError(f"{context} must define template and rotation")
         if placement["rotation"] != 0:
             raise RecipeError(f"{context}.rotation only supports 0 in the minimal template expansion")
+        parameters = _resolve_template_parameters(
+            templates[template_id].get("parameters"), placement.get("parameters"), context
+        )
         template_anchors = templates[template_id].get("anchors", {})
         if "origin" in placement:
             origin = placement["origin"]
@@ -255,7 +308,9 @@ def _expand_templates(recipe: dict[str, Any]) -> dict[str, Any]:
                     raise RecipeError(f"{operation_context} must be an operation object")
                 if "z" in operation:
                     raise RecipeError(f"{operation_context}.z must be omitted; use the enclosing relative level dz")
-                translated = copy.deepcopy(operation)
+                translated = _substitute_template_parameters(
+                    copy.deepcopy(operation), parameters, operation_context
+                )
                 operation_type = translated["type"]
                 if operation_type in {"set", "rectangle", "rectangle_outline", "furniture", "area_rectangle", "room_rectangle"}:
                     if not isinstance(translated.get("x"), int) or not isinstance(translated.get("y"), int):

--- a/Tools/tests/test_map_generator.py
+++ b/Tools/tests/test_map_generator.py
@@ -82,6 +82,48 @@ class MapGeneratorTests(unittest.TestCase):
         self.assertEqual(first["levels"][13][13 * 32 + 11], {"id": "concrete_00"})
         self.assertEqual(first["levels"][12], [])
 
+    def test_template_parameters_apply_defaults_and_placement_variants(self):
+        recipe = valid_recipe()
+        recipe["templates"] = {
+            "tile_variant": {
+                "parameters": {
+                    "tile": {"type": "tile_id", "default": "dirt_light_00"},
+                },
+                "levels": [{"dz": 0, "operations": [{"type": "set", "x": 0, "y": 0, "tile": {"id": "$tile"}}]}],
+            }
+        }
+        recipe["placements"] = [
+            {"template": "tile_variant", "origin": {"at": [10, 10], "z": 0}, "rotation": 0},
+            {"template": "tile_variant", "origin": {"at": [11, 10], "z": 0}, "parameters": {"tile": "concrete_00"}, "rotation": 0},
+        ]
+
+        generated = generate_map(recipe, TILES_PATH)
+
+        self.assertEqual(generated["levels"][10][10 * 32 + 10], {"id": "dirt_light_00"})
+        self.assertEqual(generated["levels"][10][10 * 32 + 11], {"id": "concrete_00"})
+
+    def test_template_parameters_reject_missing_unknown_and_unresolved_values(self):
+        recipe = valid_recipe()
+        recipe["templates"] = {
+            "required_tile": {
+                "parameters": {"tile": {"type": "tile_id"}},
+                "levels": [{"dz": 0, "operations": [{"type": "set", "x": 0, "y": 0, "tile": {"id": "$tile"}}]}],
+            }
+        }
+        recipe["placements"] = [{"template": "required_tile", "origin": {"at": [10, 10], "z": 0}, "rotation": 0}]
+        with self.assertRaisesRegex(RecipeError, "requires a non-empty tile_id value"):
+            generate_map(recipe, TILES_PATH)
+
+        recipe["placements"][0]["parameters"] = {"unknown": "concrete_00"}
+        with self.assertRaisesRegex(RecipeError, "unknown parameter 'unknown'"):
+            generate_map(recipe, TILES_PATH)
+
+        recipe["templates"]["required_tile"]["parameters"] = {"tile": {"type": "tile_id", "default": "dirt_light_00"}}
+        recipe["templates"]["required_tile"]["levels"][0]["operations"][0]["tile"]["id"] = "$missing"
+        recipe["placements"][0]["parameters"] = {}
+        with self.assertRaisesRegex(RecipeError, "unknown template parameter 'missing'"):
+            generate_map(recipe, TILES_PATH)
+
     def test_template_anchors_align_a_later_placement_to_a_prior_placement(self):
         recipe = valid_recipe()
         recipe["templates"] = {
@@ -127,6 +169,8 @@ class MapGeneratorTests(unittest.TestCase):
         self.assertEqual(first["levels"][12][10 * 32 + 10]["id"], "concrete_00")
         self.assertEqual(first["levels"][12][10 * 32 + 13]["id"], "concrete_00")
         self.assertEqual(first["levels"][12][10 * 32 + 14]["id"], "concrete_00")
+        self.assertEqual(first["levels"][10][10 * 32 + 14]["id"], "dirt_light_01")
+        self.assertEqual(first["levels"][11][10 * 32 + 14]["id"], "brick_wall_01")
         self.assertEqual(first["levels"][12][10 * 32 + 17]["id"], "concrete_00")
         self.assertEqual(first["levels"][12][10 * 32 + 18], {})
 


### PR DESCRIPTION
## Summary

- add declared `tile_id` template parameters with optional defaults
- support required per-placement parameter values
- substitute exact `$parameter_name` operation values before standard validation
- reject malformed declarations, missing required values, unknown overrides, and unresolved references
- update the maintained small-cabin template to generate two tile variants
- update Phase 8 and map recipe documentation

## Validation

- 163 Python tests passing
- generated small-cabin template map validates successfully
- Python compilation checks pass
- `git diff --check` passes

## Current limitations

- only `tile_id` parameter values are supported
- automatic rotation, facing-aware anchor composition, nested templates, and 3D footprint validation remain Phase 8 follow-up work