### PR TITLE
feat(map-gen): add structured template object parameters

### DIFF
--- a/Documentation/Game_design/Map_generation_plan.md
+++ b/Documentation/Game_design/Map_generation_plan.md
@@ -746,7 +746,7 @@ Generate a standalone map with one or more road edge connections and a continuou
 
 ## Phase 8 — Templates and compositional generation
 
-**Status: in progress; deterministic rotation-aware template expansion, facing-compatible anchors, and bounded numeric/collection variants complete**
+**Status: in progress; deterministic rotation-aware template expansion, facing-compatible anchors, bounded numeric/collection variants, and structured parameter objects complete**
 
 The first Phase 8 slice adds reusable template definitions without creating a second generation pipeline. Templates expand into ordinary root operations before the existing recipe validation and map generation stages.
 
@@ -762,12 +762,12 @@ The first Phase 8 slice adds reusable template definitions without creating a se
 * constrained string-list parameters with conditional operation inclusion;
 * placement rotations of `0`, `90`, `180`, and `270` degrees, rotating local horizontal geometry, anchors, and anchor facings while preserving `dz`;
 * automatic anchor-to-anchor rotation selection from cardinal facings, with explicit rejection when either connected anchor lacks facing metadata;
+* structured object parameters with declared property schemas, per-property defaults/required values, placement overrides, and dotted references;
 * rotated 5×3 cabin coverage and automatically oriented brick/metal cabin connection coverage;
 * expansion into existing ordinary root operations before normal validation;
 
 ### Remaining Phase 8 work
 
-* structured object parameter types;
 * nested templates;
 * complete three-dimensional footprint validation and richer compositional locations.
 
@@ -874,7 +874,7 @@ An agent can create a new playable, potentially multi-level map from a concise d
 
 # Recommended immediate next task
 
-**Phase 6 is complete.** Its runtime-compatible area foundation, room semantics, authored building constraints, multi-level footprint metadata, physical floor/wall/support generation, standable roof generation, authored staircase evidence, enclosed maintained building geometry, and manual player traversal verification are complete for the first narrow building slice. **Phase 7 is complete** with authored map-edge metadata, endpoint anchoring, route metadata, deterministic map-local route painting, and runtime walkability validation. Explicit map-to-map edge compatibility is intentionally deferred as an optional future follow-up. **Phase 8 is in progress**: template expansion, anchors, typed semantic variants, bounded integer parameters, constrained string-list collections, explicit quarter-turn placement rotation, and automatic facing-compatible anchor rotation are complete; remaining work is nested templates, structured object parameters, and richer 3D composition.
+**Phase 6 is complete.** Its runtime-compatible area foundation, room semantics, authored building constraints, multi-level footprint metadata, physical floor/wall/support generation, standable roof generation, authored staircase evidence, enclosed maintained building geometry, and manual player traversal verification are complete for the first narrow building slice. **Phase 7 is complete** with authored map-edge metadata, endpoint anchoring, route metadata, deterministic map-local route painting, and runtime walkability validation. Explicit map-to-map edge compatibility is intentionally deferred as an optional future follow-up. **Phase 8 is in progress**: template expansion, anchors, typed semantic variants, bounded integer parameters, constrained string-list collections, structured object parameters, explicit quarter-turn placement rotation, and automatic facing-compatible anchor rotation are complete; remaining work is nested templates and richer 3D composition.
 
 Do not yet generate towns or generalized compositional locations. Preserve the established map-level `areas` plus per-tile area membership representation, keep room semantics independent from runtime areas, and treat overmap areas as the authority for settlement composition and multi-map roads. Explicit map-to-map edge compatibility remains deferred until it becomes useful.
 

--- a/Documentation/Modding/map_recipe_generator.md
+++ b/Documentation/Modding/map_recipe_generator.md
@@ -142,6 +142,14 @@ Templates are expanded before ordinary recipe validation and generation. A templ
       "parameters": {
         "floor_tile": {"type": "tile_id", "default": "concrete_00"},
         "wall_material": {"type": "enum", "values": ["brick", "metal"], "default": "brick"},
+        "style": {
+          "type": "object",
+          "properties": {
+            "support_tile": {"type": "tile_id", "default": "dirt_light_00"},
+            "wall_tile": {"type": "tile_id", "default": "brick_wall_00"},
+            "include_roof": {"type": "boolean", "default": true}
+          }
+        },
         "width": {"type": "integer", "minimum": 3, "maximum": 6, "default": 4},
         "height": {"type": "integer", "minimum": 3, "maximum": 6, "default": 4},
         "features": {"type": "string_list", "values": ["roof"], "default": ["roof"]}
@@ -163,7 +171,7 @@ Templates are expanded before ordinary recipe validation and generation. A templ
       "template": "small_cabin",
       "anchor_to": {"placement": 0, "anchor": "exit"},
       "at_anchor": "entrance",
-      "parameters": {"wall_material": "metal", "features": []},
+      "parameters": {"style": {"wall_tile": "metal_wall_00", "include_roof": false}},
       "rotation": 0
     }
   ]
@@ -172,11 +180,11 @@ Templates are expanded before ordinary recipe validation and generation. A templ
 
 For anchor-to-anchor placement, the referenced placement must appear earlier in the `placements` array. `rotation` accepts `0`, `90`, `180`, or `270` degrees clockwise around the template origin. It rotates all local horizontal operation coordinates, rectangular footprints, line endpoints, scatter regions, patterns, anchors, anchor `facing`, and explicit tile/furniture/pattern rotations; it never changes relative `dz`. Set `rotation` to `"auto"` only with `anchor_to` and `at_anchor` to derive the quarter-turn that makes the placed anchor face opposite the referenced anchor. Auto rotation requires both connected anchors to declare cardinal `facing` values; it resolves the placed `at_anchor` after rotation before aligning it to the prior anchor. To place separate structures side by side, author connection anchors on the exterior edge immediately beyond each footprint (for example, a 4×4 template can use west `[0, 1]` and east `[4, 1]` anchors); interior anchors intentionally produce overlapping geometry when coincident.
 
-Templates may declare typed `parameters`. `tile_id` values substitute exact `$parameter_name` strings before normal operation validation and may provide a string `default`; without a default they are required on every placement. `boolean` values may provide a boolean `default` and control a template operation with `"when": "$parameter_name"`. `enum` values require a non-empty, unique string `values` array and may provide a default from that array; they select semantic operation variants with `"when": {"parameter": "material", "equals": "metal"}`. `integer` values require inclusive integer `minimum` and `maximum` bounds and can substitute operation coordinates, dimensions, or counts. `string_list` values require an allowed non-empty, unique string `values` array; each resolved list is unique and may be empty, and `"when": {"parameter": "features", "contains": "roof"}` conditionally includes an operation. Placements override declared values through `parameters`. Unknown overrides, missing required values, malformed declarations, invalid enum/list values, out-of-range integers, unresolved `$` references, and invalid conditions are rejected. Substituted tile IDs then follow the same tile-database validation as literal tile IDs.
+Templates may declare typed `parameters`. `tile_id` values substitute exact `$parameter_name` strings before normal operation validation and may provide a string `default`; without a default they are required on every placement. `boolean` values may provide a boolean `default` and control a template operation with `"when": "$parameter_name"`. `enum` values require a non-empty, unique string `values` array and may provide a default from that array; they select semantic operation variants with `"when": {"parameter": "material", "equals": "metal"}`. `integer` values require inclusive integer `minimum` and `maximum` bounds and can substitute operation coordinates, dimensions, or counts. `string_list` values require an allowed non-empty, unique string `values` array; each resolved list is unique and may be empty, and `"when": {"parameter": "features", "contains": "roof"}` conditionally includes an operation. `object` values require a non-empty declared `properties` object; each property uses any supported parameter schema, resolves its own default or required value, and rejects unknown fields. Use an exact dotted reference such as `$style.wall_tile` or `$style.include_roof` to substitute a declared object field. Placements override declared values through `parameters`. Unknown overrides, missing required values, malformed declarations, invalid enum/list values, out-of-range integers, unresolved `$` references, and invalid conditions are rejected. Substituted tile IDs then follow the same tile-database validation as literal tile IDs.
 
-The expansion supports existing `set`, rectangle, outline, line, pattern, scatter, furniture, area-rectangle, room-rectangle, and furniture-scatter operation shapes. It rejects nested operation `z` values, unsupported rotations, automatic rotation without a connected facing anchor pair, unknown templates or anchors, duplicate relative `dz` levels, forward anchor references, and placements outside the logical z range. Templates cannot yet be combined with the grouped root `levels` layout, nested templates, numeric collections, or structured object parameters. The generated map contains only expanded ordinary recipe output; `templates` and `placements` are not serialized.
+The expansion supports existing `set`, rectangle, outline, line, pattern, scatter, furniture, area-rectangle, room-rectangle, and furniture-scatter operation shapes. It rejects nested operation `z` values, unsupported rotations, automatic rotation without a connected facing anchor pair, unknown templates or anchors, duplicate relative `dz` levels, forward anchor references, and placements outside the logical z range. Templates cannot yet be combined with the grouped root `levels` layout or nested templates. The generated map contains only expanded ordinary recipe output; `templates` and `placements` are not serialized.
 
-`Tools/examples/map_recipe_small_cabin_template.json` is the maintained example. Its tests verify deterministic expansion, relative `dz` placement, anchor-to-anchor alignment, automatic facing-compatible rotation, tile variants, collection-selected roof inclusion, bounded integer footprint dimensions, and a rotated 5×3 footprint.
+`Tools/examples/map_recipe_small_cabin_template.json` is the maintained example. Its tests verify deterministic expansion, relative `dz` placement, anchor-to-anchor alignment, automatic facing-compatible rotation, structured style-object overrides, bounded integer footprint dimensions, and a rotated 5×3 footprint.
 ## Logical levels
 
 Map level-array index `10` is logical ground level `z: 0`. The conversion is:

--- a/Tools/examples/map_recipe_small_cabin_template.json
+++ b/Tools/examples/map_recipe_small_cabin_template.json
@@ -8,12 +8,17 @@
 		"small_cabin": {
 			"parameters": {
 				"floor_tile": {"type": "tile_id", "default": "concrete_00"},
-				"support_tile": {"type": "tile_id", "default": "dirt_light_00"},
-				"wall_material": {"type": "enum", "values": ["brick", "metal"], "default": "brick"},
+				"style": {
+					"type": "object",
+					"properties": {
+						"support_tile": {"type": "tile_id", "default": "dirt_light_00"},
+						"wall_tile": {"type": "tile_id", "default": "brick_wall_00"},
+						"roof_tile": {"type": "tile_id", "default": "concrete_00"},
+						"include_roof": {"type": "boolean", "default": true}
+					}
+				},
 				"width": {"type": "integer", "minimum": 3, "maximum": 6, "default": 4},
-				"height": {"type": "integer", "minimum": 3, "maximum": 6, "default": 4},
-				"features": {"type": "string_list", "values": ["roof"], "default": ["roof"]},
-				"roof_tile": {"type": "tile_id", "default": "concrete_00"}
+				"height": {"type": "integer", "minimum": 3, "maximum": 6, "default": 4}
 			},
 			"anchors": {
 				"entrance": {"at": [0, 1], "z": 0, "facing": "west"},
@@ -24,20 +29,19 @@
 					"dz": 0,
 					"operations": [
 						{"type": "rectangle", "x": 0, "y": 0, "width": "$width", "height": "$height", "tile": {"id": "$floor_tile"}},
-						{"type": "rectangle_outline", "x": 0, "y": 0, "width": "$width", "height": "$height", "tile": {"id": "$support_tile"}}
+						{"type": "rectangle_outline", "x": 0, "y": 0, "width": "$width", "height": "$height", "tile": {"id": "$style.support_tile"}}
 					]
 				},
 				{
 					"dz": 1,
 					"operations": [
-						{"type": "rectangle_outline", "x": 0, "y": 0, "width": "$width", "height": "$height", "tile": {"id": "brick_wall_00"}, "when": {"parameter": "wall_material", "equals": "brick"}},
-						{"type": "rectangle_outline", "x": 0, "y": 0, "width": "$width", "height": "$height", "tile": {"id": "metal_wall_00"}, "when": {"parameter": "wall_material", "equals": "metal"}}
+						{"type": "rectangle_outline", "x": 0, "y": 0, "width": "$width", "height": "$height", "tile": {"id": "$style.wall_tile"}}
 					]
 				},
 				{
 					"dz": 2,
 					"operations": [
-						{"type": "rectangle", "x": 0, "y": 0, "width": "$width", "height": "$height", "tile": {"id": "$roof_tile"}, "when": {"parameter": "features", "contains": "roof"}}
+						{"type": "rectangle", "x": 0, "y": 0, "width": "$width", "height": "$height", "tile": {"id": "$style.roof_tile"}, "when": "$style.include_roof"}
 					]
 				}
 			]
@@ -53,7 +57,7 @@
 			"template": "small_cabin",
 			"anchor_to": {"placement": 0, "anchor": "exit"},
 			"at_anchor": "entrance",
-			"parameters": {"support_tile": "dirt_light_01", "wall_material": "metal", "features": []},
+			"parameters": {"style": {"support_tile": "dirt_light_01", "wall_tile": "metal_wall_00", "include_roof": false}},
 			"rotation": "auto"
 		},
 		{

--- a/Tools/map_generator.py
+++ b/Tools/map_generator.py
@@ -175,9 +175,21 @@ def _resolve_template_parameters(
             "enum": {"type", "values", "default"},
             "integer": {"type", "minimum", "maximum", "default"},
             "string_list": {"type", "values", "default"},
+            "object": {"type", "properties"},
         }
         if parameter_type not in allowed_fields or set(definition) - allowed_fields[parameter_type]:
             raise RecipeError(f"{parameter_context} has an unsupported parameter definition")
+        if parameter_type == "object":
+            properties = definition.get("properties")
+            if not isinstance(properties, dict) or not properties:
+                raise RecipeError(f"{parameter_context}.properties must be a non-empty object")
+            value = overrides.get(parameter_id, {})
+            if not isinstance(value, dict):
+                raise RecipeError(f"{parameter_context} requires an object value")
+            resolved[parameter_id] = _resolve_template_parameters(
+                properties, value, parameter_context, require_values=require_values
+            )
+            continue
         if parameter_type in {"enum", "string_list"}:
             values = definition.get("values")
             if not isinstance(values, list) or not values or any(not isinstance(value, str) or not value for value in values) or len(set(values)) != len(values):
@@ -216,10 +228,16 @@ def _resolve_template_parameters(
 
 def _substitute_template_parameters(value: Any, parameters: dict[str, Any], context: str) -> Any:
     if isinstance(value, str) and value.startswith("$"):
-        parameter_id = value[1:]
+        reference = value[1:].split(".")
+        parameter_id = reference.pop(0)
         if parameter_id not in parameters:
             raise RecipeError(f"{context} references unknown template parameter '{parameter_id}'")
-        return parameters[parameter_id]
+        resolved = parameters[parameter_id]
+        for property_id in reference:
+            if not isinstance(resolved, dict) or property_id not in resolved:
+                raise RecipeError(f"{context} references unknown object parameter field '{value[1:]}'")
+            resolved = resolved[property_id]
+        return resolved
     if isinstance(value, list):
         return [_substitute_template_parameters(entry, parameters, context) for entry in value]
     if isinstance(value, dict):

--- a/Tools/tests/test_map_generator.py
+++ b/Tools/tests/test_map_generator.py
@@ -287,6 +287,69 @@ class MapGeneratorTests(unittest.TestCase):
         with self.assertRaisesRegex(RecipeError, "contains requires a string_list parameter"):
             generate_map(recipe, TILES_PATH)
 
+    def test_template_object_parameter_resolves_declared_fields_and_placement_overrides(self):
+        recipe = valid_recipe()
+        recipe["templates"] = {
+            "styled_cell": {
+                "parameters": {
+                    "style": {
+                        "type": "object",
+                        "properties": {
+                            "ground": {"type": "tile_id", "default": "dirt_light_00"},
+                            "top": {"type": "tile_id", "default": "concrete_00"},
+                            "include_top": {"type": "boolean", "default": True},
+                        },
+                    },
+                },
+                "levels": [
+                    {"dz": 0, "operations": [{"type": "set", "x": 0, "y": 0, "tile": {"id": "$style.ground"}}]},
+                    {"dz": 1, "operations": [{"type": "set", "x": 0, "y": 0, "tile": {"id": "$style.top"}, "when": "$style.include_top"}]},
+                ],
+            }
+        }
+        recipe["placements"] = [
+            {"template": "styled_cell", "origin": {"at": [10, 10], "z": 0}, "rotation": 0},
+            {
+                "template": "styled_cell",
+                "origin": {"at": [11, 10], "z": 0},
+                "parameters": {"style": {"ground": "dirt_light_01", "include_top": False}},
+                "rotation": 0,
+            },
+        ]
+
+        generated = generate_map(recipe, TILES_PATH)
+
+        self.assertEqual(generated["levels"][10][10 * 32 + 10], {"id": "dirt_light_00"})
+        self.assertEqual(generated["levels"][11][10 * 32 + 10], {"id": "concrete_00"})
+        self.assertEqual(generated["levels"][10][10 * 32 + 11], {"id": "dirt_light_01"})
+        self.assertEqual(generated["levels"][11][10 * 32 + 11], {})
+
+    def test_template_object_parameters_reject_invalid_values_and_references(self):
+        recipe = valid_recipe()
+        recipe["templates"] = {
+            "styled_cell": {
+                "parameters": {
+                    "style": {
+                        "type": "object",
+                        "properties": {"ground": {"type": "tile_id"}},
+                    },
+                },
+                "levels": [{"dz": 0, "operations": [{"type": "set", "x": 0, "y": 0, "tile": {"id": "$style.ground"}}]}],
+            }
+        }
+        recipe["placements"] = [{"template": "styled_cell", "origin": {"at": [10, 10], "z": 0}, "parameters": {"style": {}}, "rotation": 0}]
+        with self.assertRaisesRegex(RecipeError, "requires a value"):
+            generate_map(recipe, TILES_PATH)
+
+        recipe["placements"][0]["parameters"] = {"style": {"ground": "dirt_light_00", "extra": "concrete_00"}}
+        with self.assertRaisesRegex(RecipeError, "unknown parameter 'extra'"):
+            generate_map(recipe, TILES_PATH)
+
+        recipe["placements"][0]["parameters"] = {"style": {"ground": "dirt_light_00"}}
+        recipe["templates"]["styled_cell"]["levels"][0]["operations"][0]["tile"]["id"] = "$style.missing"
+        with self.assertRaisesRegex(RecipeError, "unknown object parameter field 'style.missing'"):
+            generate_map(recipe, TILES_PATH)
+
     def test_template_parameters_reject_missing_unknown_and_unresolved_values(self):
         recipe = valid_recipe()
         recipe["templates"] = {


### PR DESCRIPTION
## Summary

- add typed `object` template parameters with declared property schemas
- resolve per-property defaults and partial placement overrides
- support exact dotted parameter references such as `$style.wall_tile`
- reject missing required fields, unknown object fields, and unknown dotted references
- migrate the maintained cabin style configuration to an object parameter
- update modding documentation and mark the Phase 8 roadmap item complete

## Validation

- 172 Python tests passing
- maintained cabin map validates with no errors
- all three generated cabin examples validate with no errors
- Python compilation checks pass
- `git diff --check` passes

## Remaining Phase 8 work

- nested templates
- complete three-dimensional footprint validation and richer compositional locations