### PR TITLE
feat(map-gen): add semantic template parameter variants

### DIFF
--- a/Documentation/Game_design/Map_generation_plan.md
+++ b/Documentation/Game_design/Map_generation_plan.md
@@ -746,7 +746,7 @@ Generate a standalone map with one or more road edge connections and a continuou
 
 ## Phase 8 — Templates and compositional generation
 
-**Status: in progress; deterministic unrotated template expansion, anchors, and tile parameter variants complete**
+**Status: in progress; deterministic unrotated template expansion, anchors, and typed semantic variants complete**
 
 The first Phase 8 slice adds reusable template definitions without creating a second generation pipeline. Templates expand into ordinary root operations before the existing recipe validation and map generation stages.
 
@@ -756,13 +756,14 @@ The first Phase 8 slice adds reusable template definitions without creating a se
 * unrotated placements with translated horizontal origins and `origin.z + dz` resolution;
 * named template anchors with absolute anchor resolution; exterior connection anchors place distinct footprints adjacently while coincident interior anchors intentionally overlap;
 * anchor-to-anchor placement against prior placements;
-* `tile_id` template parameter declarations with required/default resolution and placement-level overrides;
-* deterministic reusable variants in the maintained `small_cabin` example;
+* typed `tile_id`, `boolean`, and enum template parameters with required/default resolution and placement-level overrides;
+* conditional template operations for boolean inclusion and enum-selected semantic variants;
+* deterministic reusable cabin variants: brick-roofed and metal open-top;
 * expansion into existing ordinary root operations before normal validation;
 
 ### Remaining Phase 8 work
 
-* additional parameter types and semantic variants;
+* numeric or collection parameter types;
 * automatic rotation and facing-aware anchor composition;
 * nested templates;
 * complete three-dimensional footprint validation and richer compositional locations.
@@ -870,7 +871,7 @@ An agent can create a new playable, potentially multi-level map from a concise d
 
 # Recommended immediate next task
 
-**Phase 6 is complete.** Its runtime-compatible area foundation, room semantics, authored building constraints, multi-level footprint metadata, physical floor/wall/support generation, standable roof generation, authored staircase evidence, enclosed maintained building geometry, and manual player traversal verification are complete for the first narrow building slice. **Phase 7 is complete** with authored map-edge metadata, endpoint anchoring, route metadata, deterministic map-local route painting, and runtime walkability validation. Explicit map-to-map edge compatibility is intentionally deferred as an optional future follow-up. The next planned area is **Phase 8: Templates and compositional generation**. Its first minimal slice is now implemented: deterministic unrotated `small_cabin` expansion with relative `dz`; remaining work is anchors, parameters, rotation, nesting, and richer composition.
+**Phase 6 is complete.** Its runtime-compatible area foundation, room semantics, authored building constraints, multi-level footprint metadata, physical floor/wall/support generation, standable roof generation, authored staircase evidence, enclosed maintained building geometry, and manual player traversal verification are complete for the first narrow building slice. **Phase 7 is complete** with authored map-edge metadata, endpoint anchoring, route metadata, deterministic map-local route painting, and runtime walkability validation. Explicit map-to-map edge compatibility is intentionally deferred as an optional future follow-up. **Phase 8 is in progress**: unrotated template expansion, anchors, and typed semantic variants are complete; remaining work is automatic rotation/facing-aware composition, nested templates, numeric or collection parameter types, and richer 3D composition.
 
 Do not yet generate towns or generalized compositional locations. Preserve the established map-level `areas` plus per-tile area membership representation, keep room semantics independent from runtime areas, and treat overmap areas as the authority for settlement composition and multi-map roads. Explicit map-to-map edge compatibility remains deferred until it becomes useful.
 

--- a/Documentation/Modding/map_recipe_generator.md
+++ b/Documentation/Modding/map_recipe_generator.md
@@ -141,7 +141,8 @@ Templates are expanded before ordinary recipe validation and generation. A templ
     "small_cabin": {
       "parameters": {
         "floor_tile": {"type": "tile_id", "default": "concrete_00"},
-        "wall_tile": {"type": "tile_id", "default": "brick_wall_00"}
+        "wall_material": {"type": "enum", "values": ["brick", "metal"], "default": "brick"},
+        "include_roof": {"type": "boolean", "default": true}
       },
       "anchors": {
         "entrance": {"at": [0, 1], "z": 0, "facing": "west"},
@@ -160,7 +161,7 @@ Templates are expanded before ordinary recipe validation and generation. A templ
       "template": "small_cabin",
       "anchor_to": {"placement": 0, "anchor": "exit"},
       "at_anchor": "entrance",
-      "parameters": {"wall_tile": "brick_wall_01"},
+      "parameters": {"wall_material": "metal", "include_roof": false},
       "rotation": 0
     }
   ]
@@ -169,11 +170,11 @@ Templates are expanded before ordinary recipe validation and generation. A templ
 
 For anchor-to-anchor placement, the referenced placement must appear earlier in the `placements` array. The generator computes the new origin so the placed template's `at_anchor` has the same absolute `[x, y, z]` as the referenced anchor. To place separate structures side by side, author connection anchors on the exterior edge immediately beyond each footprint (for example, a 4×4 template can use west `[0, 1]` and east `[4, 1]` anchors); interior anchors intentionally produce overlapping geometry when coincident. Anchor `facing` is preserved as metadata for future rotation-aware composition; it does not yet rotate or enforce a facing relationship.
 
-Templates may declare `parameters`; this first parameter slice supports only `tile_id` values. Each declaration has `type: "tile_id"` and may provide a string `default`. A declaration without a default is required on every placement. Placements may override declared values through `parameters`, and template operation strings of the exact form `$parameter_name` are replaced before normal operation validation. Unknown overrides, missing required values, malformed parameter declarations, and unresolved `$` references are rejected. The substituted ID then follows the same tile-database validation as a literal tile ID.
+Templates may declare typed `parameters`. `tile_id` values substitute exact `$parameter_name` strings before normal operation validation and may provide a string `default`; without a default they are required on every placement. `boolean` values may provide a boolean `default` and control a template operation with `"when": "$parameter_name"`. `enum` values require a non-empty, unique string `values` array and may provide a default from that array; they select semantic operation variants with `"when": {"parameter": "material", "equals": "metal"}`. Placements override declared values through `parameters`. Unknown overrides, missing required values, malformed declarations, invalid enum values, unresolved `$` references, and non-boolean direct `when` references are rejected. Substituted tile IDs then follow the same tile-database validation as literal tile IDs.
 
-The expansion supports existing `set`, rectangle, outline, line, pattern, scatter, furniture, area-rectangle, room-rectangle, and furniture-scatter operation shapes. It rejects nested operation `z` values, non-zero rotations, unknown templates or anchors, duplicate relative `dz` levels, forward anchor references, and placements outside the logical z range. Templates cannot yet be combined with the grouped root `levels` layout, nested templates, non-`tile_id` parameter types, or automatic rotation. The generated map contains only expanded ordinary recipe output; `templates` and `placements` are not serialized.
+The expansion supports existing `set`, rectangle, outline, line, pattern, scatter, furniture, area-rectangle, room-rectangle, and furniture-scatter operation shapes. It rejects nested operation `z` values, non-zero rotations, unknown templates or anchors, duplicate relative `dz` levels, forward anchor references, and placements outside the logical z range. Templates cannot yet be combined with the grouped root `levels` layout, nested templates, numeric or collection parameter types, or automatic rotation. The generated map contains only expanded ordinary recipe output; `templates` and `placements` are not serialized.
 
-`Tools/examples/map_recipe_small_cabin_template.json` is the maintained example. Its tests verify deterministic expansion, relative `dz` placement, anchor-to-anchor alignment, and two cabin tile variants.
+`Tools/examples/map_recipe_small_cabin_template.json` is the maintained example. Its tests verify deterministic expansion, relative `dz` placement, anchor-to-anchor alignment, tile variants, boolean roof selection, and enum-selected wall material.
 ## Logical levels
 
 Map level-array index `10` is logical ground level `z: 0`. The conversion is:

--- a/Tools/examples/map_recipe_small_cabin_template.json
+++ b/Tools/examples/map_recipe_small_cabin_template.json
@@ -9,7 +9,8 @@
 			"parameters": {
 				"floor_tile": {"type": "tile_id", "default": "concrete_00"},
 				"support_tile": {"type": "tile_id", "default": "dirt_light_00"},
-				"wall_tile": {"type": "tile_id", "default": "brick_wall_00"},
+				"wall_material": {"type": "enum", "values": ["brick", "metal"], "default": "brick"},
+				"include_roof": {"type": "boolean", "default": true},
 				"roof_tile": {"type": "tile_id", "default": "concrete_00"}
 			},
 			"anchors": {
@@ -27,13 +28,14 @@
 				{
 					"dz": 1,
 					"operations": [
-						{"type": "rectangle_outline", "x": 0, "y": 0, "width": 4, "height": 4, "tile": {"id": "$wall_tile"}}
+						{"type": "rectangle_outline", "x": 0, "y": 0, "width": 4, "height": 4, "tile": {"id": "brick_wall_00"}, "when": {"parameter": "wall_material", "equals": "brick"}},
+						{"type": "rectangle_outline", "x": 0, "y": 0, "width": 4, "height": 4, "tile": {"id": "metal_wall_00"}, "when": {"parameter": "wall_material", "equals": "metal"}}
 					]
 				},
 				{
 					"dz": 2,
 					"operations": [
-						{"type": "rectangle", "x": 0, "y": 0, "width": 4, "height": 4, "tile": {"id": "$roof_tile"}}
+						{"type": "rectangle", "x": 0, "y": 0, "width": 4, "height": 4, "tile": {"id": "$roof_tile"}, "when": "$include_roof"}
 					]
 				}
 			]
@@ -49,7 +51,7 @@
 			"template": "small_cabin",
 			"anchor_to": {"placement": 0, "anchor": "exit"},
 			"at_anchor": "entrance",
-			"parameters": {"support_tile": "dirt_light_01", "wall_tile": "brick_wall_01"},
+			"parameters": {"support_tile": "dirt_light_01", "wall_material": "metal", "include_roof": false},
 			"rotation": 0
 		}
 	]

--- a/Tools/map_generator.py
+++ b/Tools/map_generator.py
@@ -147,7 +147,7 @@ class RecipeError(ValueError):
 
 def _resolve_template_parameters(
     definitions: Any, overrides: Any, context: str, require_values: bool = True
-) -> dict[str, str]:
+) -> dict[str, Any]:
     if definitions is None:
         definitions = {}
     if not isinstance(definitions, dict):
@@ -161,24 +161,42 @@ def _resolve_template_parameters(
     if unknown_overrides:
         raise RecipeError(f"{context}.parameters contains unknown parameter '{unknown_overrides[0]}'")
 
-    resolved: dict[str, str] = {}
+    resolved: dict[str, Any] = {}
     for parameter_id, definition in definitions.items():
         parameter_context = f"{context}.parameters.{parameter_id}"
         if not isinstance(parameter_id, str) or DEFINITION_NAME_PATTERN.fullmatch(parameter_id) is None:
             raise RecipeError(f"{parameter_context} must use a valid parameter ID")
-        if not isinstance(definition, dict) or set(definition) - {"type", "default"} or definition.get("type") != "tile_id":
-            raise RecipeError(f"{parameter_context} must define type 'tile_id' with optional default")
+        if not isinstance(definition, dict) or "type" not in definition:
+            raise RecipeError(f"{parameter_context} must define a parameter type")
+        parameter_type = definition["type"]
+        allowed_fields = {
+            "tile_id": {"type", "default"},
+            "boolean": {"type", "default"},
+            "enum": {"type", "values", "default"},
+        }
+        if parameter_type not in allowed_fields or set(definition) - allowed_fields[parameter_type]:
+            raise RecipeError(f"{parameter_context} has an unsupported parameter definition")
+        if parameter_type == "enum":
+            values = definition.get("values")
+            if not isinstance(values, list) or not values or any(not isinstance(value, str) or not value for value in values) or len(set(values)) != len(values):
+                raise RecipeError(f"{parameter_context}.values must be a non-empty array of unique strings")
         value = overrides.get(parameter_id, definition.get("default"))
         if value is None and not require_values:
             continue
-        if not isinstance(value, str) or not value:
+        if value is None:
+            raise RecipeError(f"{parameter_context} requires a value")
+        if parameter_type == "tile_id" and (not isinstance(value, str) or not value):
             raise RecipeError(f"{parameter_context} requires a non-empty tile_id value")
+        if parameter_type == "boolean" and type(value) is not bool:
+            raise RecipeError(f"{parameter_context} requires a boolean value")
+        if parameter_type == "enum" and value not in definition["values"]:
+            raise RecipeError(f"{parameter_context} must be one of its declared enum values")
         resolved[parameter_id] = value
 
     return resolved
 
 
-def _substitute_template_parameters(value: Any, parameters: dict[str, str], context: str) -> Any:
+def _substitute_template_parameters(value: Any, parameters: dict[str, Any], context: str) -> Any:
     if isinstance(value, str) and value.startswith("$"):
         parameter_id = value[1:]
         if parameter_id not in parameters:
@@ -192,6 +210,25 @@ def _substitute_template_parameters(value: Any, parameters: dict[str, str], cont
             for key, entry in value.items()
         }
     return value
+
+
+def _include_template_operation(
+    operation: dict[str, Any], parameters: dict[str, Any], context: str
+) -> bool:
+    if "when" not in operation:
+        return True
+    condition = operation["when"]
+    if isinstance(condition, str) and condition.startswith("$"):
+        value = _substitute_template_parameters(condition, parameters, context)
+        if type(value) is not bool:
+            raise RecipeError(f"{context}.when must resolve to a boolean parameter")
+        return value
+    if not isinstance(condition, dict) or set(condition) != {"parameter", "equals"}:
+        raise RecipeError(f"{context}.when must be '$boolean_parameter' or define parameter and equals")
+    parameter_id = condition["parameter"]
+    if not isinstance(parameter_id, str) or parameter_id not in parameters:
+        raise RecipeError(f"{context}.when references unknown template parameter '{parameter_id}'")
+    return parameters[parameter_id] == condition["equals"]
 
 
 def _expand_templates(recipe: dict[str, Any]) -> dict[str, Any]:
@@ -308,9 +345,14 @@ def _expand_templates(recipe: dict[str, Any]) -> dict[str, Any]:
                     raise RecipeError(f"{operation_context} must be an operation object")
                 if "z" in operation:
                     raise RecipeError(f"{operation_context}.z must be omitted; use the enclosing relative level dz")
+                if "when" in operation and not _include_template_operation(
+                    operation, parameters, operation_context
+                ):
+                    continue
                 translated = _substitute_template_parameters(
                     copy.deepcopy(operation), parameters, operation_context
                 )
+                translated.pop("when", None)
                 operation_type = translated["type"]
                 if operation_type in {"set", "rectangle", "rectangle_outline", "furniture", "area_rectangle", "room_rectangle"}:
                     if not isinstance(translated.get("x"), int) or not isinstance(translated.get("y"), int):

--- a/Tools/tests/test_map_generator.py
+++ b/Tools/tests/test_map_generator.py
@@ -102,6 +102,59 @@ class MapGeneratorTests(unittest.TestCase):
         self.assertEqual(generated["levels"][10][10 * 32 + 10], {"id": "dirt_light_00"})
         self.assertEqual(generated["levels"][10][10 * 32 + 11], {"id": "concrete_00"})
 
+    def test_template_boolean_and_enum_parameters_select_semantic_variants(self):
+        recipe = valid_recipe()
+        recipe["templates"] = {
+            "variant": {
+                "parameters": {
+                    "include_top": {"type": "boolean", "default": True},
+                    "material": {"type": "enum", "values": ["dirt", "concrete"], "default": "dirt"},
+                },
+                "levels": [
+                    {"dz": 0, "operations": [
+                        {"type": "set", "x": 0, "y": 0, "tile": {"id": "dirt_light_00"}, "when": {"parameter": "material", "equals": "dirt"}},
+                        {"type": "set", "x": 0, "y": 0, "tile": {"id": "concrete_00"}, "when": {"parameter": "material", "equals": "concrete"}},
+                    ]},
+                    {"dz": 1, "operations": [{"type": "set", "x": 0, "y": 0, "tile": {"id": "concrete_00"}, "when": "$include_top"}]},
+                ],
+            }
+        }
+        recipe["placements"] = [
+            {"template": "variant", "origin": {"at": [10, 10], "z": 0}, "rotation": 0},
+            {"template": "variant", "origin": {"at": [11, 10], "z": 0}, "parameters": {"material": "concrete", "include_top": False}, "rotation": 0},
+        ]
+
+        generated = generate_map(recipe, TILES_PATH)
+
+        self.assertEqual(generated["levels"][10][10 * 32 + 10], {"id": "dirt_light_00"})
+        self.assertEqual(generated["levels"][11][10 * 32 + 10], {"id": "concrete_00"})
+        self.assertEqual(generated["levels"][10][10 * 32 + 11], {"id": "concrete_00"})
+        self.assertEqual(generated["levels"][11][10 * 32 + 11], {})
+
+    def test_template_boolean_and_enum_parameters_reject_invalid_values_and_conditions(self):
+        recipe = valid_recipe()
+        recipe["templates"] = {
+            "variant": {
+                "parameters": {
+                    "enabled": {"type": "boolean", "default": True},
+                    "style": {"type": "enum", "values": ["brick", "metal"], "default": "brick"},
+                },
+                "levels": [{"dz": 0, "operations": [{"type": "set", "x": 0, "y": 0, "tile": {"id": "dirt_light_00"}, "when": "$enabled"}]}],
+            }
+        }
+        recipe["placements"] = [{"template": "variant", "origin": {"at": [10, 10], "z": 0}, "parameters": {"enabled": "yes"}, "rotation": 0}]
+        with self.assertRaisesRegex(RecipeError, "requires a boolean value"):
+            generate_map(recipe, TILES_PATH)
+
+        recipe["placements"][0]["parameters"] = {"style": "wood"}
+        with self.assertRaisesRegex(RecipeError, "must be one of its declared enum values"):
+            generate_map(recipe, TILES_PATH)
+
+        recipe["placements"][0]["parameters"] = {}
+        recipe["templates"]["variant"]["levels"][0]["operations"][0]["when"] = "$style"
+        with self.assertRaisesRegex(RecipeError, "when must resolve to a boolean parameter"):
+            generate_map(recipe, TILES_PATH)
+
     def test_template_parameters_reject_missing_unknown_and_unresolved_values(self):
         recipe = valid_recipe()
         recipe["templates"] = {
@@ -111,7 +164,7 @@ class MapGeneratorTests(unittest.TestCase):
             }
         }
         recipe["placements"] = [{"template": "required_tile", "origin": {"at": [10, 10], "z": 0}, "rotation": 0}]
-        with self.assertRaisesRegex(RecipeError, "requires a non-empty tile_id value"):
+        with self.assertRaisesRegex(RecipeError, "requires a value"):
             generate_map(recipe, TILES_PATH)
 
         recipe["placements"][0]["parameters"] = {"unknown": "concrete_00"}
@@ -168,10 +221,10 @@ class MapGeneratorTests(unittest.TestCase):
         self.assertEqual(first["levels"][11][10 * 32 + 10]["id"], "brick_wall_00")
         self.assertEqual(first["levels"][12][10 * 32 + 10]["id"], "concrete_00")
         self.assertEqual(first["levels"][12][10 * 32 + 13]["id"], "concrete_00")
-        self.assertEqual(first["levels"][12][10 * 32 + 14]["id"], "concrete_00")
+        self.assertEqual(first["levels"][12][10 * 32 + 14], {})
         self.assertEqual(first["levels"][10][10 * 32 + 14]["id"], "dirt_light_01")
-        self.assertEqual(first["levels"][11][10 * 32 + 14]["id"], "brick_wall_01")
-        self.assertEqual(first["levels"][12][10 * 32 + 17]["id"], "concrete_00")
+        self.assertEqual(first["levels"][11][10 * 32 + 14]["id"], "metal_wall_00")
+        self.assertEqual(first["levels"][12][10 * 32 + 17], {})
         self.assertEqual(first["levels"][12][10 * 32 + 18], {})
 
     def test_legacy_regions_and_every_operation_can_target_logical_z(self):


### PR DESCRIPTION
## Summary

- add `boolean` and `enum` template parameter types
- add template-only conditional operations via `when`
- retain existing `tile_id` parameter behavior
- add semantic brick/metal cabin wall variants
- add optional roof generation through `include_roof`
- update the maintained cabin recipe, tests, and Phase 8 documentation

## Validation

- 165 Python tests passing
- generated small-cabin template map validates successfully
- Python compilation checks pass
- `git diff --check` passes

## Remaining Phase 8 work

- numeric and collection parameter types
- automatic rotation and facing-aware anchors
- nested templates
- complete 3D footprint validation and richer composition