### PR TITLE
feat(map-gen): add numeric and collection template parameters

### DIFF
--- a/Documentation/Game_design/Map_generation_plan.md
+++ b/Documentation/Game_design/Map_generation_plan.md
@@ -746,7 +746,7 @@ Generate a standalone map with one or more road edge connections and a continuou
 
 ## Phase 8 — Templates and compositional generation
 
-**Status: in progress; deterministic unrotated template expansion, anchors, and typed semantic variants complete**
+**Status: in progress; deterministic unrotated template expansion, anchors, and bounded numeric/collection variants complete**
 
 The first Phase 8 slice adds reusable template definitions without creating a second generation pipeline. Templates expand into ordinary root operations before the existing recipe validation and map generation stages.
 
@@ -758,12 +758,14 @@ The first Phase 8 slice adds reusable template definitions without creating a se
 * anchor-to-anchor placement against prior placements;
 * typed `tile_id`, `boolean`, and enum template parameters with required/default resolution and placement-level overrides;
 * conditional template operations for boolean inclusion and enum-selected semantic variants;
-* deterministic reusable cabin variants: brick-roofed and metal open-top;
+* bounded integer parameters for operation coordinates, dimensions, and counts;
+* constrained string-list parameters with conditional operation inclusion;
+* deterministic reusable cabin variants: brick-roofed 4×4, metal open-top 4×4, and a brick-roofed 5×3 footprint;
 * expansion into existing ordinary root operations before normal validation;
 
 ### Remaining Phase 8 work
 
-* numeric or collection parameter types;
+* structured object parameter types;
 * automatic rotation and facing-aware anchor composition;
 * nested templates;
 * complete three-dimensional footprint validation and richer compositional locations.
@@ -871,7 +873,7 @@ An agent can create a new playable, potentially multi-level map from a concise d
 
 # Recommended immediate next task
 
-**Phase 6 is complete.** Its runtime-compatible area foundation, room semantics, authored building constraints, multi-level footprint metadata, physical floor/wall/support generation, standable roof generation, authored staircase evidence, enclosed maintained building geometry, and manual player traversal verification are complete for the first narrow building slice. **Phase 7 is complete** with authored map-edge metadata, endpoint anchoring, route metadata, deterministic map-local route painting, and runtime walkability validation. Explicit map-to-map edge compatibility is intentionally deferred as an optional future follow-up. **Phase 8 is in progress**: unrotated template expansion, anchors, and typed semantic variants are complete; remaining work is automatic rotation/facing-aware composition, nested templates, numeric or collection parameter types, and richer 3D composition.
+**Phase 6 is complete.** Its runtime-compatible area foundation, room semantics, authored building constraints, multi-level footprint metadata, physical floor/wall/support generation, standable roof generation, authored staircase evidence, enclosed maintained building geometry, and manual player traversal verification are complete for the first narrow building slice. **Phase 7 is complete** with authored map-edge metadata, endpoint anchoring, route metadata, deterministic map-local route painting, and runtime walkability validation. Explicit map-to-map edge compatibility is intentionally deferred as an optional future follow-up. **Phase 8 is in progress**: unrotated template expansion, anchors, typed semantic variants, bounded integer parameters, and constrained string-list collections are complete; remaining work is automatic rotation/facing-aware composition, nested templates, structured object parameters, and richer 3D composition.
 
 Do not yet generate towns or generalized compositional locations. Preserve the established map-level `areas` plus per-tile area membership representation, keep room semantics independent from runtime areas, and treat overmap areas as the authority for settlement composition and multi-map roads. Explicit map-to-map edge compatibility remains deferred until it becomes useful.
 

--- a/Documentation/Modding/map_recipe_generator.md
+++ b/Documentation/Modding/map_recipe_generator.md
@@ -142,7 +142,9 @@ Templates are expanded before ordinary recipe validation and generation. A templ
       "parameters": {
         "floor_tile": {"type": "tile_id", "default": "concrete_00"},
         "wall_material": {"type": "enum", "values": ["brick", "metal"], "default": "brick"},
-        "include_roof": {"type": "boolean", "default": true}
+        "width": {"type": "integer", "minimum": 3, "maximum": 6, "default": 4},
+        "height": {"type": "integer", "minimum": 3, "maximum": 6, "default": 4},
+        "features": {"type": "string_list", "values": ["roof"], "default": ["roof"]}
       },
       "anchors": {
         "entrance": {"at": [0, 1], "z": 0, "facing": "west"},
@@ -150,7 +152,7 @@ Templates are expanded before ordinary recipe validation and generation. A templ
       },
       "levels": [
         {"dz": 0, "operations": [
-          {"type": "rectangle", "x": 0, "y": 0, "width": 4, "height": 4, "tile": {"id": "concrete_00"}}
+          {"type": "rectangle", "x": 0, "y": 0, "width": "$width", "height": "$height", "tile": {"id": "concrete_00"}}
         ]}
       ]
     }
@@ -161,7 +163,7 @@ Templates are expanded before ordinary recipe validation and generation. A templ
       "template": "small_cabin",
       "anchor_to": {"placement": 0, "anchor": "exit"},
       "at_anchor": "entrance",
-      "parameters": {"wall_material": "metal", "include_roof": false},
+      "parameters": {"wall_material": "metal", "features": []},
       "rotation": 0
     }
   ]
@@ -170,11 +172,11 @@ Templates are expanded before ordinary recipe validation and generation. A templ
 
 For anchor-to-anchor placement, the referenced placement must appear earlier in the `placements` array. The generator computes the new origin so the placed template's `at_anchor` has the same absolute `[x, y, z]` as the referenced anchor. To place separate structures side by side, author connection anchors on the exterior edge immediately beyond each footprint (for example, a 4×4 template can use west `[0, 1]` and east `[4, 1]` anchors); interior anchors intentionally produce overlapping geometry when coincident. Anchor `facing` is preserved as metadata for future rotation-aware composition; it does not yet rotate or enforce a facing relationship.
 
-Templates may declare typed `parameters`. `tile_id` values substitute exact `$parameter_name` strings before normal operation validation and may provide a string `default`; without a default they are required on every placement. `boolean` values may provide a boolean `default` and control a template operation with `"when": "$parameter_name"`. `enum` values require a non-empty, unique string `values` array and may provide a default from that array; they select semantic operation variants with `"when": {"parameter": "material", "equals": "metal"}`. Placements override declared values through `parameters`. Unknown overrides, missing required values, malformed declarations, invalid enum values, unresolved `$` references, and non-boolean direct `when` references are rejected. Substituted tile IDs then follow the same tile-database validation as literal tile IDs.
+Templates may declare typed `parameters`. `tile_id` values substitute exact `$parameter_name` strings before normal operation validation and may provide a string `default`; without a default they are required on every placement. `boolean` values may provide a boolean `default` and control a template operation with `"when": "$parameter_name"`. `enum` values require a non-empty, unique string `values` array and may provide a default from that array; they select semantic operation variants with `"when": {"parameter": "material", "equals": "metal"}`. `integer` values require inclusive integer `minimum` and `maximum` bounds and can substitute operation coordinates, dimensions, or counts. `string_list` values require an allowed non-empty, unique string `values` array; each resolved list is unique and may be empty, and `"when": {"parameter": "features", "contains": "roof"}` conditionally includes an operation. Placements override declared values through `parameters`. Unknown overrides, missing required values, malformed declarations, invalid enum/list values, out-of-range integers, unresolved `$` references, and invalid conditions are rejected. Substituted tile IDs then follow the same tile-database validation as literal tile IDs.
 
-The expansion supports existing `set`, rectangle, outline, line, pattern, scatter, furniture, area-rectangle, room-rectangle, and furniture-scatter operation shapes. It rejects nested operation `z` values, non-zero rotations, unknown templates or anchors, duplicate relative `dz` levels, forward anchor references, and placements outside the logical z range. Templates cannot yet be combined with the grouped root `levels` layout, nested templates, numeric or collection parameter types, or automatic rotation. The generated map contains only expanded ordinary recipe output; `templates` and `placements` are not serialized.
+The expansion supports existing `set`, rectangle, outline, line, pattern, scatter, furniture, area-rectangle, room-rectangle, and furniture-scatter operation shapes. It rejects nested operation `z` values, non-zero rotations, unknown templates or anchors, duplicate relative `dz` levels, forward anchor references, and placements outside the logical z range. Templates cannot yet be combined with the grouped root `levels` layout, nested templates, numeric collections, structured object parameters, or automatic rotation. The generated map contains only expanded ordinary recipe output; `templates` and `placements` are not serialized.
 
-`Tools/examples/map_recipe_small_cabin_template.json` is the maintained example. Its tests verify deterministic expansion, relative `dz` placement, anchor-to-anchor alignment, tile variants, boolean roof selection, and enum-selected wall material.
+`Tools/examples/map_recipe_small_cabin_template.json` is the maintained example. Its tests verify deterministic expansion, relative `dz` placement, anchor-to-anchor alignment, tile variants, collection-selected roof inclusion, and bounded integer footprint dimensions.
 ## Logical levels
 
 Map level-array index `10` is logical ground level `z: 0`. The conversion is:

--- a/Tools/examples/map_recipe_small_cabin_template.json
+++ b/Tools/examples/map_recipe_small_cabin_template.json
@@ -10,7 +10,9 @@
 				"floor_tile": {"type": "tile_id", "default": "concrete_00"},
 				"support_tile": {"type": "tile_id", "default": "dirt_light_00"},
 				"wall_material": {"type": "enum", "values": ["brick", "metal"], "default": "brick"},
-				"include_roof": {"type": "boolean", "default": true},
+				"width": {"type": "integer", "minimum": 3, "maximum": 6, "default": 4},
+				"height": {"type": "integer", "minimum": 3, "maximum": 6, "default": 4},
+				"features": {"type": "string_list", "values": ["roof"], "default": ["roof"]},
 				"roof_tile": {"type": "tile_id", "default": "concrete_00"}
 			},
 			"anchors": {
@@ -21,21 +23,21 @@
 				{
 					"dz": 0,
 					"operations": [
-						{"type": "rectangle", "x": 0, "y": 0, "width": 4, "height": 4, "tile": {"id": "$floor_tile"}},
-						{"type": "rectangle_outline", "x": 0, "y": 0, "width": 4, "height": 4, "tile": {"id": "$support_tile"}}
+						{"type": "rectangle", "x": 0, "y": 0, "width": "$width", "height": "$height", "tile": {"id": "$floor_tile"}},
+						{"type": "rectangle_outline", "x": 0, "y": 0, "width": "$width", "height": "$height", "tile": {"id": "$support_tile"}}
 					]
 				},
 				{
 					"dz": 1,
 					"operations": [
-						{"type": "rectangle_outline", "x": 0, "y": 0, "width": 4, "height": 4, "tile": {"id": "brick_wall_00"}, "when": {"parameter": "wall_material", "equals": "brick"}},
-						{"type": "rectangle_outline", "x": 0, "y": 0, "width": 4, "height": 4, "tile": {"id": "metal_wall_00"}, "when": {"parameter": "wall_material", "equals": "metal"}}
+						{"type": "rectangle_outline", "x": 0, "y": 0, "width": "$width", "height": "$height", "tile": {"id": "brick_wall_00"}, "when": {"parameter": "wall_material", "equals": "brick"}},
+						{"type": "rectangle_outline", "x": 0, "y": 0, "width": "$width", "height": "$height", "tile": {"id": "metal_wall_00"}, "when": {"parameter": "wall_material", "equals": "metal"}}
 					]
 				},
 				{
 					"dz": 2,
 					"operations": [
-						{"type": "rectangle", "x": 0, "y": 0, "width": 4, "height": 4, "tile": {"id": "$roof_tile"}, "when": "$include_roof"}
+						{"type": "rectangle", "x": 0, "y": 0, "width": "$width", "height": "$height", "tile": {"id": "$roof_tile"}, "when": {"parameter": "features", "contains": "roof"}}
 					]
 				}
 			]
@@ -51,7 +53,13 @@
 			"template": "small_cabin",
 			"anchor_to": {"placement": 0, "anchor": "exit"},
 			"at_anchor": "entrance",
-			"parameters": {"support_tile": "dirt_light_01", "wall_material": "metal", "include_roof": false},
+			"parameters": {"support_tile": "dirt_light_01", "wall_material": "metal", "features": []},
+			"rotation": 0
+		},
+		{
+			"template": "small_cabin",
+			"origin": {"at": [10, 16], "z": 0},
+			"parameters": {"width": 5, "height": 3},
 			"rotation": 0
 		}
 	]

--- a/Tools/map_generator.py
+++ b/Tools/map_generator.py
@@ -173,13 +173,20 @@ def _resolve_template_parameters(
             "tile_id": {"type", "default"},
             "boolean": {"type", "default"},
             "enum": {"type", "values", "default"},
+            "integer": {"type", "minimum", "maximum", "default"},
+            "string_list": {"type", "values", "default"},
         }
         if parameter_type not in allowed_fields or set(definition) - allowed_fields[parameter_type]:
             raise RecipeError(f"{parameter_context} has an unsupported parameter definition")
-        if parameter_type == "enum":
+        if parameter_type in {"enum", "string_list"}:
             values = definition.get("values")
             if not isinstance(values, list) or not values or any(not isinstance(value, str) or not value for value in values) or len(set(values)) != len(values):
                 raise RecipeError(f"{parameter_context}.values must be a non-empty array of unique strings")
+        if parameter_type == "integer":
+            minimum = definition.get("minimum")
+            maximum = definition.get("maximum")
+            if type(minimum) is not int or type(maximum) is not int or minimum > maximum:
+                raise RecipeError(f"{parameter_context} must define integer minimum and maximum bounds")
         value = overrides.get(parameter_id, definition.get("default"))
         if value is None and not require_values:
             continue
@@ -191,6 +198,17 @@ def _resolve_template_parameters(
             raise RecipeError(f"{parameter_context} requires a boolean value")
         if parameter_type == "enum" and value not in definition["values"]:
             raise RecipeError(f"{parameter_context} must be one of its declared enum values")
+        if parameter_type == "integer" and (
+            type(value) is not int
+            or not definition["minimum"] <= value <= definition["maximum"]
+        ):
+            raise RecipeError(f"{parameter_context} must be an integer within its declared bounds")
+        if parameter_type == "string_list" and (
+            not isinstance(value, list)
+            or any(not isinstance(entry, str) or entry not in definition["values"] for entry in value)
+            or len(set(value)) != len(value)
+        ):
+            raise RecipeError(f"{parameter_context} must be a unique list of declared string values")
         resolved[parameter_id] = value
 
     return resolved
@@ -223,12 +241,17 @@ def _include_template_operation(
         if type(value) is not bool:
             raise RecipeError(f"{context}.when must resolve to a boolean parameter")
         return value
-    if not isinstance(condition, dict) or set(condition) != {"parameter", "equals"}:
-        raise RecipeError(f"{context}.when must be '$boolean_parameter' or define parameter and equals")
+    if not isinstance(condition, dict) or set(condition) not in ({"parameter", "equals"}, {"parameter", "contains"}):
+        raise RecipeError(f"{context}.when must be '$boolean_parameter' or define parameter with equals or contains")
     parameter_id = condition["parameter"]
     if not isinstance(parameter_id, str) or parameter_id not in parameters:
         raise RecipeError(f"{context}.when references unknown template parameter '{parameter_id}'")
-    return parameters[parameter_id] == condition["equals"]
+    if "equals" in condition:
+        return parameters[parameter_id] == condition["equals"]
+    value = parameters[parameter_id]
+    if not isinstance(value, list) or not isinstance(condition["contains"], str):
+        raise RecipeError(f"{context}.when contains requires a string_list parameter and string value")
+    return condition["contains"] in value
 
 
 def _expand_templates(recipe: dict[str, Any]) -> dict[str, Any]:

--- a/Tools/tests/test_map_generator.py
+++ b/Tools/tests/test_map_generator.py
@@ -155,6 +155,60 @@ class MapGeneratorTests(unittest.TestCase):
         with self.assertRaisesRegex(RecipeError, "when must resolve to a boolean parameter"):
             generate_map(recipe, TILES_PATH)
 
+    def test_template_integer_and_string_list_parameters_drive_geometry_and_features(self):
+        recipe = valid_recipe()
+        recipe["templates"] = {
+            "sized_feature": {
+                "parameters": {
+                    "width": {"type": "integer", "minimum": 2, "maximum": 4, "default": 2},
+                    "features": {"type": "string_list", "values": ["top"], "default": ["top"]},
+                },
+                "levels": [
+                    {"dz": 0, "operations": [{"type": "rectangle", "x": 0, "y": 0, "width": "$width", "height": 1, "tile": {"id": "dirt_light_00"}}]},
+                    {"dz": 1, "operations": [{"type": "rectangle", "x": 0, "y": 0, "width": "$width", "height": 1, "tile": {"id": "concrete_00"}, "when": {"parameter": "features", "contains": "top"}}]},
+                ],
+            }
+        }
+        recipe["placements"] = [
+            {"template": "sized_feature", "origin": {"at": [10, 10], "z": 0}, "rotation": 0},
+            {"template": "sized_feature", "origin": {"at": [10, 12], "z": 0}, "parameters": {"width": 4, "features": []}, "rotation": 0},
+        ]
+
+        generated = generate_map(recipe, TILES_PATH)
+
+        self.assertEqual(generated["levels"][10][10 * 32 + 11], {"id": "dirt_light_00"})
+        self.assertEqual(generated["levels"][11][10 * 32 + 11], {"id": "concrete_00"})
+        self.assertEqual(generated["levels"][10][12 * 32 + 13], {"id": "dirt_light_00"})
+        self.assertEqual(generated["levels"][11][12 * 32 + 13], {})
+
+    def test_template_integer_and_string_list_parameters_reject_invalid_values(self):
+        recipe = valid_recipe()
+        recipe["templates"] = {
+            "sized_feature": {
+                "parameters": {
+                    "width": {"type": "integer", "minimum": 2, "maximum": 4, "default": 2},
+                    "features": {"type": "string_list", "values": ["top"], "default": ["top"]},
+                },
+                "levels": [{"dz": 0, "operations": [{"type": "set", "x": 0, "y": 0, "tile": {"id": "dirt_light_00"}}]}],
+            }
+        }
+        recipe["placements"] = [{"template": "sized_feature", "origin": {"at": [10, 10], "z": 0}, "parameters": {"width": 5}, "rotation": 0}]
+        with self.assertRaisesRegex(RecipeError, "integer within its declared bounds"):
+            generate_map(recipe, TILES_PATH)
+
+        recipe["placements"][0]["parameters"] = {"features": ["top", "top"]}
+        with self.assertRaisesRegex(RecipeError, "unique list of declared string values"):
+            generate_map(recipe, TILES_PATH)
+
+        recipe["placements"][0]["parameters"] = {"features": "top"}
+        with self.assertRaisesRegex(RecipeError, "unique list of declared string values"):
+            generate_map(recipe, TILES_PATH)
+
+        recipe["placements"][0]["parameters"] = {}
+        recipe["templates"]["sized_feature"]["levels"][0]["operations"][0]["when"] = {"parameter": "width", "contains": "top"}
+        with self.assertRaisesRegex(RecipeError, "contains requires a string_list parameter"):
+            generate_map(recipe, TILES_PATH)
+
     def test_template_parameters_reject_missing_unknown_and_unresolved_values(self):
         recipe = valid_recipe()
         recipe["templates"] = {
@@ -225,6 +279,10 @@ class MapGeneratorTests(unittest.TestCase):
         self.assertEqual(first["levels"][10][10 * 32 + 14]["id"], "dirt_light_01")
         self.assertEqual(first["levels"][11][10 * 32 + 14]["id"], "metal_wall_00")
         self.assertEqual(first["levels"][12][10 * 32 + 17], {})
+        self.assertEqual(first["levels"][10][16 * 32 + 10]["id"], "dirt_light_00")
+        self.assertEqual(first["levels"][11][16 * 32 + 14]["id"], "brick_wall_00")
+        self.assertEqual(first["levels"][12][18 * 32 + 14]["id"], "concrete_00")
+        self.assertEqual(first["levels"][12][18 * 32 + 15], {})
         self.assertEqual(first["levels"][12][10 * 32 + 18], {})
 
     def test_legacy_regions_and_every_operation_can_target_logical_z(self):


### PR DESCRIPTION
## Summary

- add bounded `integer` template parameters
- add constrained `string_list` template parameters
- support `when.contains` conditional template operations
- parameterize maintained cabin dimensions and roof feature selection
- add a validated 5×3 cabin variant alongside existing brick and metal variants
- update template parameter documentation and the Phase 8 roadmap

## Validation

- 167 Python tests passing
- generated small-cabin map validates with no errors
- Python compilation checks pass
- `git diff --check` passes

## Known limitation

Template anchors remain fixed local coordinates. Parameterized footprints should use literal placement origins until anchor derivation or structured anchor parameters are added.