### PR TITLE
feat: add generic reachability_validation contract for buildings

### DIFF
--- a/Documentation/Game_design/Map_generation_plan.md
+++ b/Documentation/Game_design/Map_generation_plan.md
@@ -812,9 +812,9 @@ Both canonical recipes generate deterministically and validate with `Tools/map_v
 
 This exposed and fixed one real compatibility gap: Godot JSON parsing represents numeric literals as floats, while DMap semantic sanitizers require integers for coordinates, z levels, and rotations. `Scripts/Helper/json_helper.gd` now recursively normalizes whole-number JSON floats to integers before returning parsed dictionaries or arrays; non-integral floats remain floats. Do not duplicate this generic boundary coverage for farmland.
 
-#### 9.3 Generic required-route contract
+#### 9.3 Generic required-route contract — complete
 
-Add an optional building-level `reachability_validation` record:
+Buildings may declare an optional `reachability_validation` record:
 
 ```json
 {
@@ -824,9 +824,7 @@ Add an optional building-level `reachability_validation` record:
 }
 ```
 
-It may name only existing entrances, furniture anchors, and declared occupied levels. It must not store coordinates, tile IDs, or precomputed paths. Static validation must reject unknown targets, undeclared levels, unreachable semantic rooms, and missing vertical graph links. Vertical graph edges may be derived only from already-valid authored staircases. Python must not simulate runtime collision or navigation.
-
-Implement this contract independently in `Tools/map_generator.py`, `Tools/map_validator.py`, and `Scripts/Gamedata/DMap.gd`, with focused negative and positive tests in `Tools/tests/test_map_generator.py` and only necessary GUT preservation coverage.
+It names only existing entrances, furniture anchors, and declared occupied levels. It stores no coordinates, tile IDs, or precomputed paths. Static validation rejects unknown targets, undeclared levels, unreachable semantic rooms, and missing vertical graph links. Vertical graph edges derive only from already-valid authored staircases; the link is floor-granular because staircase slopes occupy the intentional open gap with no room membership. The contract is implemented independently in `Tools/map_generator.py`, `Tools/map_validator.py`, and `Scripts/Gamedata/DMap.gd`, with focused negative and positive tests in `Tools/tests/test_map_generator.py` and DMap preservation coverage in `Tests/Unit/test_dmap_sanitization.gd`. Python does not simulate runtime collision or navigation; runtime proof remains Phase 9.4. The maintained multi-level foundation demonstrates the full cross-storey record, and the canonical single-storey fixture opts in with ground-floor requirements; the canonical two-storey fixture also opts in with ground-floor requirements only until a validated staircase is authored into it.
 
 #### 9.4 Reusable runtime navigation fixture
 
@@ -963,7 +961,7 @@ Implement this only with test-first coverage in `Tools/tests/test_map_generator.
 
 # Recommended immediate next task
 
-**Phase 6 is complete.** Its runtime-compatible area foundation, room semantics, authored building constraints, multi-level footprint metadata, physical floor/wall/support generation, standable roof generation, authored staircase evidence, enclosed maintained building geometry, and manual player traversal verification are complete for the first narrow building slice. **Phase 7 is complete** with authored map-edge metadata, endpoint anchoring, route metadata, deterministic map-local route painting, and runtime walkability validation. Explicit map-to-map edge compatibility is intentionally deferred as an optional future follow-up. **Phase 8 is complete**: template expansion, nested templates, anchors, typed semantic variants, bounded integer parameters, constrained string-list collections, structured object parameters, explicit quarter-turn placement rotation, automatic facing-compatible anchor rotation, complete three-dimensional footprint validation, and named compositional locations are complete. **Phase 9 is in progress** with maintained village-square and farmland compositions, plus complete generic semantic single-storey and two-storey fixtures and independent data-boundary validation. The immediate next task is **Phase 9.3: add the generic `reachability_validation` contract**, keeping its static checks limited to semantic rooms, declared entrances/anchors/levels, and already-valid staircases. Do not start `wall_height` until ordinary-storey semantic and reachability slices are green. Do not begin generalized settlement composition until it serves a concrete gameplay need.
+**Phase 6 is complete.** Its runtime-compatible area foundation, room semantics, authored building constraints, multi-level footprint metadata, physical floor/wall/support generation, standable roof generation, authored staircase evidence, enclosed maintained building geometry, and manual player traversal verification are complete for the first narrow building slice. **Phase 7 is complete** with authored map-edge metadata, endpoint anchoring, route metadata, deterministic map-local route painting, and runtime walkability validation. Explicit map-to-map edge compatibility is intentionally deferred as an optional future follow-up. **Phase 8 is complete**: template expansion, nested templates, anchors, typed semantic variants, bounded integer parameters, constrained string-list collections, structured object parameters, explicit quarter-turn placement rotation, automatic facing-compatible anchor rotation, complete three-dimensional footprint validation, and named compositional locations are complete. **Phase 9 is in progress** with maintained village-square and farmland compositions, plus complete generic semantic single-storey and two-storey fixtures, independent data-boundary validation, and the generic `reachability_validation` contract. The immediate next task is **Phase 9.4: extract the reusable Godot runtime navigation fixture** and prove it with the semantic single-storey and two-storey navigation tests plus the existing road and multi-level navigation tests. Do not start `wall_height` until ordinary-storey semantic and reachability slices are green. Do not begin generalized settlement composition until it serves a concrete gameplay need.
 
 Use this execution order: generic semantic profile → independent validator/DMap preservation → static required-route validation → reusable Godot navigation fixture → apply the profile to `field_farmland` → defer generalized `wall_height` until Phase 11. `field_farmland` is an acceptance fixture, not a special-case implementation.
 
@@ -1043,8 +1041,8 @@ Do not commit or push unless explicitly requested.
 [Complete] Multi-level reusable templates and richer composition
 [Complete] Phase 9.1 generic semantic single-storey and two-storey building profiles
 [Complete] Phase 9.2 independent validator and DMap preservation for generic profiles
-[In Progress] Phase 9.3 generic required-route/static reachability contract
-[Planned] Phase 9.4 reusable Godot runtime navigation fixture
+[Complete] Phase 9.3 generic required-route/static reachability contract
+[In Progress] Phase 9.4 reusable Godot runtime navigation fixture
 [Planned] Phase 9.5 apply generic semantics and runtime checks to `field_farmland`
 [Planned] Phase 10 static authored quality and gameplay validation
 [Deferred] Phase 11 generalized tall-storey `wall_height`

--- a/Documentation/Modding/map_recipe_generator.md
+++ b/Documentation/Modding/map_recipe_generator.md
@@ -676,7 +676,7 @@ For an opted-in building, `entrance_validation` requires `entrance` or `entrance
 
 This validates authored orientation and alignment only: it does not generate or modify geometry, infer a walkable path, check collision or navigation, require the context tile and door to be cardinally adjacent, or alter runtime behavior.
 
-`DMap` preserves building records through editor save/load and removes records whose room list, declared interior rooms, declared open-space rooms, malformed exterior context, stale exterior-access connection, stale entrance connection, malformed entrances array, stale entrance connection in the entrances array, malformed entrance validation, or malformed furniture anchors becomes stale. The standalone validator performs strict shape, containment, same-level overlap, complete-enclosed-room, opted-in access, and authored interior/open-space/partition/overhead/exterior-context/exterior-access-context/entrance/entrances/entrance-validation/furniture-anchors checks.
+`DMap` preserves building records through editor save/load and removes records whose room list, declared interior rooms, declared open-space rooms, malformed exterior context, stale exterior-access connection, stale entrance connection, malformed entrances array, stale entrance connection in the entrances array, malformed entrance validation, malformed furniture anchors, or malformed `reachability_validation` requirements becomes stale. The standalone validator performs strict shape, containment, same-level overlap, complete-enclosed-room, opted-in access, and authored interior/open-space/partition/overhead/exterior-context/exterior-access-context/entrance/entrances/entrance-validation/furniture-anchors checks.
 
 A building may author named furniture anchor metadata with `furniture_anchors`:
 
@@ -690,13 +690,39 @@ Each anchor must reference a tile inside the building footprint that has an exis
 
 `Tools/examples/map_recipe_furniture_anchors.json` demonstrates the maintained office building with two furniture anchors: `office_door_anchor` and `garage_door_anchor`, each pointing to an existing `door_wood` feature inside the footprint.
 
+### `reachability_validation`
+
+A building may opt in to static semantic reachability requirements with `reachability_validation`:
+
+```json
+{
+  "reachability_validation": {
+    "required_entrances": ["front_entrance", "garage_entrance"],
+    "required_furniture_anchors": ["office_door_anchor", "garage_door_anchor", "upper_bench_anchor"],
+    "required_building_levels": [0, 2]
+  }
+}
+```
+
+The record is optional, must be an object, and must define at least one of exactly three keys:
+
+- `required_entrances` names entries of the building's `entrances` array by their `id`. A singular `entrance` has no ID and cannot be referenced.
+- `required_furniture_anchors` names entries of the building's `furniture_anchors` by `id`.
+- `required_building_levels` names declared `building_levels` z values (or the building's own `z` when no `building_levels` are declared).
+
+Every requirement is a non-empty array without duplicate entries; entrance and anchor names are non-empty strings, and levels are integers. The record must not store coordinates, tile IDs, or precomputed paths — it names only existing entrances, anchors, and declared levels.
+
+Validation is a static breadth-first search over authored semantic facts, never a collision or navigation simulation. Graph nodes are `(room, level)` pairs; a room's level comes from its `building_levels` assignment, or the building `z` when levels are undeclared. Seed nodes are the rooms behind room-to-exterior connections whose connection `z` equals the room's level — restricted to the named entrances when `required_entrances` is declared, or all owned exterior connections otherwise. Same-level edges come from room-to-room `room_connections` where both rooms share the room's level and the connection `z` matches. Vertical edges are derived only from already-valid authored `staircases`: a validated staircase connects the declared `z: 0` and `z: 2` floor levels bidirectionally, and the connection is floor-granular because staircase slopes occupy the intentional open gap where no room membership exists. The search must reach the room behind every required entrance, the level of every required furniture anchor, and at least one room node on every required building level. Unknown targets, undeclared levels, and unreachable requirements are rejected; Python never simulates runtime collision or navigation — Godot runtime tests own that proof (Phase 9.4).
+
+The generator validates the record shape, echoes it into the building record, and rejects unreachable requirements while authoring. `Tools/map_validator.py` performs the same checks independently on generated maps. `DMap` preserves valid records through editor save/load and removes buildings whose record references stale entrances, anchors, or undeclared levels, or whose requirements are malformed. The maintained `map_recipe_multi_level_building_foundation.json` demonstrates the full record across both storeys through its authored staircase; the canonical two-storey semantic fixture opts in with ground-floor requirements only, because its loft route becomes provable only when a validated staircase is authored into that fixture.
+
 ### Canonical semantic-building fixtures
 
 `Tools/examples/map_recipe_semantic_single_storey_building.json` is the canonical complete one-storey profile. It combines physical `building_geometry`, one complete enclosed room, required z1 perimeter walls including every corner, a clear z1 headroom cell above its room-to-exterior door, dirt support beneath every remaining lower wall, per-floor room/anchor ownership, `access_validation`, interior/partition classification, exterior and entrance semantics, entrance validation, and a door furniture anchor. Its generated artifact is `Mods/Dimensionfall/Maps/generated_semantic_single_storey_building.json`.
 
-`Tools/examples/map_recipe_semantic_two_storey_building.json` is the canonical ordinary two-storey profile. It assigns a complete `workroom` at z0 and a complete `loft` at z2, gives each one furniture-anchor ownership, explicitly paints the required z1/z3 perimeter walls of its 6×6 footprint, and authors a concrete roof at z4. The z1 cell above its lower door is deliberately empty; all other z1 walls, including the corners, are supported by `dirt_light_00` at z0. Its generated artifact is `Mods/Dimensionfall/Maps/generated_semantic_two_storey_building.json`. The maintained multi-level foundation remains the focused staircase fixture; this canonical semantic fixture intentionally has no staircase until the generic cross-floor reachability contract is introduced. The explicit z4 roof remains recipe geometry until a future generalized `wall_height` contract can derive a roof surface from the upper wall span.
+`Tools/examples/map_recipe_semantic_two_storey_building.json` is the canonical ordinary two-storey profile. It assigns a complete `workroom` at z0 and a complete `loft` at z2, gives each one furniture-anchor ownership, explicitly paints the required z1/z3 perimeter walls of its 6×6 footprint, and authors a concrete roof at z4. The z1 cell above its lower door is deliberately empty; all other z1 walls, including the corners, are supported by `dirt_light_00` at z0. Its generated artifact is `Mods/Dimensionfall/Maps/generated_semantic_two_storey_building.json`. The maintained multi-level foundation remains the focused staircase fixture; this canonical semantic fixture intentionally has no staircase, so its `reachability_validation` opts in with ground-floor requirements only. The explicit z4 roof remains recipe geometry until a future generalized `wall_height` contract can derive a roof surface from the upper wall span.
 
-The current `access_validation` contract intentionally follows only same-z `room_connections`. Therefore the two-storey fixture does not opt into it yet: generic cross-floor semantic routes will be added by the planned `reachability_validation` contract, which may add graph edges only through already-valid `staircases`. Neither fixture replaces Godot navigation checks; collision and real traversal remain runtime responsibilities.
+The `access_validation` contract follows only same-z `room_connections`. The two-storey fixture therefore does not opt into it: generic cross-floor semantic routes are expressed by `reachability_validation`, which adds graph edges only through already-valid `staircases`. Neither contract replaces Godot navigation checks; collision and real traversal remain runtime responsibilities.
 
 ### `building_surfaces`
 

--- a/Scripts/Gamedata/DMap.gd
+++ b/Scripts/Gamedata/DMap.gd
@@ -559,6 +559,53 @@ func _sanitize_buildings(data: Dictionary) -> void:
 				if anchor["id"] in seen_anchor_ids:
 					return false
 				seen_anchor_ids.append(anchor["id"])
+		if building.has("reachability_validation"):
+			var reachability: Variant = building["reachability_validation"]
+			if not reachability is Dictionary or reachability.is_empty():
+				return false
+			var declared_rv_fields: Array[String] = ["required_entrances", "required_furniture_anchors", "required_building_levels"]
+			for rv_key in reachability.keys():
+				if rv_key is String and rv_key not in declared_rv_fields:
+					return false
+			var declared_entrance_ids: Array[String] = []
+			if building.has("entrances") and building["entrances"] is Array:
+				for entrance_entry in building["entrances"]:
+					if entrance_entry is Dictionary and entrance_entry.has("id") and entrance_entry["id"] is String:
+						declared_entrance_ids.append(entrance_entry["id"])
+			var declared_anchor_ids: Array[String] = []
+			if building.has("furniture_anchors") and building["furniture_anchors"] is Array:
+				for anchor in building["furniture_anchors"]:
+					if anchor is Dictionary and anchor.has("id") and anchor["id"] is String:
+						declared_anchor_ids.append(anchor["id"])
+			var declared_level_zs: Array = []
+			if building.has("building_levels") and building["building_levels"] is Array:
+				for level_definition in building["building_levels"]:
+					if level_definition is Dictionary and level_definition.has("z") and level_definition["z"] is int:
+						declared_level_zs.append(level_definition["z"])
+			elif building.has("z") and building["z"] is int:
+				declared_level_zs.append(building["z"])
+			for rv_key in ["required_entrances", "required_furniture_anchors", "required_building_levels"]:
+				if not reachability.has(rv_key):
+					continue
+				var requirement: Variant = reachability[rv_key]
+				if not requirement is Array or requirement.is_empty():
+					return false
+				var seen_requirement_values: Array = []
+				for value in requirement:
+					if not value is String and not value is int:
+						return false
+					if value in seen_requirement_values:
+						return false
+					seen_requirement_values.append(value)
+					if rv_key == "required_building_levels":
+						if not value is int or not value in declared_level_zs:
+							return false
+					elif not value is String or (value as String).is_empty():
+						return false
+					elif rv_key == "required_entrances" and not value in declared_entrance_ids:
+						return false
+					elif rv_key == "required_furniture_anchors" and not value in declared_anchor_ids:
+						return false
 		return true
 	)
 	if data["buildings"].is_empty():

--- a/Tests/Unit/test_dmap_sanitization.gd
+++ b/Tests/Unit/test_dmap_sanitization.gd
@@ -263,6 +263,92 @@ func test_dmap_buildings_roundtrip_and_sanitization():
 	}])
 
 
+func test_dmap_reachability_validation_roundtrip_and_sanitization():
+	var DMap = load("res://Scripts/Gamedata/DMap.gd")
+	var map = DMap.new("test_reachability_validation", "/tmp/", null)
+	map.set_data({
+		"name": "Reachability validation",
+		"description": "Preserve authored reachability requirements.",
+		"rooms": [
+			{"id": "office", "kind": "enclosed", "boundary_validation": "complete"},
+			{"id": "office_upper", "kind": "enclosed"},
+		],
+		"room_connections": [{
+			"id": "office_front_door",
+			"at": [8, 9],
+			"z": 0,
+			"from": {"kind": "room", "id": "office"},
+			"to": {"kind": "exterior"},
+		}],
+		"buildings": [
+			{
+				"id": "office_building",
+				"rooms": ["office", "office_upper"],
+				"footprint": {"x": 7, "y": 7, "width": 5, "height": 4},
+				"z": 0,
+				"building_levels": [{"z": 0}, {"z": 2}],
+				"entrances": [
+					{"id": "front_entrance", "connection": "office_front_door", "facing": "east"},
+				],
+				"exterior_context": {"at": [6, 8], "z": 0},
+				"furniture_anchors": [
+					{"id": "office_door_anchor", "at": [7, 8], "z": 0, "kind": "door"},
+					{"id": "upper_bench_anchor", "at": [8, 8], "z": 2, "kind": "workstation"},
+				],
+				"reachability_validation": {
+					"required_entrances": ["front_entrance"],
+					"required_furniture_anchors": ["office_door_anchor", "upper_bench_anchor"],
+					"required_building_levels": [0, 2],
+				},
+			},
+			{
+				"id": "bad_unknown_entrance",
+				"rooms": ["office"],
+				"footprint": {"x": 16, "y": 7, "width": 4, "height": 4},
+				"z": 0,
+				"reachability_validation": {"required_entrances": ["missing_entrance"]},
+			},
+			{
+				"id": "bad_unknown_anchor",
+				"rooms": ["office"],
+				"footprint": {"x": 16, "y": 12, "width": 4, "height": 4},
+				"z": 0,
+				"reachability_validation": {"required_furniture_anchors": ["missing_anchor"]},
+			},
+			{
+				"id": "bad_undeclared_level",
+				"rooms": ["office"],
+				"footprint": {"x": 16, "y": 17, "width": 4, "height": 4},
+				"z": 0,
+				"reachability_validation": {"required_building_levels": [4]},
+			},
+			{
+				"id": "bad_empty_record",
+				"rooms": ["office"],
+				"footprint": {"x": 16, "y": 22, "width": 4, "height": 4},
+				"z": 0,
+				"reachability_validation": {},
+			},
+			{
+				"id": "bad_wrong_type",
+				"rooms": ["office"],
+				"footprint": {"x": 16, "y": 27, "width": 4, "height": 4},
+				"z": 0,
+				"reachability_validation": {"required_building_levels": ["0"]},
+			},
+		],
+	})
+
+	var data = map.get_data()
+
+	assert_eq(data["buildings"].size(), 1)
+	assert_eq(data["buildings"][0]["reachability_validation"], {
+		"required_entrances": ["front_entrance"],
+		"required_furniture_anchors": ["office_door_anchor", "upper_bench_anchor"],
+		"required_building_levels": [0, 2],
+	})
+
+
 func test_dmap_building_levels_roundtrip_and_sanitization():
 	var DMap = load("res://Scripts/Gamedata/DMap.gd")
 	var map = DMap.new("test_building_levels", "/tmp/", null)

--- a/Tools/examples/map_recipe_multi_level_building_foundation.json
+++ b/Tools/examples/map_recipe_multi_level_building_foundation.json
@@ -28,6 +28,11 @@
 			"staircases": [
 				{"id": "office_staircase", "lower_at": [10, 10], "upper_at": [11, 9], "landing_at": [11, 10], "rotation": 90, "upper_rotation": 0}
 			],
+			"reachability_validation": {
+				"required_entrances": ["front_entrance", "garage_entrance"],
+				"required_furniture_anchors": ["office_door_anchor", "garage_door_anchor", "upper_bench_anchor"],
+				"required_building_levels": [0, 2]
+			},
 			"exterior_context": {"at": [6, 8], "z": 0},
 			"exterior_access_context": {"connection": "office_front_door"},
 			"entrances": [

--- a/Tools/examples/map_recipe_semantic_single_storey_building.json
+++ b/Tools/examples/map_recipe_semantic_single_storey_building.json
@@ -25,6 +25,10 @@
 			"access_validation": "complete",
 			"interior_rooms": ["study"],
 			"room_partition_validation": "complete",
+			"reachability_validation": {
+				"required_furniture_anchors": ["study_door"],
+				"required_building_levels": [0]
+			},
 			"exterior_context": {"at": [6, 8], "z": 0},
 			"exterior_access_context": {"connection": "study_front_door"},
 			"entrance": {"connection": "study_front_door", "facing": "east"},

--- a/Tools/examples/map_recipe_semantic_two_storey_building.json
+++ b/Tools/examples/map_recipe_semantic_two_storey_building.json
@@ -24,6 +24,10 @@
 				{"z": 0, "rooms": ["workroom"], "furniture_anchors": ["workroom_door"]},
 				{"z": 2, "rooms": ["loft"], "furniture_anchors": ["loft_bench"]}
 			],
+			"reachability_validation": {
+				"required_furniture_anchors": ["workroom_door"],
+				"required_building_levels": [0]
+			},
 			"furniture_anchors": [
 				{"id": "workroom_door", "at": [7, 9], "z": 0, "kind": "door"},
 				{"id": "loft_bench", "at": [8, 8], "z": 2, "kind": "workstation"}

--- a/Tools/map_generator.py
+++ b/Tools/map_generator.py
@@ -90,7 +90,7 @@ ROOM_CONNECTION_ENDPOINT_FIELDS = {"kind", "id"}
 ROOM_CONNECTION_ENDPOINT_KINDS = {"room", "exterior"}
 ROOM_BOUNDARY_FIELDS = {"id", "room", "at", "target_at", "room_at", "z", "element", "side"}
 ROOM_BOUNDARY_ELEMENTS = {"wall_tile", "door_furniture"}
-BUILDING_FIELDS = {"id", "rooms", "footprint", "z", "building_levels", "staircases", "access_validation", "interior_rooms", "open_space_rooms", "room_partition_validation", "overhead_validation", "exterior_context", "exterior_access_context", "entrance", "entrances", "entrance_validation", "furniture_anchors", "building_geometry"}
+BUILDING_FIELDS = {"id", "rooms", "footprint", "z", "building_levels", "staircases", "access_validation", "interior_rooms", "open_space_rooms", "room_partition_validation", "overhead_validation", "exterior_context", "exterior_access_context", "entrance", "entrances", "entrance_validation", "furniture_anchors", "building_geometry", "reachability_validation"}
 BUILDING_REQUIRED_FIELDS = {"id", "rooms", "footprint", "z"}
 BUILDING_LEVEL_FIELDS = {"z", "rooms", "furniture_anchors"}
 BUILDING_STAIRCASE_FIELDS = {"id", "lower_at", "upper_at", "rotation", "upper_rotation", "landing_at"}
@@ -102,6 +102,7 @@ BUILDING_ENTRANCE_FACINGS = {"north", "east", "south", "west"}
 BUILDING_ENTRANCE_VALIDATIONS = {"complete"}
 BUILDING_FURNITURE_ANCHOR_FIELDS = {"id", "at", "z", "kind"}
 BUILDING_ACCESS_VALIDATIONS = {"complete"}
+BUILDING_REACHABILITY_FIELDS = {"required_entrances", "required_furniture_anchors", "required_building_levels"}
 BUILDING_ROOM_PARTITION_VALIDATIONS = {"complete"}
 BUILDING_OVERHEAD_VALIDATIONS = {"complete"}
 BUILDING_FOOTPRINT_FIELDS = {"x", "y", "width", "height"}
@@ -1989,6 +1990,49 @@ def _validate_recipe_buildings(
                         raise RecipeError(f"{context}.building_levels furniture_anchors must assign every building anchor exactly once")
                     if len(assigned_anchor_ids) != len(set(assigned_anchor_ids)):
                         raise RecipeError(f"{context}.building_levels furniture_anchors must not assign an anchor to multiple levels")
+        reachability_validation = building.get("reachability_validation")
+        if reachability_validation is not None:
+            context_rv = f"{context}.reachability_validation"
+            if not isinstance(reachability_validation, dict):
+                raise RecipeError(f"{context_rv} must be an object")
+            unknown_rv_fields = sorted(set(reachability_validation) - BUILDING_REACHABILITY_FIELDS)
+            if unknown_rv_fields:
+                raise RecipeError(f"unknown {context_rv} field '{unknown_rv_fields[0]}'")
+            if not reachability_validation:
+                raise RecipeError(f"{context_rv} must define at least one requirement")
+            for requirement_name in ("required_entrances", "required_furniture_anchors", "required_building_levels"):
+                if requirement_name not in reachability_validation:
+                    continue
+                requirement = reachability_validation[requirement_name]
+                if not isinstance(requirement, list) or not requirement:
+                    raise RecipeError(f"{context_rv} {requirement_name} must be a non-empty array")
+                if len(requirement) != len(set(requirement)):
+                    raise RecipeError(f"{context_rv} {requirement_name} must not duplicate entries")
+                if requirement_name == "required_building_levels":
+                    if any(type(value) is not int for value in requirement):
+                        raise RecipeError(f"{context_rv} {requirement_name} must contain integers")
+                else:
+                    if any(not isinstance(value, str) or not value.strip() for value in requirement):
+                        raise RecipeError(f"{context_rv} {requirement_name} must contain non-empty strings")
+                    _validate_unicode(requirement[0], f"{context_rv}.{requirement_name}")
+            if "required_entrances" in reachability_validation:
+                declared_entrance_ids = {
+                    entry["id"] for entry in building.get("entrances", []) or []
+                    if isinstance(entry, dict) and isinstance(entry.get("id"), str)
+                }
+                for entrance_id in reachability_validation["required_entrances"]:
+                    if entrance_id not in declared_entrance_ids:
+                        raise RecipeError(f"{context_rv}.required_entrances references unknown entrance '{entrance_id}'")
+            if "required_furniture_anchors" in reachability_validation:
+                declared_anchor_ids = {anchor["id"] for anchor in building.get("furniture_anchors") or [] if isinstance(anchor, dict) and isinstance(anchor.get("id"), str)}
+                for anchor_id in reachability_validation["required_furniture_anchors"]:
+                    if anchor_id not in declared_anchor_ids:
+                        raise RecipeError(f"{context_rv}.required_furniture_anchors references unknown furniture anchor '{anchor_id}'")
+            if "required_building_levels" in reachability_validation:
+                declared_level_zs = {level_definition["z"] for level_definition in building_levels or []} or {z}
+                for level_z in reachability_validation["required_building_levels"]:
+                    if level_z not in declared_level_zs:
+                        raise RecipeError(f"{context_rv}.required_building_levels references undeclared building level z {level_z}")
         validated_building = {
             "id": building_id,
             "rooms": room_ids,
@@ -2021,6 +2065,8 @@ def _validate_recipe_buildings(
             validated_building["entrance_validation"] = entrance_validation
         if furniture_anchors is not None:
             validated_building["furniture_anchors"] = furniture_anchors
+        if reachability_validation is not None:
+            validated_building["reachability_validation"] = reachability_validation
         building_geometry = building.get("building_geometry")
         if building_geometry is not None:
             if not isinstance(building_geometry, dict) or set(building_geometry) != BUILDING_GEOMETRY_FIELDS:
@@ -2718,6 +2764,88 @@ def _validate_building_targets(
                     raise RecipeError(
                         f"{context} room '{room_id}' has no route to exterior through owned room_connections"
                     )
+        if building.get("reachability_validation") is not None:
+            reachability = building["reachability_validation"]
+            level_of_room = {room_id: z for room_id in building["rooms"]}
+            for level_definition in building.get("building_levels", []) or []:
+                for room_id in level_definition.get("rooms", []):
+                    level_of_room[room_id] = level_definition["z"]
+            room_nodes = {(room_id, level_of_room[room_id]) for room_id in building["rooms"]}
+            room_graph = {node: set() for node in room_nodes}
+            seed_nodes: set[tuple[str, int]] = set()
+            required_entrance_ids = reachability.get("required_entrances")
+            entrance_records = building.get("entrances") or []
+            if required_entrance_ids is not None:
+                entrance_records = [entry for entry in entrance_records if entry["id"] in set(required_entrance_ids)]
+            for entrance_entry in entrance_records:
+                connection = next(
+                    (conn for conn in room_connections if conn["id"] == entrance_entry["connection"]),
+                    None,
+                )
+                if connection is None:
+                    continue
+                named_rooms = [endpoint["id"] for endpoint in (connection["from"], connection["to"]) if endpoint["kind"] == "room"]
+                for room_id in named_rooms:
+                    if room_id in level_of_room and connection["z"] == level_of_room[room_id]:
+                        seed_nodes.add((room_id, level_of_room[room_id]))
+            for connection in room_connections:
+                endpoints = (connection["from"], connection["to"])
+                room_endpoints = [endpoint["id"] for endpoint in endpoints if endpoint["kind"] == "room"]
+                if any(endpoint["kind"] == "exterior" for endpoint in endpoints):
+                    if required_entrance_ids is None:
+                        for room_id in room_endpoints:
+                            if room_id in level_of_room and connection["z"] == level_of_room[room_id]:
+                                seed_nodes.add((room_id, level_of_room[room_id]))
+                elif len(room_endpoints) == 2 and all(room_id in level_of_room for room_id in room_endpoints):
+                    left_level = level_of_room[room_endpoints[0]]
+                    right_level = level_of_room[room_endpoints[1]]
+                    if left_level == right_level and connection["z"] == left_level:
+                        left_node = (room_endpoints[0], left_level)
+                        right_node = (room_endpoints[1], right_level)
+                        room_graph[left_node].add(right_node)
+                        room_graph[right_node].add(left_node)
+            for staircase in building.get("staircases", []):
+                staircase_levels = [0, 2]
+                lower_node = next((node for node in room_nodes if node[1] == staircase_levels[0]), None)
+                upper_node = next((node for node in room_nodes if node[1] == staircase_levels[1]), None)
+                if lower_node is not None and upper_node is not None:
+                    room_graph[lower_node].add(upper_node)
+                    room_graph[upper_node].add(lower_node)
+            reachable_nodes = set(seed_nodes)
+            frontier = list(seed_nodes)
+            while frontier:
+                node = frontier.pop()
+                for connected_node in room_graph[node]:
+                    if connected_node not in reachable_nodes:
+                        reachable_nodes.add(connected_node)
+                        frontier.append(connected_node)
+            reachable_levels = {node[1] for node in reachable_nodes}
+            if "required_entrances" in reachability:
+                for entrance_entry in entrance_records:
+                    connection = next(
+                        (conn for conn in room_connections if conn["id"] == entrance_entry["connection"]),
+                        None,
+                    )
+                    if connection is None:
+                        continue
+                    named_rooms = [endpoint["id"] for endpoint in (connection["from"], connection["to"]) if endpoint["kind"] == "room"]
+                    if not any((room_id, level_of_room.get(room_id)) in reachable_nodes for room_id in named_rooms):
+                        raise RecipeError(
+                            f"{context}.reachability_validation entrance '{entrance_entry['id']}' is not reachable"
+                        )
+            if "required_furniture_anchors" in reachability:
+                anchor_level = {anchor["id"]: anchor["z"] for anchor in building.get("furniture_anchors") or [] if isinstance(anchor, dict)}
+                for anchor_id in reachability["required_furniture_anchors"]:
+                    if not any(node[1] == anchor_level.get(anchor_id) for node in reachable_nodes):
+                        raise RecipeError(
+                            f"{context}.reachability_validation furniture anchor '{anchor_id}' is not reachable from the required entrances"
+                        )
+            if "required_building_levels" in reachability:
+                for level_z in reachability["required_building_levels"]:
+                    if level_z not in reachable_levels:
+                        raise RecipeError(
+                            f"{context}.reachability_validation building level z {level_z} is not reachable from the required entrances"
+                        )
 
 
 def _validate_room_connection_endpoint(

--- a/Tools/map_validator.py
+++ b/Tools/map_validator.py
@@ -2,7 +2,7 @@ import json
 import os
 import sys
 import argparse
-from typing import List, Dict, Any, Set
+from typing import List, Dict, Any, Set, Tuple
 
 MAP_WIDTH = 32
 MAP_HEIGHT = 32
@@ -34,7 +34,7 @@ def _physical_at(record):
 def _room_at(record):
     return record.get('room_at', record['at'])
 ROOM_BOUNDARY_ELEMENTS = {'wall_tile', 'door_furniture'}
-BUILDING_FIELDS = {'id', 'rooms', 'footprint', 'z', 'building_levels', 'staircases', 'access_validation', 'interior_rooms', 'open_space_rooms', 'room_partition_validation', 'overhead_validation', 'exterior_context', 'exterior_access_context', 'entrance', 'entrances', 'entrance_validation', 'furniture_anchors', 'building_geometry'}
+BUILDING_FIELDS = {'id', 'rooms', 'footprint', 'z', 'building_levels', 'staircases', 'access_validation', 'interior_rooms', 'open_space_rooms', 'room_partition_validation', 'overhead_validation', 'exterior_context', 'exterior_access_context', 'entrance', 'entrances', 'entrance_validation', 'furniture_anchors', 'building_geometry', 'reachability_validation'}
 BUILDING_REQUIRED_FIELDS = {'id', 'rooms', 'footprint', 'z'}
 BUILDING_LEVEL_FIELDS = {'z', 'rooms', 'furniture_anchors'}
 BUILDING_STAIRCASE_FIELDS = {'id', 'lower_at', 'upper_at', 'rotation', 'upper_rotation', 'landing_at'}
@@ -46,6 +46,7 @@ BUILDING_ENTRANCE_FACINGS = {'north', 'east', 'south', 'west'}
 BUILDING_FURNITURE_ANCHOR_FIELDS = {'id', 'at', 'z', 'kind'}
 BUILDING_ENTRANCE_VALIDATIONS = {'complete'}
 BUILDING_ACCESS_VALIDATIONS = {'complete'}
+BUILDING_REACHABILITY_FIELDS = {'required_entrances', 'required_furniture_anchors', 'required_building_levels'}
 BUILDING_ROOM_PARTITION_VALIDATIONS = {'complete'}
 BUILDING_OVERHEAD_VALIDATIONS = {'complete'}
 BUILDING_FOOTPRINT_FIELDS = {'x', 'y', 'width', 'height'}
@@ -1165,6 +1166,57 @@ class MapValidator:
                     self.add_error(file_path, f"{context} entrance_validation has unsupported validation '{entrance_validation}'.")
                 if entrance is None and entrances is None:
                     self.add_error(file_path, f"{context} entrance_validation requires entrance or entrances.")
+            reachability_validation = building.get('reachability_validation')
+            if reachability_validation is not None:
+                rv_context = f"{context} reachability_validation"
+                if not isinstance(reachability_validation, dict):
+                    self.add_error(file_path, f"{rv_context} must be an object.")
+                else:
+                    unknown_rv_fields = sorted(set(reachability_validation) - BUILDING_REACHABILITY_FIELDS)
+                    for unknown_field in unknown_rv_fields:
+                        self.add_error(file_path, f"unknown {rv_context} field '{unknown_field}'.")
+                    if not reachability_validation:
+                        self.add_error(file_path, f"{rv_context} must define at least one requirement.")
+                    declared_entrance_ids = {
+                        entry.get('id') for entry in (building.get('entrances') or [])
+                        if isinstance(entry, dict) and isinstance(entry.get('id'), str)
+                    }
+                    declared_anchor_ids = {
+                        anchor.get('id') for anchor in (building.get('furniture_anchors') or [])
+                        if isinstance(anchor, dict) and isinstance(anchor.get('id'), str)
+                    }
+                    declared_level_zs = {
+                        level_definition.get('z') for level_definition in (building.get('building_levels') or [])
+                        if isinstance(level_definition, dict)
+                    } or {building.get('z')}
+                    for requirement_name in ('required_entrances', 'required_furniture_anchors', 'required_building_levels'):
+                        if requirement_name not in reachability_validation:
+                            continue
+                        requirement = reachability_validation[requirement_name]
+                        if not isinstance(requirement, list) or not requirement:
+                            self.add_error(file_path, f"{rv_context} {requirement_name} must be a non-empty array.")
+                            continue
+                        if len(requirement) != len(set(requirement)):
+                            self.add_error(file_path, f"{rv_context} {requirement_name} must not duplicate entries.")
+                        if requirement_name == 'required_building_levels':
+                            if any(type(value) is not int for value in requirement):
+                                self.add_error(file_path, f"{rv_context} {requirement_name} must contain integers.")
+                                continue
+                            for level_z in requirement:
+                                if level_z not in declared_level_zs:
+                                    self.add_error(file_path, f"{rv_context} required_building_levels references undeclared building level z {level_z}.")
+                        else:
+                            if any(not isinstance(value, str) or not value.strip() for value in requirement):
+                                self.add_error(file_path, f"{rv_context} {requirement_name} must contain non-empty strings.")
+                                continue
+                            if requirement_name == 'required_entrances':
+                                for entrance_id in requirement:
+                                    if entrance_id not in declared_entrance_ids:
+                                        self.add_error(file_path, f"{rv_context} required_entrances references unknown entrance '{entrance_id}'.")
+                            else:
+                                for anchor_id in requirement:
+                                    if anchor_id not in declared_anchor_ids:
+                                        self.add_error(file_path, f"{rv_context} required_furniture_anchors references unknown furniture anchor '{anchor_id}'.")
             furniture_anchors = building.get('furniture_anchors')
             if furniture_anchors is not None:
                 if not isinstance(furniture_anchors, list) or not furniture_anchors:
@@ -1585,6 +1637,86 @@ class MapValidator:
                 for room_id in building['rooms']:
                     if room_id not in reachable_rooms:
                         self.add_error(file_path, f"{context} room '{room_id}' has no route to exterior through owned room_connections.")
+            if building.get('reachability_validation') is not None:
+                reachability = building['reachability_validation']
+                level_of_room = {room_id: z for room_id in building['rooms']}
+                for level_definition in building.get('building_levels') or []:
+                    if not isinstance(level_definition, dict):
+                        continue
+                    for room_id in level_definition.get('rooms') or []:
+                        level_of_room[room_id] = level_definition['z']
+                room_nodes = {(room_id, level_of_room[room_id]) for room_id in building['rooms']}
+                room_graph = {node: set() for node in room_nodes}
+                seed_nodes: Set[Tuple[str, int]] = set()
+                required_entrance_ids = reachability.get('required_entrances')
+                entrance_records = building.get('entrances') or []
+                if required_entrance_ids is not None:
+                    entrance_records = [entry for entry in entrance_records if entry.get('id') in set(required_entrance_ids)]
+                for entrance_entry in entrance_records:
+                    connection = next(
+                        (conn for conn in validated_room_connections if conn.get('id') == entrance_entry.get('connection')),
+                        None,
+                    )
+                    if connection is None:
+                        continue
+                    named_rooms = [endpoint['id'] for endpoint in (connection['from'], connection['to']) if endpoint.get('kind') == 'room']
+                    for room_id in named_rooms:
+                        if room_id in level_of_room and connection['z'] == level_of_room[room_id]:
+                            seed_nodes.add((room_id, level_of_room[room_id]))
+                for connection in validated_room_connections:
+                    endpoints = (connection['from'], connection['to'])
+                    room_endpoints = [endpoint['id'] for endpoint in endpoints if endpoint.get('kind') == 'room']
+                    if any(endpoint.get('kind') == 'exterior' for endpoint in endpoints):
+                        if required_entrance_ids is None:
+                            for room_id in room_endpoints:
+                                if room_id in level_of_room and connection['z'] == level_of_room[room_id]:
+                                    seed_nodes.add((room_id, level_of_room[room_id]))
+                    elif len(room_endpoints) == 2 and all(room_id in level_of_room for room_id in room_endpoints):
+                        left_level = level_of_room[room_endpoints[0]]
+                        right_level = level_of_room[room_endpoints[1]]
+                        if left_level == right_level and connection['z'] == left_level:
+                            left_node = (room_endpoints[0], left_level)
+                            right_node = (room_endpoints[1], right_level)
+                            room_graph[left_node].add(right_node)
+                            room_graph[right_node].add(left_node)
+                for staircase in building.get('staircases') or []:
+                    lower_node = next((node for node in room_nodes if node[1] == 0), None)
+                    upper_node = next((node for node in room_nodes if node[1] == 2), None)
+                    if lower_node is not None and upper_node is not None:
+                        room_graph[lower_node].add(upper_node)
+                        room_graph[upper_node].add(lower_node)
+                reachable_nodes = set(seed_nodes)
+                frontier = list(seed_nodes)
+                while frontier:
+                    node = frontier.pop()
+                    for connected_node in room_graph[node]:
+                        if connected_node not in reachable_nodes:
+                            reachable_nodes.add(connected_node)
+                            frontier.append(connected_node)
+                reachable_levels = {node[1] for node in reachable_nodes}
+                if 'required_entrances' in reachability:
+                    for entrance_entry in entrance_records:
+                        connection = next(
+                            (conn for conn in validated_room_connections if conn.get('id') == entrance_entry.get('connection')),
+                            None,
+                        )
+                        if connection is None:
+                            continue
+                        named_rooms = [endpoint['id'] for endpoint in (connection['from'], connection['to']) if endpoint.get('kind') == 'room']
+                        if not any((room_id, level_of_room.get(room_id)) in reachable_nodes for room_id in named_rooms):
+                            self.add_error(file_path, f"{context} reachability_validation entrance '{entrance_entry.get('id')}' is not reachable.")
+                if 'required_furniture_anchors' in reachability:
+                    anchor_level = {
+                        anchor.get('id'): anchor.get('z') for anchor in (building.get('furniture_anchors') or [])
+                        if isinstance(anchor, dict)
+                    }
+                    for anchor_id in reachability['required_furniture_anchors']:
+                        if not any(node[1] == anchor_level.get(anchor_id) for node in reachable_nodes):
+                            self.add_error(file_path, f"{context} reachability_validation furniture anchor '{anchor_id}' is not reachable from the required entrances.")
+                if 'required_building_levels' in reachability:
+                    for level_z in reachability['required_building_levels']:
+                        if level_z not in reachable_levels:
+                            self.add_error(file_path, f"{context} reachability_validation building level z {level_z} is not reachable from the required entrances.")
 
         building_by_id = {building['id']: building for building in validated_buildings}
         seen_surface_ids: Set[str] = set()

--- a/Tools/tests/test_map_generator.py
+++ b/Tools/tests/test_map_generator.py
@@ -2533,6 +2533,76 @@ class MapGeneratorTests(unittest.TestCase):
         with self.assertRaisesRegex(RecipeError, "room 'office' has no route to exterior"):
             generate_map(missing_exterior_route, TILES_PATH)
 
+    def test_reachability_validation_echoes_declared_requirements(self):
+        recipe_path = ROOT / "Tools" / "examples" / "map_recipe_multi_level_building_foundation.json"
+        recipe = json.loads(recipe_path.read_text(encoding="utf-8"))
+        validation = {
+            "required_entrances": ["front_entrance", "garage_entrance"],
+            "required_furniture_anchors": ["office_door_anchor", "garage_door_anchor", "upper_bench_anchor"],
+            "required_building_levels": [0, 2],
+        }
+        recipe["buildings"][0]["reachability_validation"] = validation
+
+        generated = generate_map(recipe, TILES_PATH)
+
+        self.assertEqual(generated["buildings"][0]["reachability_validation"], validation)
+
+        single_path = ROOT / "Tools" / "examples" / "map_recipe_semantic_single_storey_building.json"
+        single = json.loads(single_path.read_text(encoding="utf-8"))
+        single["buildings"][0]["reachability_validation"] = {
+            "required_furniture_anchors": ["study_door"],
+            "required_building_levels": [0],
+        }
+        self.assertEqual(
+            generate_map(single, TILES_PATH)["buildings"][0]["reachability_validation"],
+            {"required_furniture_anchors": ["study_door"], "required_building_levels": [0]},
+        )
+
+    def test_reachability_validation_rejects_unknown_targets_and_malformed_requirements(self):
+        recipe_path = ROOT / "Tools" / "examples" / "map_recipe_multi_level_building_foundation.json"
+        invalid_cases = [
+            ({"required_entrances": ["missing_entrance"]}, "required_entrances references unknown entrance 'missing_entrance'"),
+            ({"required_furniture_anchors": ["missing_anchor"]}, "required_furniture_anchors references unknown furniture anchor 'missing_anchor'"),
+            ({"required_building_levels": [4]}, "required_building_levels references undeclared building level z 4"),
+            ({"required_building_levels": ["0"]}, "required_building_levels must contain integers"),
+            ({}, "reachability_validation must define at least one requirement"),
+            ({"required_entrances": []}, "reachability_validation required_entrances must be a non-empty array"),
+            ({"required_entrances": ["front_entrance", "front_entrance"]}, "reachability_validation required_entrances must not duplicate entries"),
+            ({"required_entrances": ["front_entrance"], "extra": True}, r"unknown buildings\[0\]\.reachability_validation field 'extra'"),
+        ]
+        for validation, message in invalid_cases:
+            with self.subTest(validation=validation):
+                recipe = json.loads(recipe_path.read_text(encoding="utf-8"))
+                recipe["buildings"][0]["reachability_validation"] = validation
+                with self.assertRaisesRegex(RecipeError, message):
+                    generate_map(recipe, TILES_PATH)
+
+    def test_reachability_validation_requires_cross_floor_routes_through_staircases(self):
+        recipe_path = ROOT / "Tools" / "examples" / "map_recipe_semantic_two_storey_building.json"
+        unreachable_level = json.loads(recipe_path.read_text(encoding="utf-8"))
+        unreachable_level["buildings"][0]["reachability_validation"] = {"required_building_levels": [0, 2]}
+        with self.assertRaisesRegex(RecipeError, "building level z 2 is not reachable from the required entrances"):
+            generate_map(unreachable_level, TILES_PATH)
+
+        unreachable_anchor = json.loads(recipe_path.read_text(encoding="utf-8"))
+        unreachable_anchor["buildings"][0]["reachability_validation"] = {"required_furniture_anchors": ["loft_bench"]}
+        with self.assertRaisesRegex(RecipeError, "furniture anchor 'loft_bench' is not reachable from the required entrances"):
+            generate_map(unreachable_anchor, TILES_PATH)
+
+    def test_reachability_validation_positive_cross_floor_route_through_authored_staircase(self):
+        recipe_path = ROOT / "Tools" / "examples" / "map_recipe_multi_level_building_foundation.json"
+        recipe = json.loads(recipe_path.read_text(encoding="utf-8"))
+        recipe["buildings"][0]["reachability_validation"] = {
+            "required_entrances": ["front_entrance", "garage_entrance"],
+            "required_furniture_anchors": ["office_door_anchor", "garage_door_anchor", "upper_bench_anchor"],
+            "required_building_levels": [0, 2],
+        }
+        generated = generate_map(recipe, TILES_PATH)
+        self.assertEqual(
+            generated["buildings"][0]["reachability_validation"]["required_building_levels"],
+            [0, 2],
+        )
+
     def test_building_compositions_require_declared_surface_kinds(self):
         recipe_path = ROOT / "Tools" / "examples" / "map_recipe_building_surfaces.json"
         recipe = json.loads(recipe_path.read_text(encoding="utf-8"))
@@ -4157,6 +4227,43 @@ class MapValidatorDimensionTests(unittest.TestCase):
         missing_exterior_route["room_connections"][0]["to"] = {"kind": "room", "id": "garage"}
         errors = self.validate(missing_exterior_route)
         self.assertTrue(any("room 'office' has no route to exterior" in error for error in errors))
+
+    def test_validates_reachability_validation_contract(self):
+        recipe_path = ROOT / "Tools" / "examples" / "map_recipe_multi_level_building_foundation.json"
+        recipe = json.loads(recipe_path.read_text(encoding="utf-8"))
+        recipe["buildings"][0]["reachability_validation"] = {
+            "required_entrances": ["front_entrance", "garage_entrance"],
+            "required_furniture_anchors": ["office_door_anchor", "garage_door_anchor", "upper_bench_anchor"],
+            "required_building_levels": [0, 2],
+        }
+        valid_map = generate_map(recipe, TILES_PATH)
+        self.assertEqual(self.validate(valid_map), [])
+
+        unreachable_level = json.loads(json.dumps(valid_map))
+        unreachable_level["buildings"][0]["reachability_validation"] = {"required_building_levels": [0, 2]}
+        unreachable_level["buildings"][0]["staircases"] = []
+        errors = self.validate(unreachable_level)
+        self.assertTrue(any("building level z 2 is not reachable from the required entrances" in error for error in errors))
+
+        unknown_entrance = json.loads(json.dumps(valid_map))
+        unknown_entrance["buildings"][0]["reachability_validation"] = {"required_entrances": ["missing_entrance"]}
+        errors = self.validate(unknown_entrance)
+        self.assertTrue(any("required_entrances references unknown entrance 'missing_entrance'" in error for error in errors))
+
+        unknown_anchor = json.loads(json.dumps(valid_map))
+        unknown_anchor["buildings"][0]["reachability_validation"] = {"required_furniture_anchors": ["missing_anchor"]}
+        errors = self.validate(unknown_anchor)
+        self.assertTrue(any("required_furniture_anchors references unknown furniture anchor 'missing_anchor'" in error for error in errors))
+
+        undeclared_level = json.loads(json.dumps(valid_map))
+        undeclared_level["buildings"][0]["reachability_validation"] = {"required_building_levels": [4]}
+        errors = self.validate(undeclared_level)
+        self.assertTrue(any("required_building_levels references undeclared building level z 4" in error for error in errors))
+
+        empty_record = json.loads(json.dumps(valid_map))
+        empty_record["buildings"][0]["reachability_validation"] = {}
+        errors = self.validate(empty_record)
+        self.assertTrue(any("reachability_validation must define at least one requirement" in error for error in errors))
 
     def test_validates_building_composition_constraints(self):
         recipe_path = ROOT / "Tools" / "examples" / "map_recipe_building_surfaces.json"


### PR DESCRIPTION
## Summary
Completes Phase 9.3 of the map-generation roadmap: an optional per-building `reachability_validation` record requiring named entrances, furniture anchors, and building levels to be reachable through authored semantics.

- Static BFS over (room, level) nodes in generator and standalone validator; same-level edges from room_connections, vertical edges only from already-valid authored staircases (floor-granular z0↔z2).
- DMap save/load preservation with malformed-record rejection.
- Opted into by the multi-level foundation (full cross-storey) and both canonical semantic fixtures (ground-floor requirements).
- Roadmap and modding-guide documentation updated.

## Validation
- Python suite 186/186; py_compile clean
- map_validator.py: 3 regenerated artifacts, no errors
- GUT: 12/12 focused, 94/94 full
- Deterministic regeneration byte-for-byte; git diff --check clean

## Follow-up
Phase 9.4: reusable Godot runtime navigation fixture (runtime proof); two-storey fixture gains a validated staircase when its loft route is authored.