### PR TITLE
feat(map-gen): validate 3d template footprints and locations

### DIFF
--- a/Documentation/Game_design/Map_generation_plan.md
+++ b/Documentation/Game_design/Map_generation_plan.md
@@ -746,7 +746,7 @@ Generate a standalone map with one or more road edge connections and a continuou
 
 ## Phase 8 — Templates and compositional generation
 
-**Status: in progress; deterministic nested and rotation-aware template expansion, facing-compatible anchors, bounded numeric/collection variants, and structured parameter objects complete**
+**Status: Phase 8 complete; deterministic nested and rotation-aware template expansion, validated 3D footprints, compositional locations, facing-compatible anchors, bounded numeric/collection variants, and structured parameter objects complete**
 
 The first Phase 8 slice adds reusable template definitions without creating a second generation pipeline. Templates expand into ordinary root operations before the existing recipe validation and map generation stages.
 
@@ -765,11 +765,13 @@ The first Phase 8 slice adds reusable template definitions without creating a se
 * recursive nested template placements with local origins, cumulative rotation and `dz`, forwarded parameter overrides, and cycle rejection;
 * structured object parameters with declared property schemas, per-property defaults/required values, placement overrides, and dotted references;
 * rotated 5×3 cabin coverage and automatically oriented brick/metal cabin connection coverage;
+* complete three-dimensional template-footprint validation before ordinary generation, with conservative operation coverage, map/logical-z bounds, and unconnected-conflict rejection;
+* named rectangular compositional locations with rotation-aware placement, matching-volume checks, and intentional aligned-volume overlap;
 * expansion into existing ordinary root operations before normal validation;
 
-### Remaining Phase 8 work
+### Phase 8 completion note
 
-* complete three-dimensional footprint validation and richer compositional locations.
+The next map-generation work should remain separate from generalized town or overmap composition until a concrete gameplay need requires it.
 
 Candidate templates include:
 
@@ -874,7 +876,7 @@ An agent can create a new playable, potentially multi-level map from a concise d
 
 # Recommended immediate next task
 
-**Phase 6 is complete.** Its runtime-compatible area foundation, room semantics, authored building constraints, multi-level footprint metadata, physical floor/wall/support generation, standable roof generation, authored staircase evidence, enclosed maintained building geometry, and manual player traversal verification are complete for the first narrow building slice. **Phase 7 is complete** with authored map-edge metadata, endpoint anchoring, route metadata, deterministic map-local route painting, and runtime walkability validation. Explicit map-to-map edge compatibility is intentionally deferred as an optional future follow-up. **Phase 8 is in progress**: template expansion, nested templates, anchors, typed semantic variants, bounded integer parameters, constrained string-list collections, structured object parameters, explicit quarter-turn placement rotation, and automatic facing-compatible anchor rotation are complete; remaining work is richer 3D composition.
+**Phase 6 is complete.** Its runtime-compatible area foundation, room semantics, authored building constraints, multi-level footprint metadata, physical floor/wall/support generation, standable roof generation, authored staircase evidence, enclosed maintained building geometry, and manual player traversal verification are complete for the first narrow building slice. **Phase 7 is complete** with authored map-edge metadata, endpoint anchoring, route metadata, deterministic map-local route painting, and runtime walkability validation. Explicit map-to-map edge compatibility is intentionally deferred as an optional future follow-up. **Phase 8 is complete**: template expansion, nested templates, anchors, typed semantic variants, bounded integer parameters, constrained string-list collections, structured object parameters, explicit quarter-turn placement rotation, automatic facing-compatible anchor rotation, complete three-dimensional footprint validation, and named compositional locations are complete. Do not begin generalized settlement composition until it serves a concrete gameplay need.
 
 Do not yet generate towns or generalized compositional locations. Preserve the established map-level `areas` plus per-tile area membership representation, keep room semantics independent from runtime areas, and treat overmap areas as the authority for settlement composition and multi-map roads. Explicit map-to-map edge compatibility remains deferred until it becomes useful.
 

--- a/Documentation/Modding/map_recipe_generator.md
+++ b/Documentation/Modding/map_recipe_generator.md
@@ -178,13 +178,34 @@ Templates are expanded before ordinary recipe validation and generation. A templ
 }
 ```
 
+Templates can also expose named rectangular `locations` for richer three-dimensional composition:
+
+```json
+"locations": {
+  "roof_pad": {"at": [0, 0], "z": 2, "width": 4, "height": 4}
+}
+```
+
+A root placement may align an equal-sized location on an earlier placement:
+
+```json
+{
+  "template": "roof_module",
+  "location_to": {"placement": 0, "location": "roof_pad"},
+  "at_location": "roof_pad",
+  "rotation": 0
+}
+```
+
+Locations resolve their local rectangle through placement rotation and `origin.z + location.z`. The placed and referenced rotated dimensions must match exactly. Location alignment intentionally permits overlap inside the referenced location volume; ordinary root placements still reject conflicting three-dimensional footprints. Anchor-connected placements likewise permit overlap with their explicitly referenced placement, preserving intentional coincident-anchor composition. Each placement footprint is conservatively derived from its resolved set, rectangle, outline, line, pattern, scatter, furniture, area, room, and nested operations. Out-of-bounds x/y/z cells and unconnected conflicts are rejected before ordinary generation.
+
 Nested templates are declared with a template-local `placements` array. A nested placement uses `{ "template", "origin", "rotation", "parameters" }`; its `origin.at` and `origin.z` are relative to the enclosing template origin, its rotation is added to the enclosing rotation, and its parameter values may reference enclosing parameters. The child template expands recursively into ordinary root operations. Nested placements intentionally use literal local origins in this slice: they cannot use `anchor_to`, `at_anchor`, or `rotation: "auto"`, and child anchors are not re-exported through the parent. Cycles, unknown child templates, malformed local origins, unsupported rotations, unresolved forwarded parameters, and logical-z overflow are rejected.
 
 For anchor-to-anchor placement, the referenced placement must appear earlier in the `placements` array. `rotation` accepts `0`, `90`, `180`, or `270` degrees clockwise around the template origin. It rotates all local horizontal operation coordinates, rectangular footprints, line endpoints, scatter regions, patterns, anchors, anchor `facing`, and explicit tile/furniture/pattern rotations; it never changes relative `dz`. Set `rotation` to `"auto"` only with `anchor_to` and `at_anchor` to derive the quarter-turn that makes the placed anchor face opposite the referenced anchor. Auto rotation requires both connected anchors to declare cardinal `facing` values; it resolves the placed `at_anchor` after rotation before aligning it to the prior anchor. To place separate structures side by side, author connection anchors on the exterior edge immediately beyond each footprint (for example, a 4×4 template can use west `[0, 1]` and east `[4, 1]` anchors); interior anchors intentionally produce overlapping geometry when coincident.
 
 Templates may declare typed `parameters`. `tile_id` values substitute exact `$parameter_name` strings before normal operation validation and may provide a string `default`; without a default they are required on every placement. `boolean` values may provide a boolean `default` and control a template operation with `"when": "$parameter_name"`. `enum` values require a non-empty, unique string `values` array and may provide a default from that array; they select semantic operation variants with `"when": {"parameter": "material", "equals": "metal"}`. `integer` values require inclusive integer `minimum` and `maximum` bounds and can substitute operation coordinates, dimensions, or counts. `string_list` values require an allowed non-empty, unique string `values` array; each resolved list is unique and may be empty, and `"when": {"parameter": "features", "contains": "roof"}` conditionally includes an operation. `object` values require a non-empty declared `properties` object; each property uses any supported parameter schema, resolves its own default or required value, and rejects unknown fields. Use an exact dotted reference such as `$style.wall_tile` or `$style.include_roof` to substitute a declared object field. Placements override declared values through `parameters`. Unknown overrides, missing required values, malformed declarations, invalid enum/list values, out-of-range integers, unresolved `$` references, and invalid conditions are rejected. Substituted tile IDs then follow the same tile-database validation as literal tile IDs.
 
-The expansion supports existing `set`, rectangle, outline, line, pattern, scatter, furniture, area-rectangle, room-rectangle, and furniture-scatter operation shapes. It rejects nested operation `z` values, unsupported rotations, automatic rotation without a connected facing anchor pair, invalid nested placements, template cycles, unknown templates or anchors, duplicate relative `dz` levels, forward root-anchor references, and placements outside the logical z range. Templates cannot yet be combined with the grouped root `levels` layout. The generated map contains only expanded ordinary recipe output; `templates` and `placements` are not serialized.
+The expansion supports existing `set`, rectangle, outline, line, pattern, scatter, furniture, area-rectangle, room-rectangle, and furniture-scatter operation shapes. It rejects nested operation `z` values, unsupported rotations, automatic rotation without a connected facing anchor pair, invalid nested placements, template cycles, malformed locations, incompatible location dimensions, unknown templates or anchors, duplicate relative `dz` levels, forward root-anchor/location references, out-of-bounds three-dimensional footprints, and unconnected conflicting footprints. Templates cannot yet be combined with the grouped root `levels` layout. The generated map contains only expanded ordinary recipe output; `templates`, `placements`, anchors, and locations are not serialized.
 
 `Tools/examples/map_recipe_small_cabin_template.json` is the maintained example. Its tests verify deterministic expansion, relative `dz` placement, nested roof-panel composition with forwarded style and dimension parameters, anchor-to-anchor alignment, automatic facing-compatible rotation, structured style-object overrides, bounded integer footprint dimensions, and a rotated 5×3 footprint.
 ## Logical levels

--- a/Tools/map_generator.py
+++ b/Tools/map_generator.py
@@ -431,6 +431,59 @@ def _append_expanded_template_operations(
         )
 
 
+def _rotate_template_location(location: dict[str, Any], rotation: int) -> dict[str, int | list[int]]:
+    rectangle = {"x": location["at"][0], "y": location["at"][1], "width": location["width"], "height": location["height"]}
+    _rotate_template_rectangle(rectangle, rotation)
+    return {"at": [rectangle["x"], rectangle["y"]], "z": location["z"], "width": rectangle["width"], "height": rectangle["height"]}
+
+
+def _template_operation_footprint(operation: dict[str, Any]) -> set[tuple[int, int, int]]:
+    operation_type = operation["type"]
+    z = operation["z"]
+    if operation_type in {"set", "furniture", "pattern"}:
+        x, y = (operation["at"] if operation_type == "pattern" else [operation["x"], operation["y"]])
+        return {(x, y, z)}
+    if operation_type in {"rectangle", "area_rectangle", "room_rectangle"}:
+        x, y, width, height = operation["x"], operation["y"], operation["width"], operation["height"]
+        return {(cell_x, cell_y, z) for cell_x in range(x, x + width) for cell_y in range(y, y + height)}
+    if operation_type == "rectangle_outline":
+        x, y, width, height = operation["x"], operation["y"], operation["width"], operation["height"]
+        return {
+            (cell_x, cell_y, z)
+            for cell_x in range(x, x + width)
+            for cell_y in range(y, y + height)
+            if cell_x in {x, x + width - 1} or cell_y in {y, y + height - 1}
+        }
+    if operation_type in {"scatter", "furniture_scatter"}:
+        region = operation["region"]
+        return {
+            (cell_x, cell_y, z)
+            for cell_x in range(region["x"], region["x"] + region["width"])
+            for cell_y in range(region["y"], region["y"] + region["height"])
+        }
+    if operation_type == "line":
+        start, end = operation["from"], operation["to"]
+        return {
+            (cell_x, cell_y, z)
+            for cell_x in range(min(start[0], end[0]), max(start[0], end[0]) + 1)
+            for cell_y in range(min(start[1], end[1]), max(start[1], end[1]) + 1)
+        }
+    return set()
+
+
+def _validate_template_footprint(
+    operations: list[dict[str, Any]], placement_index: int, occupied: dict[tuple[int, int, int], int], allowed_overlap: set[tuple[int, int, int]],
+) -> None:
+    cells = set().union(*(_template_operation_footprint(operation) for operation in operations)) if operations else set()
+    for x, y, z in sorted(cells):
+        if not (0 <= x < MAP_WIDTH and 0 <= y < MAP_HEIGHT):
+            raise RecipeError(f"placements[{placement_index}] 3D footprint extends outside the {MAP_WIDTH}x{MAP_HEIGHT} map at [{x}, {y}, {z}]")
+        if (x, y, z) in occupied and (x, y, z) not in allowed_overlap:
+            raise RecipeError(f"placements[{placement_index}] 3D footprint overlaps placement {occupied[(x, y, z)]} at [{x}, {y}, {z}]")
+    for cell in cells:
+        occupied.setdefault(cell, placement_index)
+
+
 def _expand_templates(recipe: dict[str, Any]) -> dict[str, Any]:
     templates = recipe.get("templates")
     placements = recipe.get("placements")
@@ -454,8 +507,8 @@ def _expand_templates(recipe: dict[str, Any]) -> dict[str, Any]:
         context = f"templates.{template_id}"
         if not isinstance(template_id, str) or DEFINITION_NAME_PATTERN.fullmatch(template_id) is None:
             raise RecipeError(f"{context} must use a valid template ID")
-        if not isinstance(template, dict) or set(template) - {"levels", "anchors", "parameters", "placements"} or "levels" not in template:
-            raise RecipeError(f"{context} must define levels and may define anchors, parameters, or nested placements")
+        if not isinstance(template, dict) or set(template) - {"levels", "anchors", "locations", "parameters", "placements"} or "levels" not in template:
+            raise RecipeError(f"{context} must define levels and may define anchors, locations, parameters, or nested placements")
         _resolve_template_parameters(template.get("parameters"), {}, context, require_values=False)
         levels = template["levels"]
         if not isinstance(levels, list) or not levels:
@@ -488,16 +541,32 @@ def _expand_templates(recipe: dict[str, Any]) -> dict[str, Any]:
                 raise RecipeError(f"{anchor_context}.z must be an integer between -10 and 10")
             if "facing" in anchor and anchor["facing"] not in CONNECTION_DIRECTIONS:
                 raise RecipeError(f"{anchor_context}.facing must be a cardinal direction")
+        locations = template.get("locations", {})
+        if not isinstance(locations, dict):
+            raise RecipeError(f"{context}.locations must be an object")
+        for location_id, location in locations.items():
+            location_context = f"{context}.locations.{location_id}"
+            if not isinstance(location_id, str) or DEFINITION_NAME_PATTERN.fullmatch(location_id) is None:
+                raise RecipeError(f"{location_context} must use a valid location ID")
+            if (not isinstance(location, dict) or set(location) != {"at", "z", "width", "height"}
+                    or not isinstance(location.get("at"), list) or len(location["at"]) != 2
+                    or any(type(value) is not int for value in location["at"])
+                    or type(location.get("z")) is not int or type(location.get("width")) is not int
+                    or type(location.get("height")) is not int or location["width"] <= 0 or location["height"] <= 0):
+                raise RecipeError(f"{location_context} must define at, z, positive width, and positive height")
 
     resolved_anchors: list[dict[str, dict[str, Any]]] = []
+    resolved_locations: list[dict[str, dict[str, Any]]] = []
+    occupied_footprint: dict[tuple[int, int, int], int] = {}
     for placement_index, placement in enumerate(placements):
         context = f"placements[{placement_index}]"
-        if not isinstance(placement, dict) or set(placement) - {"template", "origin", "anchor_to", "at_anchor", "rotation", "parameters"}:
+        if not isinstance(placement, dict) or set(placement) - {"template", "origin", "anchor_to", "at_anchor", "location_to", "at_location", "rotation", "parameters"}:
             raise RecipeError(f"{context} contains unknown placement fields")
         if "template" not in placement or "rotation" not in placement:
             raise RecipeError(f"{context} must define template and rotation")
-        if set(placement) & {"origin", "anchor_to", "at_anchor"} not in ({"origin"}, {"anchor_to", "at_anchor"}):
-            raise RecipeError(f"{context} must define either origin or anchor_to with at_anchor")
+        placement_locations = set(placement) & {"origin", "anchor_to", "at_anchor", "location_to", "at_location"}
+        if placement_locations not in ({"origin"}, {"anchor_to", "at_anchor"}, {"location_to", "at_location"}):
+            raise RecipeError(f"{context} must define origin, anchor_to with at_anchor, or location_to with at_location")
         template_id = placement["template"]
         if not isinstance(template_id, str) or template_id not in templates:
             raise RecipeError(f"{context}.template references unknown template '{template_id}'")
@@ -510,6 +579,7 @@ def _expand_templates(recipe: dict[str, Any]) -> dict[str, Any]:
             templates[template_id].get("parameters"), placement.get("parameters"), context
         )
         template_anchors = templates[template_id].get("anchors", {})
+        allowed_overlap: set[tuple[int, int, int]] = set()
         if "origin" in placement:
             if requested_rotation == "auto":
                 raise RecipeError(f"{context}.rotation 'auto' requires anchor_to and at_anchor")
@@ -526,7 +596,7 @@ def _expand_templates(recipe: dict[str, Any]) -> dict[str, Any]:
                 raise RecipeError(f"{context}.origin must define a two-integer at and integer z")
             origin_at = origin["at"]
             origin_z = origin["z"]
-        else:
+        elif "anchor_to" in placement:
             anchor_to = placement["anchor_to"]
             at_anchor = placement["at_anchor"]
             if not isinstance(anchor_to, dict) or set(anchor_to) != {"placement", "anchor"}:
@@ -538,6 +608,7 @@ def _expand_templates(recipe: dict[str, Any]) -> dict[str, Any]:
             if not isinstance(at_anchor, str) or at_anchor not in template_anchors:
                 raise RecipeError(f"{context}.at_anchor must reference an anchor on the placed template")
             target = resolved_anchors[anchor_to["placement"]][anchor_to["anchor"]]
+            allowed_overlap.update(cell for cell, owner in occupied_footprint.items() if owner == anchor_to["placement"])
             local = template_anchors[at_anchor]
             if requested_rotation == "auto":
                 if "facing" not in target or "facing" not in local:
@@ -548,8 +619,38 @@ def _expand_templates(recipe: dict[str, Any]) -> dict[str, Any]:
             rotated_at = _rotate_template_point(local["at"], rotation)
             origin_at = [target["at"][0] - rotated_at[0], target["at"][1] - rotated_at[1]]
             origin_z = target["z"] - local["z"]
+        else:
+            location_to = placement["location_to"]
+            at_location = placement["at_location"]
+            if not isinstance(location_to, dict) or set(location_to) != {"placement", "location"}:
+                raise RecipeError(f"{context}.location_to must define placement and location")
+            if type(location_to["placement"]) is not int or not 0 <= location_to["placement"] < placement_index:
+                raise RecipeError(f"{context}.location_to.placement must reference a prior placement")
+            if not isinstance(location_to["location"], str) or location_to["location"] not in resolved_locations[location_to["placement"]]:
+                raise RecipeError(f"{context}.location_to.location must reference a location on the prior placement")
+            template_locations = templates[template_id].get("locations", {})
+            if not isinstance(at_location, str) or at_location not in template_locations:
+                raise RecipeError(f"{context}.at_location must reference a location on the placed template")
+            if requested_rotation == "auto":
+                raise RecipeError(f"{context}.rotation 'auto' requires anchor_to and at_anchor")
+            rotation = requested_rotation
+            target_location = resolved_locations[location_to["placement"]][location_to["location"]]
+            local_location = _rotate_template_location(template_locations[at_location], rotation)
+            if (local_location["width"], local_location["height"]) != (target_location["width"], target_location["height"]):
+                raise RecipeError(f"{context}.at_location footprint must match the referenced location dimensions")
+            origin_at = [target_location["at"][0] - local_location["at"][0], target_location["at"][1] - local_location["at"][1]]
+            origin_z = target_location["z"] - local_location["z"]
+            allowed_overlap.update(
+                (x, y, target_location["z"])
+                for x in range(target_location["at"][0], target_location["at"][0] + target_location["width"])
+                for y in range(target_location["at"][1], target_location["at"][1] + target_location["height"])
+            )
+        operation_start = len(expanded_operations)
         _append_expanded_template_operations(
             templates, template_id, parameters, origin_at, origin_z, rotation, context, (), expanded_operations
+        )
+        _validate_template_footprint(
+            expanded_operations[operation_start:], placement_index, occupied_footprint, allowed_overlap
         )
         resolved_template_anchors: dict[str, dict[str, Any]] = {}
         for anchor_id, anchor in template_anchors.items():
@@ -565,6 +666,23 @@ def _expand_templates(recipe: dict[str, Any]) -> dict[str, Any]:
                 raise RecipeError(f"{context}.{anchor_id} resolves outside logical z bounds")
             resolved_template_anchors[anchor_id] = resolved_anchor
         resolved_anchors.append(resolved_template_anchors)
+        resolved_template_locations: dict[str, dict[str, Any]] = {}
+        for location_id, location in templates[template_id].get("locations", {}).items():
+            rotated_location = _rotate_template_location(location, rotation)
+            resolved_location = {
+                "at": [origin_at[0] + rotated_location["at"][0], origin_at[1] + rotated_location["at"][1]],
+                "z": origin_z + rotated_location["z"],
+                "width": rotated_location["width"],
+                "height": rotated_location["height"],
+            }
+            if (not (0 <= resolved_location["at"][0] < MAP_WIDTH and 0 <= resolved_location["at"][1] < MAP_HEIGHT)
+                    or resolved_location["at"][0] + resolved_location["width"] > MAP_WIDTH
+                    or resolved_location["at"][1] + resolved_location["height"] > MAP_HEIGHT):
+                raise RecipeError(f"{context}.{location_id} resolves outside map bounds")
+            if not MIN_LOGICAL_Z <= resolved_location["z"] <= MAX_LOGICAL_Z:
+                raise RecipeError(f"{context}.{location_id} resolves outside logical z bounds")
+            resolved_template_locations[location_id] = resolved_location
+        resolved_locations.append(resolved_template_locations)
     return expanded
 
 

--- a/Tools/tests/test_map_generator.py
+++ b/Tools/tests/test_map_generator.py
@@ -392,6 +392,76 @@ class MapGeneratorTests(unittest.TestCase):
         with self.assertRaisesRegex(RecipeError, "nested template cycle: a -> b -> a"):
             generate_map(recipe, TILES_PATH)
 
+    def test_template_3d_footprint_validation_rejects_conflicting_root_placements(self):
+        recipe = valid_recipe()
+        recipe["templates"] = {
+            "cell": {
+                "levels": [{"dz": 0, "operations": [{"type": "set", "x": 0, "y": 0, "tile": {"id": "dirt_light_00"}}]}],
+            }
+        }
+        recipe["placements"] = [
+            {"template": "cell", "origin": {"at": [10, 10], "z": 0}, "rotation": 0},
+            {"template": "cell", "origin": {"at": [10, 10], "z": 0}, "rotation": 0},
+        ]
+
+        with self.assertRaisesRegex(RecipeError, r"3D footprint overlaps placement 0 at \[10, 10, 0\]"):
+            generate_map(recipe, TILES_PATH)
+
+    def test_template_3d_footprint_allows_the_same_xy_at_different_z(self):
+        recipe = valid_recipe()
+        recipe["templates"] = {
+            "cell": {
+                "levels": [{"dz": 0, "operations": [{"type": "set", "x": 0, "y": 0, "tile": {"id": "dirt_light_00"}}]}],
+            }
+        }
+        recipe["placements"] = [
+            {"template": "cell", "origin": {"at": [10, 10], "z": 0}, "rotation": 0},
+            {"template": "cell", "origin": {"at": [10, 10], "z": 1}, "rotation": 0},
+        ]
+
+        generated = generate_map(recipe, TILES_PATH)
+
+        self.assertEqual(generated["levels"][10][10 * 32 + 10], {"id": "dirt_light_00"})
+        self.assertEqual(generated["levels"][11][10 * 32 + 10], {"id": "dirt_light_00"})
+
+    def test_template_locations_align_matching_3d_regions_and_allow_intentional_overlap(self):
+        recipe = valid_recipe()
+        recipe["templates"] = {
+            "pad": {
+                "locations": {"pad": {"at": [0, 0], "z": 0, "width": 2, "height": 1}},
+                "levels": [{"dz": 0, "operations": [{"type": "rectangle", "x": 0, "y": 0, "width": 2, "height": 1, "tile": {"id": "dirt_light_00"}}]}],
+            }
+        }
+        recipe["placements"] = [
+            {"template": "pad", "origin": {"at": [10, 10], "z": 0}, "rotation": 0},
+            {"template": "pad", "location_to": {"placement": 0, "location": "pad"}, "at_location": "pad", "rotation": 0},
+        ]
+
+        generated = generate_map(recipe, TILES_PATH)
+
+        self.assertEqual(generated["levels"][10][10 * 32 + 10], {"id": "dirt_light_00"})
+        self.assertEqual(generated["levels"][10][10 * 32 + 11], {"id": "dirt_light_00"})
+
+    def test_template_locations_reject_mismatched_footprints(self):
+        recipe = valid_recipe()
+        recipe["templates"] = {
+            "wide": {
+                "locations": {"pad": {"at": [0, 0], "z": 0, "width": 2, "height": 1}},
+                "levels": [{"dz": 0, "operations": []}],
+            },
+            "narrow": {
+                "locations": {"pad": {"at": [0, 0], "z": 0, "width": 1, "height": 1}},
+                "levels": [{"dz": 0, "operations": []}],
+            },
+        }
+        recipe["placements"] = [
+            {"template": "wide", "origin": {"at": [10, 10], "z": 0}, "rotation": 0},
+            {"template": "narrow", "location_to": {"placement": 0, "location": "pad"}, "at_location": "pad", "rotation": 0},
+        ]
+
+        with self.assertRaisesRegex(RecipeError, "footprint must match the referenced location dimensions"):
+            generate_map(recipe, TILES_PATH)
+
     def test_template_parameters_reject_missing_unknown_and_unresolved_values(self):
         recipe = valid_recipe()
         recipe["templates"] = {


### PR DESCRIPTION
## Summary

- validate expanded template footprints across x, y, and logical z
- reject unconnected root-placement conflicts and out-of-bounds footprint cells
- preserve intentional overlap for explicit anchor and location composition
- add named, rotation-aware rectangular template locations
- support location-to-location alignment against earlier placements
- require matching rotated location dimensions
- complete the remaining Phase 8 roadmap work
- update modding documentation and regression coverage

## Validation

- 178 Python tests passing
- Python compilation checks pass
- regenerated maintained cabin map validates with no errors
- `git diff --check` passes

## Note

Scatter and line footprint checks are deliberately conservative to prevent missed collisions.