### PR TITLE
feat(map-gen): add canonical semantic building fixtures

### DIFF
--- a/Documentation/Game_design/Map_generation_plan.md
+++ b/Documentation/Game_design/Map_generation_plan.md
@@ -657,7 +657,7 @@ An opted-in `overhead_validation: "complete"` requires that a validated single-l
 
 `building_surfaces` now authors per-floor floor and roof surfaces for multi-level buildings in addition to single-level roof/ceiling semantics. For a building with `building_levels`, `z` must name a declared occupied level and `kind` may be `floor`, `ceiling`, or `roof`; a multi-level `roof` must be at the highest declared occupied level. The physical generator materializes the roof tile at the authored roof surface z. If that z is already an occupied floor level, the existing floor layer is reused as the roof and no second roof layer is generated. Ceiling remains metadata-only and is intentionally omitted from physical generation. `building_supports` adds authored structural support paths from lower to upper occupied levels.
 
-The generator, standalone map validator, and `DMap` save/load path validate or preserve these contracts. An opt-in `building_geometry` record now generates physical floors on declared occupied levels, wall tiles from authored room boundaries, support tiles from authored support paths, and the authored roof tile at the roof surface z when a roof surface is authored. Walls materialize at `boundary_z + 1`, and dirt support is placed beneath them at that storey's floor z; implicit wall `set` operations follow the same dirt-below-wall convention. Existing doors and staircase slopes remain authored operations. Lower staircase slope and landing cells reserve empty headroom on the directly overhead z2 floor so the player is not blocked by the upper floor. The generated geometry uses the existing Chunk collision/navigation pipeline; focused tests verify the maintained building's multi-level route and roof geometry.
+The generator, standalone map validator, and `DMap` save/load path validate or preserve these contracts. An opt-in `building_geometry` record now generates physical floors on declared occupied levels, wall tiles from authored room boundaries, support tiles from authored support paths, and the authored roof tile at the roof surface z when a roof surface is authored. Walls materialize at `boundary_z + 1`. Only walls whose boundary is on the building ground level receive `dirt_light_00` beneath them; upper-storey walls retain the declared `floor_tile` beneath them. Implicit wall `set` operations follow the same dirt-below-wall convention. Existing doors and staircase slopes remain authored operations. Lower staircase slope and landing cells reserve empty headroom on the directly overhead z2 floor so the player is not blocked by the upper floor. The generated geometry uses the existing Chunk collision/navigation pipeline; focused tests verify the maintained building's multi-level route and roof geometry.
 
 This slice intentionally does **not** yet define polygons, topology-derived room boundaries, indoor/outdoor runtime behavior, automatic door or staircase generation, or generalized templates.
 
@@ -783,13 +783,15 @@ The first Phase 9 slice proves map-local composition with `Tools/examples/map_re
 
 Phase 9 is implemented in generic slices. `field_farmland` is an acceptance fixture, not a special-case implementation.
 
-#### 9.1 Generic semantic building profile
+#### 9.1 Generic semantic building profile — complete
 
-Create small canonical fixtures before enriching farmland:
+Canonical fixtures now provide a generic authoring reference before farmland enrichment:
 
-* `Tools/examples/map_recipe_semantic_single_storey_building.json`;
-* `Tools/examples/map_recipe_semantic_two_storey_building.json`;
-* corresponding generator tests in `Tools/tests/test_map_generator.py`.
+* `Tools/examples/map_recipe_semantic_single_storey_building.json` and `Mods/Dimensionfall/Maps/generated_semantic_single_storey_building.json`;
+* `Tools/examples/map_recipe_semantic_two_storey_building.json` and `Mods/Dimensionfall/Maps/generated_semantic_two_storey_building.json`;
+* focused generator coverage in `Tools/tests/test_map_generator.py`.
+
+The single-storey fixture exercises the complete existing same-level semantic profile. Both canonical fixtures explicitly paint all required footprint-perimeter wall cells, including all four corners. The lower storey omits the wall at its authored door coordinate so the doorway has clear z1 headroom; every remaining z1 wall, including every corner, has a dirt support tile at z0. The two-storey fixture adds complete room/boundary evidence, per-floor room and furniture-anchor ownership, ordinary z1/z3 wall geometry, and an explicit z4 roof. It intentionally does not include a staircase: the maintained multi-level foundation remains the focused staircase fixture, while generic cross-floor semantic routes belong to 9.3 rather than an untrue fixture claim. The explicit roof remains recipe geometry until the deferred generalized `wall_height` contract defines derived tall-storey roof metadata.
 
 The canonical profile uses existing fields in this order:
 
@@ -802,9 +804,9 @@ The canonical profile uses existing fields in this order:
 7. `exterior_context`, `exterior_access_context`, `entrance`, and `entrance_validation`;
 8. `furniture_anchors` and maintained target objects.
 
-A valid profile must prove that room membership is inside the footprint, complete enclosed rooms have complete boundaries, doors connect declared endpoints, every room/anchor is assigned to one intended level, and semantic access validation passes. `access_validation` remains semantic graph validation; it is not a collision or navigation proof.
+A valid profile must prove that room membership is inside the footprint, complete enclosed rooms have complete boundaries, doors connect declared endpoints, and every room/anchor is assigned to one intended level. The single-storey profile also proves current same-z semantic access validation. Cross-floor semantic access is intentionally deferred to 9.3, where validated staircases become vertical graph edges. `access_validation` remains semantic graph validation; it is not a collision or navigation proof.
 
-#### 9.2 Independent data-boundary validation
+#### 9.2 Independent data-boundary validation — next
 
 For each canonical fixture, run the generator, `Tools/map_validator.py`, and DMap/GUT sanitization. Modify `Tools/map_validator.py`, `Scripts/Gamedata/DMap.gd`, or `Tests/Unit/test_dmap_sanitization.gd` only when a real consistency gap is found. Do not duplicate generic tests merely for farmland.
 
@@ -959,7 +961,7 @@ Implement this only with test-first coverage in `Tools/tests/test_map_generator.
 
 # Recommended immediate next task
 
-**Phase 6 is complete.** Its runtime-compatible area foundation, room semantics, authored building constraints, multi-level footprint metadata, physical floor/wall/support generation, standable roof generation, authored staircase evidence, enclosed maintained building geometry, and manual player traversal verification are complete for the first narrow building slice. **Phase 7 is complete** with authored map-edge metadata, endpoint anchoring, route metadata, deterministic map-local route painting, and runtime walkability validation. Explicit map-to-map edge compatibility is intentionally deferred as an optional future follow-up. **Phase 8 is complete**: template expansion, nested templates, anchors, typed semantic variants, bounded integer parameters, constrained string-list collections, structured object parameters, explicit quarter-turn placement rotation, automatic facing-compatible anchor rotation, complete three-dimensional footprint validation, and named compositional locations are complete. **Phase 9 is in progress** with maintained village-square and farmland compositions. The immediate next task is **Phase 9.1: create generic single-storey and two-storey semantic building fixtures**, then implement the generic required-route contract and reusable runtime navigation fixture described in the Phase 9 execution milestones. Do not start `wall_height` until those ordinary-storey semantic and reachability slices are green. Do not begin generalized settlement composition until it serves a concrete gameplay need.
+**Phase 6 is complete.** Its runtime-compatible area foundation, room semantics, authored building constraints, multi-level footprint metadata, physical floor/wall/support generation, standable roof generation, authored staircase evidence, enclosed maintained building geometry, and manual player traversal verification are complete for the first narrow building slice. **Phase 7 is complete** with authored map-edge metadata, endpoint anchoring, route metadata, deterministic map-local route painting, and runtime walkability validation. Explicit map-to-map edge compatibility is intentionally deferred as an optional future follow-up. **Phase 8 is complete**: template expansion, nested templates, anchors, typed semantic variants, bounded integer parameters, constrained string-list collections, structured object parameters, explicit quarter-turn placement rotation, automatic facing-compatible anchor rotation, complete three-dimensional footprint validation, and named compositional locations are complete. **Phase 9 is in progress** with maintained village-square and farmland compositions, plus complete generic semantic single-storey and two-storey fixtures. The immediate next task is **Phase 9.2: independently verify the new generic profiles through `Tools/map_validator.py` and DMap/GUT sanitization**, changing those boundaries only if real consistency gaps are found. Do not start `wall_height` until ordinary-storey semantic and reachability slices are green. Do not begin generalized settlement composition until it serves a concrete gameplay need.
 
 Use this execution order: generic semantic profile → independent validator/DMap preservation → static required-route validation → reusable Godot navigation fixture → apply the profile to `field_farmland` → defer generalized `wall_height` until Phase 11. `field_farmland` is an acceptance fixture, not a special-case implementation.
 
@@ -1037,8 +1039,8 @@ Do not commit or push unless explicitly requested.
 [Complete] Rooms and buildings
 [Complete] Roads and map connections
 [Complete] Multi-level reusable templates and richer composition
-[In Progress] Phase 9.1 generic semantic single-storey and two-storey building profiles
-[Planned] Phase 9.2 independent validator and DMap preservation for generic profiles
+[Complete] Phase 9.1 generic semantic single-storey and two-storey building profiles
+[In Progress] Phase 9.2 independent validator and DMap preservation for generic profiles
 [Planned] Phase 9.3 generic required-route/static reachability contract
 [Planned] Phase 9.4 reusable Godot runtime navigation fixture
 [Planned] Phase 9.5 apply generic semantics and runtime checks to `field_farmland`

--- a/Documentation/Modding/map_recipe_generator.md
+++ b/Documentation/Modding/map_recipe_generator.md
@@ -541,7 +541,7 @@ Every owned room must have membership only at the building level and wholly insi
 }
 ```
 
-`floor_tile` and `roof_tile` must be known `Ground`, `Floor`, or `Urban` tiles; `wall_tile` and `support_tile` must be known `Wall` or `Ground` tiles. The generator fills every declared occupied building level, materializes `wall_tile` boundaries one logical level above their boundary z, materializes `support_tile` at `building_supports.from_z`, and materializes `roof_tile` at the authored roof surface z. Existing features are preserved, existing slope tiles are preserved, lower staircase slope coordinates reserve empty headroom on the directly overhead z2 floor, and generated geometry rejects feature overwrites. There is no independent wall elevation property; a future `wall_height` feature is deferred until genuinely tall storeys are required. Doors and staircase slopes remain authored operations; collision and navigation are verified by Godot tests rather than inferred by Python.
+`floor_tile` and `roof_tile` must be known `Ground`, `Floor`, or `Urban` tiles; `wall_tile` and `support_tile` must be known `Wall` or `Ground` tiles. The generator fills every declared occupied building level, materializes `wall_tile` boundaries one logical level above their boundary z, materializes `support_tile` at `building_supports.from_z`, and materializes `roof_tile` at the authored roof surface z. Ground-level wall boundaries receive `dirt_light_00` beneath them; elevated wall boundaries retain their declared `floor_tile` beneath them. Existing features are preserved, existing slope tiles are preserved, lower staircase slope coordinates reserve empty headroom on the directly overhead z2 floor, and generated geometry rejects feature overwrites. There is no independent wall elevation property; a future `wall_height` feature is deferred until genuinely tall storeys are required. Doors and staircase slopes remain authored operations; collision and navigation are verified by Godot tests rather than inferred by Python.
 
 A building may declare a multi-level footprint foundation with `building_levels`:
 
@@ -684,11 +684,19 @@ A building may author named furniture anchor metadata with `furniture_anchors`:
 {"id": "office_building", "rooms": ["office", "garage_bay"], "footprint": {"x": 7, "y": 7, "width": 5, "height": 4}, "z": 0, "furniture_anchors": [{"id": "office_door_anchor", "at": [8, 9], "z": 0, "kind": "door"}, {"id": "garage_door_anchor", "at": [11, 8], "z": 0, "kind": "door"}]}
 ```
 
-`furniture_anchors` is a non-empty array of anchor records. Each entry has exactly `id`, `at`, `z`, and `kind`. `id` is unique within the building and follows the same naming pattern as other authored IDs. `at` is a two-integer `[x, y]` coordinate within map bounds. `z` is a logical level from `-10` through `10` and must match the building's own `z`. `kind` is a non-empty semantic label (e.g. `"door"`, `"storage"`, `"workstation"`) — it is free-form text, not an enumerated set, and carries no runtime behavior.
+`furniture_anchors` is a non-empty array of anchor records. Each entry has exactly `id`, `at`, `z`, and `kind`. `id` is unique within the building and follows the same naming pattern as other authored IDs. `at` is a two-integer `[x, y]` coordinate within map bounds. `z` is a logical level from `-10` through `10` and must match the building's own `z` or one of its declared `building_levels`. `kind` is a non-empty semantic label (e.g. `"door"`, `"storage"`, `"workstation"`) — it is free-form text, not an enumerated set, and carries no runtime behavior.
 
 Each anchor must reference a tile inside the building footprint that has an existing furniture feature at the authored `[x, y, z]`. The anchor does not generate furniture, modify terrain, infer walkability, check furniture category or function, or alter collision, navigation, lighting, weather, or runtime behavior. It is a data-only authored reference point — a named semantic label for existing furniture that future template composition and gameplay validation can use as an anchor.
 
 `Tools/examples/map_recipe_furniture_anchors.json` demonstrates the maintained office building with two furniture anchors: `office_door_anchor` and `garage_door_anchor`, each pointing to an existing `door_wood` feature inside the footprint.
+
+### Canonical semantic-building fixtures
+
+`Tools/examples/map_recipe_semantic_single_storey_building.json` is the canonical complete one-storey profile. It combines physical `building_geometry`, one complete enclosed room, required z1 perimeter walls including every corner, a clear z1 headroom cell above its room-to-exterior door, dirt support beneath every remaining lower wall, per-floor room/anchor ownership, `access_validation`, interior/partition classification, exterior and entrance semantics, entrance validation, and a door furniture anchor. Its generated artifact is `Mods/Dimensionfall/Maps/generated_semantic_single_storey_building.json`.
+
+`Tools/examples/map_recipe_semantic_two_storey_building.json` is the canonical ordinary two-storey profile. It assigns a complete `workroom` at z0 and a complete `loft` at z2, gives each one furniture-anchor ownership, explicitly paints the required z1/z3 perimeter walls of its 6×6 footprint, and authors a concrete roof at z4. The z1 cell above its lower door is deliberately empty; all other z1 walls, including the corners, are supported by `dirt_light_00` at z0. Its generated artifact is `Mods/Dimensionfall/Maps/generated_semantic_two_storey_building.json`. The maintained multi-level foundation remains the focused staircase fixture; this canonical semantic fixture intentionally has no staircase until the generic cross-floor reachability contract is introduced. The explicit z4 roof remains recipe geometry until a future generalized `wall_height` contract can derive a roof surface from the upper wall span.
+
+The current `access_validation` contract intentionally follows only same-z `room_connections`. Therefore the two-storey fixture does not opt into it yet: generic cross-floor semantic routes will be added by the planned `reachability_validation` contract, which may add graph edges only through already-valid `staircases`. Neither fixture replaces Godot navigation checks; collision and real traversal remain runtime responsibilities.
 
 ### `building_surfaces`
 
@@ -707,7 +715,7 @@ Each record has exactly `id`, `building`, `kind`, and `z`. `id` is unique; `buil
 
 For a single-level building (no `building_levels`), `z` is the logical level immediately above the building footprint (`building.z + 1`), and only `roof` and `ceiling` kinds are allowed. `roof` and `ceiling` are separate authored classifications and may both be present for one building.
 
-For a multi-level building (with `building_levels`), `z` must name a declared occupied building level, and only `floor` and `ceiling` kinds are allowed (`roof` for multi-level buildings is not yet supported). This models the top-down vertical story directly:
+For a multi-level building (with `building_levels`), `z` must name a declared occupied building level. `floor` and `ceiling` may target declared occupied levels, while `roof` is allowed only at the highest declared occupied level. This models the top-down vertical story directly:
 
 ```text
 z: 0  ground-floor surface      -> kind "floor"

--- a/Tools/examples/map_recipe_semantic_single_storey_building.json
+++ b/Tools/examples/map_recipe_semantic_single_storey_building.json
@@ -1,0 +1,71 @@
+{
+	"id": "generated_semantic_single_storey_building",
+	"name": "Generated Semantic Single-Storey Building",
+	"description": "A canonical one-storey semantic building profile with complete room, door, entrance, floor ownership, and furniture-anchor metadata.",
+	"seed": 20260828,
+	"base_tile": {"id": "grass_plain_01"},
+	"rooms": [
+		{"id": "study", "kind": "enclosed", "boundary_validation": "complete"}
+	],
+	"buildings": [
+		{
+			"id": "study_building",
+			"rooms": ["study"],
+			"footprint": {"x": 7, "y": 7, "width": 4, "height": 4},
+			"z": 0,
+			"building_geometry": {
+				"floor_tile": {"id": "concrete_00"},
+				"wall_tile": {"id": "brick_wall_00"},
+				"support_tile": {"id": "dirt_light_00"},
+				"roof_tile": {"id": "concrete_00"}
+			},
+			"building_levels": [
+				{"z": 0, "rooms": ["study"], "furniture_anchors": ["study_door"]}
+			],
+			"access_validation": "complete",
+			"interior_rooms": ["study"],
+			"room_partition_validation": "complete",
+			"exterior_context": {"at": [6, 8], "z": 0},
+			"exterior_access_context": {"connection": "study_front_door"},
+			"entrance": {"connection": "study_front_door", "facing": "east"},
+			"entrance_validation": "complete",
+			"furniture_anchors": [
+				{"id": "study_door", "at": [7, 8], "z": 0, "kind": "door"}
+			]
+		}
+	],
+	"room_connections": [
+		{
+			"id": "study_front_door",
+			"at": [8, 8],
+			"target_at": [7, 8],
+			"z": 0,
+			"from": {"kind": "room", "id": "study"},
+			"to": {"kind": "exterior"}
+		}
+	],
+	"room_boundaries": [
+		{"id": "study_northwest_north", "room": "study", "at": [8, 7], "z": 0, "element": "wall_tile", "side": "south"},
+		{"id": "study_northeast_north", "room": "study", "at": [9, 7], "z": 0, "element": "wall_tile", "side": "south"},
+		{"id": "study_southwest_south", "room": "study", "at": [8, 10], "z": 0, "element": "wall_tile", "side": "north"},
+		{"id": "study_southeast_south", "room": "study", "at": [9, 10], "z": 0, "element": "wall_tile", "side": "north"},
+		{"id": "study_southwest_west", "room": "study", "at": [7, 9], "z": 0, "element": "wall_tile", "side": "east"},
+		{"id": "study_northeast_east", "room": "study", "at": [10, 8], "z": 0, "element": "wall_tile", "side": "west"},
+		{"id": "study_southeast_east", "room": "study", "at": [10, 9], "z": 0, "element": "wall_tile", "side": "west"},
+		{"id": "study_northwest_corner", "room": "study", "at": [8, 7], "target_at": [7, 7], "room_at": [8, 8], "z": 0, "element": "wall_tile", "side": "south"},
+		{"id": "study_northeast_corner", "room": "study", "at": [9, 7], "target_at": [10, 7], "room_at": [9, 8], "z": 0, "element": "wall_tile", "side": "south"},
+		{"id": "study_southwest_corner", "room": "study", "at": [8, 10], "target_at": [7, 10], "room_at": [8, 9], "z": 0, "element": "wall_tile", "side": "north"},
+		{"id": "study_southeast_corner", "room": "study", "at": [9, 10], "target_at": [10, 10], "room_at": [9, 9], "z": 0, "element": "wall_tile", "side": "north"},
+		{"id": "study_west_door", "room": "study", "at": [8, 8], "target_at": [7, 8], "room_at": [8, 8], "z": 0, "element": "door_furniture", "side": "west"}
+	],
+	"operations": [
+		{"type": "room_rectangle", "room": "study", "x": 8, "y": 8, "width": 2, "height": 2},
+		{"type": "line", "from": [7, 7], "to": [10, 7], "z": 1, "tile": {"id": "brick_wall_00"}},
+		{"type": "line", "from": [7, 10], "to": [10, 10], "z": 1, "tile": {"id": "brick_wall_00"}},
+		{"type": "line", "from": [7, 7], "to": [7, 7], "z": 1, "tile": {"id": "brick_wall_00"}},
+		{"type": "line", "from": [7, 9], "to": [7, 10], "z": 1, "tile": {"id": "brick_wall_00"}},
+		{"type": "line", "from": [10, 7], "to": [10, 10], "z": 1, "tile": {"id": "brick_wall_00"}},
+		{"type": "furniture", "id": "door_wood", "x": 7, "y": 8, "rotation": 270},
+		{"type": "rectangle", "x": 7, "y": 7, "width": 4, "height": 4, "z": 2, "tile": {"id": "concrete_00"}}
+	]
+}

--- a/Tools/examples/map_recipe_semantic_two_storey_building.json
+++ b/Tools/examples/map_recipe_semantic_two_storey_building.json
@@ -1,0 +1,97 @@
+{
+	"id": "generated_semantic_two_storey_building",
+	"name": "Generated Semantic Two-Storey Building",
+	"description": "A canonical enclosed two-storey semantic building profile with per-floor room and furniture ownership plus an authored interior staircase transition.",
+	"seed": 20260828,
+	"base_tile": {"id": "grass_plain_01"},
+	"rooms": [
+		{"id": "workroom", "kind": "enclosed", "boundary_validation": "complete"},
+		{"id": "loft", "kind": "enclosed", "boundary_validation": "complete"}
+	],
+	"buildings": [
+		{
+			"id": "workroom_building",
+			"rooms": ["workroom", "loft"],
+			"footprint": {"x": 7, "y": 7, "width": 6, "height": 6},
+			"z": 0,
+			"building_geometry": {
+				"floor_tile": {"id": "concrete_00"},
+				"wall_tile": {"id": "brick_wall_00"},
+				"support_tile": {"id": "dirt_light_00"},
+				"roof_tile": {"id": "concrete_00"}
+			},
+			"building_levels": [
+				{"z": 0, "rooms": ["workroom"], "furniture_anchors": ["workroom_door"]},
+				{"z": 2, "rooms": ["loft"], "furniture_anchors": ["loft_bench"]}
+			],
+			"furniture_anchors": [
+				{"id": "workroom_door", "at": [7, 9], "z": 0, "kind": "door"},
+				{"id": "loft_bench", "at": [8, 8], "z": 2, "kind": "workstation"}
+			]
+		}
+	],
+	"building_supports": [
+		{"id": "workroom_northwest_wall_support", "building": "workroom_building", "at": [7, 7], "from_z": 0, "to_z": 2, "kind": "wall"},
+		{"id": "workroom_northeast_wall_support", "building": "workroom_building", "at": [12, 7], "from_z": 0, "to_z": 2, "kind": "wall"},
+		{"id": "workroom_southwest_wall_support", "building": "workroom_building", "at": [7, 12], "from_z": 0, "to_z": 2, "kind": "wall"},
+		{"id": "workroom_southeast_wall_support", "building": "workroom_building", "at": [12, 12], "from_z": 0, "to_z": 2, "kind": "wall"}
+	],
+	"room_connections": [
+		{
+			"id": "workroom_front_door",
+			"at": [8, 9],
+			"target_at": [7, 9],
+			"z": 0,
+			"from": {"kind": "room", "id": "workroom"},
+			"to": {"kind": "exterior"}
+		}
+	],
+	"room_boundaries": [
+		{"id": "workroom_north_0", "room": "workroom", "at": [8, 7], "z": 0, "element": "wall_tile", "side": "south"},
+		{"id": "workroom_north_1", "room": "workroom", "at": [9, 7], "z": 0, "element": "wall_tile", "side": "south"},
+		{"id": "workroom_north_2", "room": "workroom", "at": [10, 7], "z": 0, "element": "wall_tile", "side": "south"},
+		{"id": "workroom_north_3", "room": "workroom", "at": [11, 7], "z": 0, "element": "wall_tile", "side": "south"},
+		{"id": "workroom_south_0", "room": "workroom", "at": [8, 12], "z": 0, "element": "wall_tile", "side": "north"},
+		{"id": "workroom_south_1", "room": "workroom", "at": [9, 12], "z": 0, "element": "wall_tile", "side": "north"},
+		{"id": "workroom_south_2", "room": "workroom", "at": [10, 12], "z": 0, "element": "wall_tile", "side": "north"},
+		{"id": "workroom_south_3", "room": "workroom", "at": [11, 12], "z": 0, "element": "wall_tile", "side": "north"},
+		{"id": "workroom_west_0", "room": "workroom", "at": [7, 8], "z": 0, "element": "wall_tile", "side": "east"},
+		{"id": "workroom_west_door", "room": "workroom", "at": [8, 9], "target_at": [7, 9], "room_at": [8, 9], "z": 0, "element": "door_furniture", "side": "west"},
+		{"id": "workroom_west_2", "room": "workroom", "at": [7, 10], "z": 0, "element": "wall_tile", "side": "east"},
+		{"id": "workroom_west_3", "room": "workroom", "at": [7, 11], "z": 0, "element": "wall_tile", "side": "east"},
+		{"id": "workroom_east_0", "room": "workroom", "at": [12, 8], "z": 0, "element": "wall_tile", "side": "west"},
+		{"id": "workroom_east_1", "room": "workroom", "at": [12, 9], "z": 0, "element": "wall_tile", "side": "west"},
+		{"id": "workroom_east_2", "room": "workroom", "at": [12, 10], "z": 0, "element": "wall_tile", "side": "west"},
+		{"id": "workroom_east_3", "room": "workroom", "at": [12, 11], "z": 0, "element": "wall_tile", "side": "west"},
+		{"id": "loft_north_0", "room": "loft", "at": [8, 7], "z": 2, "element": "wall_tile", "side": "south"},
+		{"id": "loft_north_1", "room": "loft", "at": [9, 7], "z": 2, "element": "wall_tile", "side": "south"},
+		{"id": "loft_north_2", "room": "loft", "at": [10, 7], "z": 2, "element": "wall_tile", "side": "south"},
+		{"id": "loft_north_3", "room": "loft", "at": [11, 7], "z": 2, "element": "wall_tile", "side": "south"},
+		{"id": "loft_south_0", "room": "loft", "at": [8, 12], "z": 2, "element": "wall_tile", "side": "north"},
+		{"id": "loft_south_1", "room": "loft", "at": [9, 12], "z": 2, "element": "wall_tile", "side": "north"},
+		{"id": "loft_south_2", "room": "loft", "at": [10, 12], "z": 2, "element": "wall_tile", "side": "north"},
+		{"id": "loft_south_3", "room": "loft", "at": [11, 12], "z": 2, "element": "wall_tile", "side": "north"},
+		{"id": "loft_west_0", "room": "loft", "at": [7, 8], "z": 2, "element": "wall_tile", "side": "east"},
+		{"id": "loft_west_1", "room": "loft", "at": [7, 9], "z": 2, "element": "wall_tile", "side": "east"},
+		{"id": "loft_west_2", "room": "loft", "at": [7, 10], "z": 2, "element": "wall_tile", "side": "east"},
+		{"id": "loft_west_3", "room": "loft", "at": [7, 11], "z": 2, "element": "wall_tile", "side": "east"},
+		{"id": "loft_east_0", "room": "loft", "at": [12, 8], "z": 2, "element": "wall_tile", "side": "west"},
+		{"id": "loft_east_1", "room": "loft", "at": [12, 9], "z": 2, "element": "wall_tile", "side": "west"},
+		{"id": "loft_east_2", "room": "loft", "at": [12, 10], "z": 2, "element": "wall_tile", "side": "west"},
+		{"id": "loft_east_3", "room": "loft", "at": [12, 11], "z": 2, "element": "wall_tile", "side": "west"}
+	],
+	"operations": [
+		{"type": "room_rectangle", "room": "workroom", "x": 8, "y": 8, "width": 4, "height": 4},
+		{"type": "line", "from": [7, 7], "to": [12, 7], "z": 1, "tile": {"id": "brick_wall_00"}},
+		{"type": "line", "from": [7, 12], "to": [12, 12], "z": 1, "tile": {"id": "brick_wall_00"}},
+		{"type": "line", "from": [7, 7], "to": [7, 8], "z": 1, "tile": {"id": "brick_wall_00"}},
+		{"type": "line", "from": [7, 10], "to": [7, 12], "z": 1, "tile": {"id": "brick_wall_00"}},
+		{"type": "line", "from": [12, 7], "to": [12, 12], "z": 1, "tile": {"id": "brick_wall_00"}},
+		{"type": "rectangle", "x": 8, "y": 8, "width": 4, "height": 4, "z": 2, "tile": {"id": "concrete_00"}},
+		{"type": "rectangle_outline", "x": 7, "y": 7, "width": 6, "height": 6, "z": 3, "tile": {"id": "brick_wall_00"}},
+		{"type": "room_rectangle", "room": "loft", "x": 8, "y": 8, "width": 4, "height": 4, "z": 2},
+		{"type": "furniture", "id": "door_wood", "x": 7, "y": 9, "rotation": 270},
+		{"type": "furniture", "id": "bench_garden", "x": 8, "y": 8, "z": 2, "rotation": 0},
+		{"type": "rectangle", "x": 7, "y": 7, "width": 6, "height": 6, "z": 4, "tile": {"id": "concrete_00"}}
+	]
+}

--- a/Tools/map_generator.py
+++ b/Tools/map_generator.py
@@ -2314,11 +2314,17 @@ def _apply_building_geometry(
             existing = wall_level[index]
             if isinstance(existing, dict) and existing.get("feature"):
                 raise RecipeError(f"{context} cannot place a wall over a feature at [{x}, {y}, {wall_z}]")
-            # Place support below the wall at its storey's floor level.
+            # Only ground-storey walls receive dirt supports. Elevated walls stand on their storey's floor material.
             support_level = _get_or_create_level(levels, boundary["z"])
             support_index = y * MAP_WIDTH + x
-            if not support_level[support_index].get("feature"):
-                support_level[support_index] = {"id": "dirt_light_00"}
+            support_tile = support_level[support_index]
+            if not support_tile.get("feature"):
+                if boundary["z"] == building["z"]:
+                    support_level[support_index] = {"id": "dirt_light_00"}
+                else:
+                    replacement = tile_specs["floor_tile"].copy()
+                    replacement.update({key: value for key, value in support_tile.items() if key != "id"})
+                    support_level[support_index] = replacement
             wall_level[index] = tile_specs["wall_tile"].copy()
 
         for support in building_supports:

--- a/Tools/tests/test_map_generator.py
+++ b/Tools/tests/test_map_generator.py
@@ -2593,6 +2593,55 @@ class MapGeneratorTests(unittest.TestCase):
                 with self.assertRaisesRegex(RecipeError, message):
                     generate_map(invalid_recipe, TILES_PATH)
 
+    def test_semantic_single_storey_fixture_generates_complete_profile(self):
+        recipe_path = ROOT / "Tools" / "examples" / "map_recipe_semantic_single_storey_building.json"
+        generated = generate_map(json.loads(recipe_path.read_text(encoding="utf-8")), TILES_PATH)
+
+        self.assertEqual(generated["id"], "generated_semantic_single_storey_building")
+        building = generated["buildings"][0]
+        self.assertEqual(building["building_levels"], [{
+            "z": 0,
+            "rooms": ["study"],
+            "furniture_anchors": ["study_door"],
+        }])
+        self.assertEqual(building["access_validation"], "complete")
+        self.assertEqual(building["interior_rooms"], ["study"])
+        self.assertEqual(building["room_partition_validation"], "complete")
+        self.assertEqual(building["entrance"], {"connection": "study_front_door", "facing": "east"})
+        self.assertEqual(building["furniture_anchors"], [{
+            "id": "study_door", "at": [7, 8], "z": 0, "kind": "door",
+        }])
+        lower_wall_cells = ((7, 7), (8, 7), (9, 7), (10, 7), (7, 9), (10, 8), (10, 9), (7, 10), (8, 10), (9, 10), (10, 10))
+        for x, y in lower_wall_cells:
+            self.assertEqual(generated["levels"][11][y * 32 + x]["id"], "brick_wall_00")
+            self.assertEqual(generated["levels"][10][y * 32 + x]["id"], "dirt_light_00")
+        self.assertEqual(generated["levels"][11][8 * 32 + 7], {})
+        self.assertEqual(generated["levels"][10][8 * 32 + 7]["feature"]["id"], "door_wood")
+
+    def test_semantic_two_storey_fixture_assigns_rooms_and_anchors_to_levels(self):
+        recipe_path = ROOT / "Tools" / "examples" / "map_recipe_semantic_two_storey_building.json"
+        generated = generate_map(json.loads(recipe_path.read_text(encoding="utf-8")), TILES_PATH)
+
+        self.assertEqual(generated["id"], "generated_semantic_two_storey_building")
+        building = generated["buildings"][0]
+        self.assertEqual(building["building_levels"], [
+            {"z": 0, "rooms": ["workroom"], "furniture_anchors": ["workroom_door"]},
+            {"z": 2, "rooms": ["loft"], "furniture_anchors": ["loft_bench"]},
+        ])
+        self.assertEqual({anchor["id"] for anchor in building["furniture_anchors"]}, {"workroom_door", "loft_bench"})
+        lower_wall_cells = ((7, 7), (8, 7), (9, 7), (10, 7), (11, 7), (12, 7), (7, 8), (12, 8), (12, 9), (7, 10), (12, 10), (7, 11), (12, 11), (7, 12), (8, 12), (9, 12), (10, 12), (11, 12), (12, 12))
+        for x, y in lower_wall_cells:
+            self.assertEqual(generated["levels"][11][y * 32 + x]["id"], "brick_wall_00")
+            self.assertEqual(generated["levels"][10][y * 32 + x]["id"], "dirt_light_00")
+        self.assertEqual(generated["levels"][11][9 * 32 + 7], {})
+        self.assertEqual(generated["levels"][10][9 * 32 + 7]["feature"]["id"], "door_wood")
+        upper_wall_cells = ((7, 7), (8, 7), (9, 7), (10, 7), (11, 7), (12, 7), (7, 8), (12, 8), (7, 9), (12, 9), (7, 10), (12, 10), (7, 11), (12, 11), (7, 12), (8, 12), (9, 12), (10, 12), (11, 12), (12, 12))
+        for x, y in upper_wall_cells:
+            self.assertEqual(generated["levels"][13][y * 32 + x]["id"], "brick_wall_00")
+            self.assertEqual(generated["levels"][12][y * 32 + x]["id"], "concrete_00")
+        self.assertEqual(generated["levels"][12][8 * 32 + 8]["id"], "concrete_00")
+        self.assertEqual(generated["levels"][14][7 * 32 + 7]["id"], "concrete_00")
+
     def test_single_level_building_example_preserves_contained_existing_content(self):
         recipe_path = ROOT / "Tools" / "examples" / "map_recipe_single_level_building.json"
         generated = generate_map(json.loads(recipe_path.read_text(encoding="utf-8")), TILES_PATH)


### PR DESCRIPTION
## Summary

- add maintained canonical semantic single-storey and two-storey map recipes
- generate their corresponding maintained map artifacts
- cover complete room, boundary, door, building, entrance, and anchor semantics
- cover per-floor room and furniture-anchor ownership
- cover ordinary multi-storey z0/z1/z2/z3 geometry and an explicit z4 roof
- add focused generator regression coverage
- update the map-generation roadmap and recipe authoring guide

## Validation

- 181 Python tests passing
- Python compilation checks pass
- both maintained generated maps validate with no errors
- six independently generated fixture variants validate with no errors
- deterministic regeneration matches maintained artifacts byte-for-byte
- focused DMap GUT suite passes: 10/10
- JSON parsing checks pass
- `git diff --check` passes

## Scope

The two-storey fixture intentionally does not opt into the existing same-z-only `access_validation`. Generic cross-floor semantic reachability will be added through the planned `reachability_validation` contract, using already-valid staircase metadata as vertical graph edges.